### PR TITLE
Enable symbol packages and deterministic builds

### DIFF
--- a/JsonSchemaValidation/JsonSchemaValidation.csproj
+++ b/JsonSchemaValidation/JsonSchemaValidation.csproj
@@ -17,6 +17,8 @@
     <RepositoryUrl>https://github.com/formfinch/JsonSchemaValidation</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageTags>json schema validation</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>FormFinch JsonSchemaValidation</Title>
@@ -24,6 +26,8 @@
     <PackageProjectUrl>https://www.formfinch.com</PackageProjectUrl>
   </PropertyGroup>
   <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Suppress backcompat warnings for 1.0.0 release - no prior public API to maintain -->


### PR DESCRIPTION
## Summary
- **TASK-23:** Enable symbol packages (`.snupkg`) so consumers can debug into the library via the NuGet symbol server
- **TASK-24:** Configure deterministic builds with `ContinuousIntegrationBuild` conditional on CI environment

## Changes
- `IncludeSymbols`: true
- `SymbolPackageFormat`: snupkg
- `Deterministic`: true
- `ContinuousIntegrationBuild`: true (only when `CI=true`)

## Test plan
- [x] Build succeeds with 0 warnings in Release mode
- [x] `.snupkg` symbol package generated alongside `.nupkg`
- [x] All 4158 tests pass on both net8.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)