### PR TITLE
Fix cross-platform path compatibility for Linux CI runners (TASK-72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build-and-test:
     name: Build, Test & Pack
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/JsonSchemaValidationTests/Draft201909/CompiledSchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft201909/CompiledSchemaValidationTests.cs
@@ -93,7 +93,7 @@ namespace FormFinch.JsonSchemaValidationTests.Draft201909
 
         private static void LoadRemoteSchemas(CompiledValidatorRegistry registry)
         {
-            var remotesPath = @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes";
+            var remotesPath = "../../../../submodules/JSON-Schema-Test-Suite/remotes";
             if (!Directory.Exists(remotesPath)) return;
 
             // Collect all remote schema files first (including subschemas with fragments)
@@ -443,17 +443,17 @@ namespace FormFinch.JsonSchemaValidationTests.Draft201909
                 "unknownKeyword",
                 "vocabulary",
 
-                @"\optional\anchor",
-                @"\optional\bignum",
-                @"\optional\cross-draft",
-                @"\optional\dependencies-compatibility",
-                @"\optional\float-overflow",
-                @"\optional\format-assertion",
-                @"\optional\id",
-                @"\optional\no-schema",
-                @"\optional\non-bmp-regex",
-                @"\optional\refOfUnknownKeyword",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2019-09");
+                "/optional/anchor",
+                "/optional/bignum",
+                "/optional/cross-draft",
+                "/optional/dependencies-compatibility",
+                "/optional/float-overflow",
+                "/optional/format-assertion",
+                "/optional/id",
+                "/optional/no-schema",
+                "/optional/non-bmp-regex",
+                "/optional/refOfUnknownKeyword",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2019-09");
 
         public static IEnumerable<object[]> GetDraft201909FormatAssertionTests()
             => GetAllDraft201909FormatAssertionTests().Where(arr => GetSkipReason(((TestCase)arr[0]).Description) == null);
@@ -463,28 +463,28 @@ namespace FormFinch.JsonSchemaValidationTests.Draft201909
 
         private static IEnumerable<object[]> GetAllDraft201909FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\duration",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\idn-email",
-                @"\optional\format\idn-hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\iri",
-                @"\optional\format\iri-reference",
-                @"\optional\format\json-pointer",
-                @"\optional\format\regex",
-                @"\optional\format\relative-json-pointer",
-                @"\optional\format\time",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-                @"\optional\format\uuid",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2019-09");
+                "/optional/ecmascript-regex",
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/duration",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/idn-email",
+                "/optional/format/idn-hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/iri",
+                "/optional/format/iri-reference",
+                "/optional/format/json-pointer",
+                "/optional/format/regex",
+                "/optional/format/relative-json-pointer",
+                "/optional/format/time",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+                "/optional/format/uuid",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2019-09");
 
         /// <summary>
         /// Returns a skip reason if the test case should be skipped, null otherwise.

--- a/JsonSchemaValidationTests/Draft201909/SchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft201909/SchemaValidationTests.cs
@@ -47,23 +47,23 @@ namespace FormFinch.JsonSchemaValidationTests.Draft201909
             // Load draft2019-09 specific remote schemas
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2019-09",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2019-09",
                 "http://localhost:1234/draft2019-09/");
 
             // Load draft2020-12 and draft7 remotes for cross-draft tests
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2020-12",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2020-12",
                 "http://localhost:1234/draft2020-12/");
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft7",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft7",
                 "http://localhost:1234/draft7/");
 
             // Load common remote schemas from root remotes folder
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes",
                 "http://localhost:1234/",
                 topLevelOnly: true);
         }
@@ -203,17 +203,17 @@ namespace FormFinch.JsonSchemaValidationTests.Draft201909
                 "unknownKeyword",
                 "vocabulary",
 
-                @"\optional\anchor",
-                @"\optional\bignum",
-                @"\optional\cross-draft",
-                @"\optional\dependencies-compatibility",
-                @"\optional\float-overflow",
-                @"\optional\format-assertion",                  // Requires vocabulary support
-                @"\optional\id",
-                @"\optional\no-schema",
-                @"\optional\non-bmp-regex",
-                @"\optional\refOfUnknownKeyword",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2019-09");
+                "/optional/anchor",
+                "/optional/bignum",
+                "/optional/cross-draft",
+                "/optional/dependencies-compatibility",
+                "/optional/float-overflow",
+                "/optional/format-assertion",                  // Requires vocabulary support
+                "/optional/id",
+                "/optional/no-schema",
+                "/optional/non-bmp-regex",
+                "/optional/refOfUnknownKeyword",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2019-09");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -221,28 +221,28 @@ namespace FormFinch.JsonSchemaValidationTests.Draft201909
         /// </summary>
         public static IEnumerable<object[]> GetDraft201909FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",                  // Requires format:regex validation for metaschema
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\duration",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\idn-email",
-                @"\optional\format\idn-hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\iri",
-                @"\optional\format\iri-reference",
-                @"\optional\format\json-pointer",
-                @"\optional\format\regex",
-                @"\optional\format\relative-json-pointer",
-                @"\optional\format\time",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-                @"\optional\format\uuid",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2019-09");
+                "/optional/ecmascript-regex",                  // Requires format:regex validation for metaschema
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/duration",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/idn-email",
+                "/optional/format/idn-hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/iri",
+                "/optional/format/iri-reference",
+                "/optional/format/json-pointer",
+                "/optional/format/regex",
+                "/optional/format/relative-json-pointer",
+                "/optional/format/time",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+                "/optional/format/uuid",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2019-09");
 
         private bool IsTestDisabled(string testCaseDescription, string testDescription)
         {

--- a/JsonSchemaValidationTests/Draft202012/CompiledSchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft202012/CompiledSchemaValidationTests.cs
@@ -128,7 +128,7 @@ namespace FormFinch.JsonSchemaValidationTests.Draft202012
 
         private static void LoadRemoteSchemas(CompiledValidatorRegistry registry)
         {
-            var remotesPath = @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes";
+            var remotesPath = "../../../../submodules/JSON-Schema-Test-Suite/remotes";
             if (!Directory.Exists(remotesPath)) return;
 
             // Collect all remote schema files first (including subschemas with fragments)
@@ -513,18 +513,18 @@ namespace FormFinch.JsonSchemaValidationTests.Draft202012
                 "unknownKeyword",
                 "vocabulary",
 
-                @"\optional\anchor",
-                @"\optional\bignum",
-                @"\optional\cross-draft",
-                @"\optional\dependencies-compatibility",
-                @"\optional\dynamicRef",
-                @"\optional\float-overflow",
-                @"\optional\format-assertion",                  // Requires vocabulary support
-                @"\optional\id",
-                @"\optional\no-schema",
-                @"\optional\non-bmp-regex",
-                @"\optional\refOfUnknownKeyword",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2020-12");
+                "/optional/anchor",
+                "/optional/bignum",
+                "/optional/cross-draft",
+                "/optional/dependencies-compatibility",
+                "/optional/dynamicRef",
+                "/optional/float-overflow",
+                "/optional/format-assertion",                  // Requires vocabulary support
+                "/optional/id",
+                "/optional/no-schema",
+                "/optional/non-bmp-regex",
+                "/optional/refOfUnknownKeyword",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2020-12");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -538,28 +538,28 @@ namespace FormFinch.JsonSchemaValidationTests.Draft202012
 
         private static IEnumerable<object[]> GetAllDraft202012FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",                  // Requires format:regex validation for metaschema
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\duration",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\idn-email",
-                @"\optional\format\idn-hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\iri",
-                @"\optional\format\iri-reference",
-                @"\optional\format\json-pointer",
-                @"\optional\format\regex",
-                @"\optional\format\relative-json-pointer",
-                @"\optional\format\time",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-                @"\optional\format\uuid",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2020-12");
+                "/optional/ecmascript-regex",                  // Requires format:regex validation for metaschema
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/duration",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/idn-email",
+                "/optional/format/idn-hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/iri",
+                "/optional/format/iri-reference",
+                "/optional/format/json-pointer",
+                "/optional/format/regex",
+                "/optional/format/relative-json-pointer",
+                "/optional/format/time",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+                "/optional/format/uuid",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2020-12");
 
         /// <summary>
         /// Returns a skip reason if the test case should be skipped, null otherwise.

--- a/JsonSchemaValidationTests/Draft202012/SchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft202012/SchemaValidationTests.cs
@@ -47,19 +47,19 @@ namespace FormFinch.JsonSchemaValidationTests.Draft202012
             // Load draft2020-12 specific remote schemas
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2020-12",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2020-12",
                 "http://localhost:1234/draft2020-12/");
 
             // Load draft2019-09 remotes for cross-draft tests
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2019-09",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2019-09",
                 "http://localhost:1234/draft2019-09/");
 
             // Load common remote schemas from root remotes folder
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes",
                 "http://localhost:1234/",
                 topLevelOnly: true);
         }
@@ -199,18 +199,18 @@ namespace FormFinch.JsonSchemaValidationTests.Draft202012
                 "unknownKeyword",
                 "vocabulary",
 
-                @"\optional\anchor",
-                @"\optional\bignum",
-                @"\optional\cross-draft",
-                @"\optional\dependencies-compatibility",
-                @"\optional\dynamicRef",
-                @"\optional\float-overflow",
-                @"\optional\format-assertion",                  // Requires vocabulary support
-                @"\optional\id",
-                @"\optional\no-schema",
-                @"\optional\non-bmp-regex",
-                @"\optional\refOfUnknownKeyword",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2020-12");
+                "/optional/anchor",
+                "/optional/bignum",
+                "/optional/cross-draft",
+                "/optional/dependencies-compatibility",
+                "/optional/dynamicRef",
+                "/optional/float-overflow",
+                "/optional/format-assertion",                  // Requires vocabulary support
+                "/optional/id",
+                "/optional/no-schema",
+                "/optional/non-bmp-regex",
+                "/optional/refOfUnknownKeyword",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2020-12");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -218,28 +218,28 @@ namespace FormFinch.JsonSchemaValidationTests.Draft202012
         /// </summary>
         public static IEnumerable<object[]> GetDraft202012FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",                  // Requires format:regex validation for metaschema
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\duration",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\idn-email",
-                @"\optional\format\idn-hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\iri",
-                @"\optional\format\iri-reference",
-                @"\optional\format\json-pointer",
-                @"\optional\format\regex",
-                @"\optional\format\relative-json-pointer",
-                @"\optional\format\time",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-                @"\optional\format\uuid",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2020-12");
+                "/optional/ecmascript-regex",                  // Requires format:regex validation for metaschema
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/duration",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/idn-email",
+                "/optional/format/idn-hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/iri",
+                "/optional/format/iri-reference",
+                "/optional/format/json-pointer",
+                "/optional/format/regex",
+                "/optional/format/relative-json-pointer",
+                "/optional/format/time",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+                "/optional/format/uuid",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft2020-12");
 
         private bool IsTestDisabled(string testCaseDescription, string testDescription)
         {

--- a/JsonSchemaValidationTests/Draft3/CompiledSchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft3/CompiledSchemaValidationTests.cs
@@ -88,7 +88,7 @@ namespace FormFinch.JsonSchemaValidationTests.Draft3
 
         private static void LoadRemoteSchemas(CompiledValidatorRegistry registry)
         {
-            var remotesPath = @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes";
+            var remotesPath = "../../../../submodules/JSON-Schema-Test-Suite/remotes";
             if (!Directory.Exists(remotesPath)) return;
 
             var pendingSchemas = new List<(Uri SchemaUri, string Content)>();
@@ -376,10 +376,10 @@ namespace FormFinch.JsonSchemaValidationTests.Draft3
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\non-bmp-regex",
+                "/optional/bignum",
+                "/optional/non-bmp-regex",
                 // Note: zeroTerminatedFloats excluded because .NET's System.Text.Json normalizes 1.0 to 1
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft3");
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft3");
 
         public static IEnumerable<object[]> GetDraft3FormatAssertionTests()
             => GetAllDraft3FormatAssertionTests().Where(arr => GetSkipReason(((TestCase)arr[0]).Description) == null);
@@ -389,18 +389,18 @@ namespace FormFinch.JsonSchemaValidationTests.Draft3
 
         private static IEnumerable<object[]> GetAllDraft3FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\format\color",
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\email",
-                @"\optional\format\host-name",
-                @"\optional\format\ip-address",
-                @"\optional\format\ipv6",
-                @"\optional\format\regex",
-                @"\optional\format\time",
-                @"\optional\format\uri",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft3");
+                "/optional/ecmascript-regex",
+                "/optional/format/color",
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/email",
+                "/optional/format/host-name",
+                "/optional/format/ip-address",
+                "/optional/format/ipv6",
+                "/optional/format/regex",
+                "/optional/format/time",
+                "/optional/format/uri",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft3");
 
         /// <summary>
         /// Returns a skip reason if the test case should be skipped, null otherwise.

--- a/JsonSchemaValidationTests/Draft3/SchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft3/SchemaValidationTests.cs
@@ -50,39 +50,39 @@ namespace FormFinch.JsonSchemaValidationTests.Draft3
             // Load draft3 specific remote schemas
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft3",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft3",
                 "http://localhost:1234/draft3/");
 
             // Load future draft remotes for cross-draft tests
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft4",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft4",
                 "http://localhost:1234/draft4/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft6",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft6",
                 "http://localhost:1234/draft6/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft7",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft7",
                 "http://localhost:1234/draft7/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2019-09",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2019-09",
                 "http://localhost:1234/draft2019-09/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2020-12",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2020-12",
                 "http://localhost:1234/draft2020-12/");
 
             // Load common remote schemas from root remotes folder (including subdirectories)
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes",
                 "http://localhost:1234/",
                 excludeDirectories: new[] { "draft3", "draft4", "draft6", "draft7", "draft2019-09", "draft2020-12", "v1" });
         }
@@ -211,10 +211,10 @@ namespace FormFinch.JsonSchemaValidationTests.Draft3
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\non-bmp-regex",
+                "/optional/bignum",
+                "/optional/non-bmp-regex",
                 // Note: zeroTerminatedFloats excluded because .NET's System.Text.Json normalizes 1.0 to 1
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft3");
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft3");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -222,18 +222,18 @@ namespace FormFinch.JsonSchemaValidationTests.Draft3
         /// </summary>
         public static IEnumerable<object[]> GetDraft3FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\format\color",
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\email",
-                @"\optional\format\host-name",
-                @"\optional\format\ip-address",
-                @"\optional\format\ipv6",
-                @"\optional\format\regex",
-                @"\optional\format\time",
-                @"\optional\format\uri",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft3");
+                "/optional/ecmascript-regex",
+                "/optional/format/color",
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/email",
+                "/optional/format/host-name",
+                "/optional/format/ip-address",
+                "/optional/format/ipv6",
+                "/optional/format/regex",
+                "/optional/format/time",
+                "/optional/format/uri",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft3");
 
         private bool IsTestDisabled(string testCaseDescription, string testDescription)
         {

--- a/JsonSchemaValidationTests/Draft4/CompiledSchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft4/CompiledSchemaValidationTests.cs
@@ -88,7 +88,7 @@ namespace FormFinch.JsonSchemaValidationTests.Draft4
 
         private static void LoadRemoteSchemas(CompiledValidatorRegistry registry)
         {
-            var remotesPath = @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes";
+            var remotesPath = "../../../../submodules/JSON-Schema-Test-Suite/remotes";
             if (!Directory.Exists(remotesPath)) return;
 
             var pendingSchemas = new List<(Uri SchemaUri, string Content)>();
@@ -378,11 +378,11 @@ namespace FormFinch.JsonSchemaValidationTests.Draft4
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\float-overflow",
-                @"\optional\non-bmp-regex",
+                "/optional/bignum",
+                "/optional/float-overflow",
+                "/optional/non-bmp-regex",
                 // Note: zeroTerminatedFloats excluded because .NET's System.Text.Json normalizes 1.0 to 1
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft4");
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft4");
 
         public static IEnumerable<object[]> GetDraft4FormatAssertionTests()
             => GetAllDraft4FormatAssertionTests().Where(arr => GetSkipReason(((TestCase)arr[0]).Description) == null);
@@ -392,16 +392,16 @@ namespace FormFinch.JsonSchemaValidationTests.Draft4
 
         private static IEnumerable<object[]> GetAllDraft4FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\id",
-                @"\optional\format\date-time",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft4");
+                "/optional/ecmascript-regex",
+                "/optional/id",
+                "/optional/format/date-time",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft4");
 
         /// <summary>
         /// Returns a skip reason if the test case should be skipped, null otherwise.

--- a/JsonSchemaValidationTests/Draft4/SchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft4/SchemaValidationTests.cs
@@ -50,34 +50,34 @@ namespace FormFinch.JsonSchemaValidationTests.Draft4
             // Load draft4 specific remote schemas
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft4",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft4",
                 "http://localhost:1234/draft4/");
 
             // Load future draft remotes for cross-draft tests
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft6",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft6",
                 "http://localhost:1234/draft6/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft7",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft7",
                 "http://localhost:1234/draft7/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2019-09",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2019-09",
                 "http://localhost:1234/draft2019-09/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2020-12",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2020-12",
                 "http://localhost:1234/draft2020-12/");
 
             // Load common remote schemas from root remotes folder (including subdirectories)
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes",
                 "http://localhost:1234/",
                 excludeDirectories: new[] { "draft3", "draft4", "draft6", "draft7", "draft2019-09", "draft2020-12", "v1" });
         }
@@ -209,11 +209,11 @@ namespace FormFinch.JsonSchemaValidationTests.Draft4
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\float-overflow",
-                @"\optional\non-bmp-regex",
+                "/optional/bignum",
+                "/optional/float-overflow",
+                "/optional/non-bmp-regex",
                 // Note: zeroTerminatedFloats excluded because .NET's System.Text.Json normalizes 1.0 to 1
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft4");
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft4");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -221,16 +221,16 @@ namespace FormFinch.JsonSchemaValidationTests.Draft4
         /// </summary>
         public static IEnumerable<object[]> GetDraft4FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\id",
-                @"\optional\format\date-time",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft4");
+                "/optional/ecmascript-regex",
+                "/optional/id",
+                "/optional/format/date-time",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft4");
 
         private bool IsTestDisabled(string testCaseDescription, string testDescription)
         {

--- a/JsonSchemaValidationTests/Draft6/CompiledSchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft6/CompiledSchemaValidationTests.cs
@@ -88,7 +88,7 @@ namespace FormFinch.JsonSchemaValidationTests.Draft6
 
         private static void LoadRemoteSchemas(CompiledValidatorRegistry registry)
         {
-            var remotesPath = @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes";
+            var remotesPath = "../../../../submodules/JSON-Schema-Test-Suite/remotes";
             if (!Directory.Exists(remotesPath)) return;
 
             var pendingSchemas = new List<(Uri SchemaUri, string Content)>();
@@ -380,10 +380,10 @@ namespace FormFinch.JsonSchemaValidationTests.Draft6
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\float-overflow",
-                @"\optional\non-bmp-regex",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft6");
+                "/optional/bignum",
+                "/optional/float-overflow",
+                "/optional/non-bmp-regex",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft6");
 
         public static IEnumerable<object[]> GetDraft6FormatAssertionTests()
             => GetAllDraft6FormatAssertionTests().Where(arr => GetSkipReason(((TestCase)arr[0]).Description) == null);
@@ -393,20 +393,20 @@ namespace FormFinch.JsonSchemaValidationTests.Draft6
 
         private static IEnumerable<object[]> GetAllDraft6FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\id",
-                @"\optional\unknownKeyword",
-                @"\optional\format\date-time",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\json-pointer",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft6");
+                "/optional/ecmascript-regex",
+                "/optional/id",
+                "/optional/unknownKeyword",
+                "/optional/format/date-time",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/json-pointer",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft6");
 
         /// <summary>
         /// Returns a skip reason if the test case should be skipped, null otherwise.

--- a/JsonSchemaValidationTests/Draft6/SchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft6/SchemaValidationTests.cs
@@ -50,29 +50,29 @@ namespace FormFinch.JsonSchemaValidationTests.Draft6
             // Load draft6 specific remote schemas
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft6",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft6",
                 "http://localhost:1234/draft6/");
 
             // Load future draft remotes for cross-draft tests
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft7",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft7",
                 "http://localhost:1234/draft7/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2019-09",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2019-09",
                 "http://localhost:1234/draft2019-09/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2020-12",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2020-12",
                 "http://localhost:1234/draft2020-12/");
 
             // Load common remote schemas from root remotes folder (including subdirectories)
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes",
                 "http://localhost:1234/",
                 excludeDirectories: new[] { "draft6", "draft7", "draft2019-09", "draft2020-12", "draft3", "draft4", "v1" });
         }
@@ -209,10 +209,10 @@ namespace FormFinch.JsonSchemaValidationTests.Draft6
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\float-overflow",
-                @"\optional\non-bmp-regex",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft6");
+                "/optional/bignum",
+                "/optional/float-overflow",
+                "/optional/non-bmp-regex",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft6");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -220,20 +220,20 @@ namespace FormFinch.JsonSchemaValidationTests.Draft6
         /// </summary>
         public static IEnumerable<object[]> GetDraft6FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\id",
-                @"\optional\unknownKeyword",
-                @"\optional\format\date-time",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\json-pointer",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft6");
+                "/optional/ecmascript-regex",
+                "/optional/id",
+                "/optional/unknownKeyword",
+                "/optional/format/date-time",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/json-pointer",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft6");
 
         private bool IsTestDisabled(string testCaseDescription, string testDescription)
         {

--- a/JsonSchemaValidationTests/Draft7/CompiledSchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft7/CompiledSchemaValidationTests.cs
@@ -92,7 +92,7 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
 
         private static void LoadRemoteSchemas(CompiledValidatorRegistry registry)
         {
-            var remotesPath = @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes";
+            var remotesPath = "../../../../submodules/JSON-Schema-Test-Suite/remotes";
             if (!Directory.Exists(remotesPath)) return;
 
             var pendingSchemas = new List<(Uri SchemaUri, string Content)>();
@@ -401,12 +401,12 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
-                @"\optional\cross-draft",
-                @"\optional\float-overflow",
-                @"\optional\non-bmp-regex",
-                @"\optional\unknownKeyword",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft7");
+                "/optional/bignum",
+                "/optional/cross-draft",
+                "/optional/float-overflow",
+                "/optional/non-bmp-regex",
+                "/optional/unknownKeyword",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft7");
 
         public static IEnumerable<object[]> GetDraft7FormatAssertionTests()
             => GetAllDraft7FormatAssertionTests().Where(arr => GetSkipReason(((TestCase)arr[0]).Description) == null);
@@ -416,26 +416,26 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
 
         private static IEnumerable<object[]> GetAllDraft7FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\idn-email",
-                @"\optional\format\idn-hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\iri",
-                @"\optional\format\iri-reference",
-                @"\optional\format\json-pointer",
-                @"\optional\format\regex",
-                @"\optional\format\relative-json-pointer",
-                @"\optional\format\time",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft7");
+                "/optional/ecmascript-regex",
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/idn-email",
+                "/optional/format/idn-hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/iri",
+                "/optional/format/iri-reference",
+                "/optional/format/json-pointer",
+                "/optional/format/regex",
+                "/optional/format/relative-json-pointer",
+                "/optional/format/time",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft7");
 
         public static IEnumerable<object[]> GetDraft7ContentAssertionTests()
             => GetAllDraft7ContentAssertionTests().Where(arr => GetSkipReason(((TestCase)arr[0]).Description) == null);
@@ -445,8 +445,8 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
 
         private static IEnumerable<object[]> GetAllDraft7ContentAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\content",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft7");
+                "/optional/content",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft7");
 
         /// <summary>
         /// Returns a skip reason if the test case should be skipped, null otherwise.

--- a/JsonSchemaValidationTests/Draft7/SchemaValidationTests.cs
+++ b/JsonSchemaValidationTests/Draft7/SchemaValidationTests.cs
@@ -63,24 +63,24 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
             // Load draft7 specific remote schemas
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft7",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft7",
                 "http://localhost:1234/draft7/");
 
             // Load future draft remotes for cross-draft tests
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2019-09",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2019-09",
                 "http://localhost:1234/draft2019-09/");
 
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes\draft2020-12",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes/draft2020-12",
                 "http://localhost:1234/draft2020-12/");
 
             // Load common remote schemas from root remotes folder (including subdirectories)
             LoadRemoteSchemasFromPath(
                 schemaRepository,
-                @"..\..\..\..\submodules\JSON-Schema-Test-Suite\remotes",
+                "../../../../submodules/JSON-Schema-Test-Suite/remotes",
                 "http://localhost:1234/",
                 excludeDirectories: new[] { "draft7", "draft2019-09", "draft2020-12", "draft3", "draft4", "draft6", "v1" });
         }
@@ -225,13 +225,13 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
                 "type",
                 "uniqueItems",
 
-                @"\optional\bignum",
+                "/optional/bignum",
                 // Note: content tests removed - they require ContentAssertionEnabled
-                @"\optional\cross-draft",
-                @"\optional\float-overflow",
-                @"\optional\non-bmp-regex",
-                @"\optional\unknownKeyword",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft7");
+                "/optional/cross-draft",
+                "/optional/float-overflow",
+                "/optional/non-bmp-regex",
+                "/optional/unknownKeyword",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft7");
 
         /// <summary>
         /// Returns test cases for optional format validation tests.
@@ -239,26 +239,26 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
         /// </summary>
         public static IEnumerable<object[]> GetDraft7FormatAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\ecmascript-regex",
-                @"\optional\format\date-time",
-                @"\optional\format\date",
-                @"\optional\format\email",
-                @"\optional\format\hostname",
-                @"\optional\format\idn-email",
-                @"\optional\format\idn-hostname",
-                @"\optional\format\ipv4",
-                @"\optional\format\ipv6",
-                @"\optional\format\iri",
-                @"\optional\format\iri-reference",
-                @"\optional\format\json-pointer",
-                @"\optional\format\regex",
-                @"\optional\format\relative-json-pointer",
-                @"\optional\format\time",
-                @"\optional\format\unknown",
-                @"\optional\format\uri",
-                @"\optional\format\uri-reference",
-                @"\optional\format\uri-template",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft7");
+                "/optional/ecmascript-regex",
+                "/optional/format/date-time",
+                "/optional/format/date",
+                "/optional/format/email",
+                "/optional/format/hostname",
+                "/optional/format/idn-email",
+                "/optional/format/idn-hostname",
+                "/optional/format/ipv4",
+                "/optional/format/ipv6",
+                "/optional/format/iri",
+                "/optional/format/iri-reference",
+                "/optional/format/json-pointer",
+                "/optional/format/regex",
+                "/optional/format/relative-json-pointer",
+                "/optional/format/time",
+                "/optional/format/unknown",
+                "/optional/format/uri",
+                "/optional/format/uri-reference",
+                "/optional/format/uri-template",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft7");
 
         /// <summary>
         /// Returns test cases for optional content validation tests.
@@ -266,8 +266,8 @@ namespace FormFinch.JsonSchemaValidationTests.Draft7
         /// </summary>
         public static IEnumerable<object[]> GetDraft7ContentAssertionTests()
             => new TestCaseLoader(new string[] {
-                @"\optional\content",
-            }).LoadTestCases(@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft7");
+                "/optional/content",
+            }).LoadTestCases("../../../../submodules/JSON-Schema-Test-Suite/tests/draft7");
 
         private bool IsTestDisabled(string testCaseDescription, string testDescription)
         {

--- a/JsonSchemaValidationTests/TestCases/TestCaseLoader.cs
+++ b/JsonSchemaValidationTests/TestCases/TestCaseLoader.cs
@@ -25,10 +25,11 @@ namespace FormFinch.JsonSchemaValidationTests.TestCases
                 {
                     foreach (var test in tests)
                     {
-                        var keyword = keywords!.FirstOrDefault(kw =>
+                        var normalizedFile = file.Replace('\\', '/');
+                    var keyword = keywords!.FirstOrDefault(kw =>
                             kw != null
-                            && file.EndsWith($"{kw}.json", StringComparison.CurrentCultureIgnoreCase)
-                            && kw.EndsWith(Path.GetFileNameWithoutExtension(file)));
+                            && normalizedFile.EndsWith($"{kw.Replace('\\', '/')}.json", StringComparison.CurrentCultureIgnoreCase)
+                            && kw.Replace('\\', '/').EndsWith(Path.GetFileNameWithoutExtension(file)));
                         if (keyword != null)
                         {
                             yield return new object[] { test };

--- a/backlog/tasks/task-33 - Set-up-GitHub-Actions-PR-CI-fast.md
+++ b/backlog/tasks/task-33 - Set-up-GitHub-Actions-PR-CI-fast.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-33
 title: Set up GitHub Actions - PR CI (fast)
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-01-30 21:57'
-updated_date: '2026-02-06 23:10'
+updated_date: '2026-02-07 00:11'
 labels:
   - infrastructure
   - ci-cd
@@ -44,11 +44,11 @@ Create a fast GitHub Actions CI workflow for pull request validation.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `.github/workflows/ci.yml` created
-- [ ] #2 Build passes on net8.0 and net10.0
-- [ ] #3 Unit tests run and report results
-- [ ] #4 Package build verified (`dotnet pack`)
-- [ ] #5 Path filters exclude docs/backlog changes
-- [ ] #6 Concurrency groups cancel superseded runs
+- [x] #1 `.github/workflows/ci.yml` created
+- [x] #2 Build passes on net8.0 and net10.0
+- [x] #3 Unit tests run and report results
+- [x] #4 Package build verified (`dotnet pack`)
+- [x] #5 Path filters exclude docs/backlog changes
+- [x] #6 Concurrency groups cancel superseded runs
 - [ ] #7 Status checks required for PR merge (branch protection)
 <!-- AC:END -->

--- a/backlog/tasks/task-72 - Fix-cross-platform-path-compatibility-for-Linux-CI-runners.md
+++ b/backlog/tasks/task-72 - Fix-cross-platform-path-compatibility-for-Linux-CI-runners.md
@@ -1,0 +1,32 @@
+---
+id: TASK-72
+title: Fix cross-platform path compatibility for Linux CI runners
+status: To Do
+assignee: []
+created_date: '2026-02-06 23:43'
+labels:
+  - infrastructure
+  - ci-cd
+  - testing
+milestone: 1.0.0 Release
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Test files throughout the codebase use hardcoded Windows backslash paths (e.g., `@"..\..\..\..\submodules\JSON-Schema-Test-Suite\tests\draft2019-09"`) which don't resolve on Linux. This forces CI to use `windows-latest` runners, which are slower (~7m vs ~2-3m target) and more expensive.
+
+**Affected files:** All test files that reference the JSON-Schema-Test-Suite submodule across Draft3, Draft4, Draft6, Draft7, Draft201909, Draft202012, and their compiled variants. Paths are used both in `LoadTestCases()` calls and direct `remotesPath` variables.
+
+**Fix approach:** Replace all hardcoded backslash path strings with `Path.Combine()` or forward slashes (which .NET handles cross-platform). Once fixed, switch CI workflow (`.github/workflows/ci.yml`) from `windows-latest` back to `ubuntu-latest` for faster, cheaper runs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All test file paths use cross-platform compatible path construction
+- [ ] #2 CI workflow switched to ubuntu-latest
+- [ ] #3 All tests pass on Linux runner
+- [ ] #4 CI run time under 3 minutes
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- Replace Windows backslash paths (`\`) with forward slashes (`/`) in all 12 test files (6 SchemaValidationTests + 6 CompiledSchemaValidationTests)
- Normalize path comparison in `TestCaseLoader.cs` so keyword filter matching works on both Windows and Linux
- Switch CI runner from `windows-latest` to `ubuntu-latest` for faster builds (~2-3 min vs ~7 min)

## Test plan
- [x] All 4158 tests pass locally on Windows with forward-slash paths (net8.0 + net10.0)
- [ ] CI passes on `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)