### PR TITLE
build: Add Source Link support for debugging into source

### DIFF
--- a/JsonSchemaValidation/JsonSchemaValidation.csproj
+++ b/JsonSchemaValidation/JsonSchemaValidation.csproj
@@ -60,10 +60,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="FormFinch.JsonSchemaValidation.Tests" />

--- a/JsonSchemaValidation/JsonSchemaValidation.csproj
+++ b/JsonSchemaValidation/JsonSchemaValidation.csproj
@@ -15,6 +15,8 @@
     <Description>FormFinch JsonSchemaValidation is a .NET class library for validating JSON documents against JSON Schemas without reliance on third-party libraries, built on top of System.Text.Json.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/formfinch/JsonSchemaValidation</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageTags>json schema validation</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>FormFinch JsonSchemaValidation</Title>
@@ -55,6 +57,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Add `Microsoft.SourceLink.GitHub` package (PrivateAssets=all, build-time only)
- Set `PublishRepositoryUrl` and `EmbedUntrackedSources` properties
- Enables package consumers to step into source code when debugging via Visual Studio

## Test plan
- [x] Build passes with 0 warnings, 0 errors
- [x] All 4,158 tests pass on net8.0 and net10.0
- [ ] AC #4 (verify debugging from consuming project) can be validated after package is published

Closes TASK-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)