### PR TITLE
build: Replace Version with VersionPrefix for CI/release versioning

### DIFF
--- a/JsonSchemaValidation/JsonSchemaValidation.csproj
+++ b/JsonSchemaValidation/JsonSchemaValidation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>FormFinch.JsonSchemaValidation</PackageId>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Arjan Bosma</Authors>
     <Company>FormFinch VOF</Company>
     <Description>FormFinch JsonSchemaValidation is a .NET class library for validating JSON documents against JSON Schemas without reliance on third-party libraries, built on top of System.Text.Json.</Description>


### PR DESCRIPTION
## Summary
- Replace `<Version>1.0.0</Version>` with `<VersionPrefix>1.0.0</VersionPrefix>` in the main project `.csproj`
- Enables nightly CI to produce pre-release packages (`dotnet pack --version-suffix ci.42` → `1.0.0-ci.42`)
- Enables release workflow to derive version from git tags (`dotnet pack -p:Version=1.0.0`)
- No additional tooling or dependencies added — pure MSBuild

## Test plan
- [x] `dotnet pack --version-suffix ci.1` produces `FormFinch.JsonSchemaValidation.1.0.0-ci.1.nupkg`
- [x] `dotnet pack -p:Version=1.0.0` produces `FormFinch.JsonSchemaValidation.1.0.0.nupkg`
- [x] Build passes with 0 warnings
- [x] All 4,158 tests pass on net8.0 and net10.0

Closes TASK-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)