### PR TITLE
build: Enable XML documentation file generation

### DIFF
--- a/JsonSchemaValidation/JsonSchemaValidation.csproj
+++ b/JsonSchemaValidation/JsonSchemaValidation.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>FormFinch.JsonSchemaValidation</RootNamespace>
     <AssemblyName>FormFinch.JsonSchemaValidation</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>FormFinch.JsonSchemaValidation</PackageId>
@@ -24,7 +25,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Suppress backcompat warnings for 1.0.0 release - no prior public API to maintain -->
-    <NoWarn>$(NoWarn);RS0026;RS0027</NoWarn>
+    <!-- CS1591: suppress until TASK-21 adds missing XML docs to all public APIs -->
+    <NoWarn>$(NoWarn);RS0026;RS0027;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="" />

--- a/JsonSchemaValidation/JsonSchemaValidator.cs
+++ b/JsonSchemaValidation/JsonSchemaValidator.cs
@@ -34,7 +34,7 @@ namespace FormFinch.JsonSchemaValidation
     /// </para>
     /// <para>
     /// For advanced scenarios (custom configuration, dependency injection integration),
-    /// use <see cref="SchemaValidationSetup.AddJsonSchemaValidation"/> instead.
+    /// use <see cref="SchemaValidationSetup.AddJsonSchemaValidation(IServiceCollection, Action{SchemaValidationOptions}?)"/> instead.
     /// </para>
     /// <para>
     /// <b>Note:</b> Schemas are cached by content hash to avoid unbounded memory growth


### PR DESCRIPTION
## Summary
- Enable `GenerateDocumentationFile` so XML docs are included in the NuGet package (IntelliSense for consumers)
- Temporarily suppress CS1591 (missing XML comments) — 396 public members need docs, tracked by TASK-21
- Fix CS0419 ambiguous `cref` in `JsonSchemaValidator.cs`

## Test plan
- [x] Build passes with 0 warnings, 0 errors
- [x] XML doc files generated for both net8.0 and net10.0
- [x] XML files present in NuGet package (`lib/net8.0/*.xml`, `lib/net10.0/*.xml`)
- [x] All 4,158 tests pass on both frameworks

Closes TASK-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)