### PR TITLE
ci: Add nightly quality gate workflow (TASK-67)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+
 concurrency:
   group: nightly-${{ github.ref }}
   cancel-in-progress: true
@@ -28,8 +32,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          LAST_SHA=$(gh api repos/${{ github.repository }}/actions/workflows/nightly.yml/runs?status=success\&per_page=1 --jq '.workflow_runs[0].head_sha // empty')
-          if [ "$LAST_SHA" == "${{ github.sha }}" ]; then
+          LAST_SHA=$(gh api "repos/${{ github.repository }}/actions/workflows/nightly.yml/runs?status=success&branch=${{ github.ref_name }}&per_page=1" --jq '.workflow_runs[0].head_sha // empty' 2>&1) || true
+          if [ -z "$LAST_SHA" ]; then
+            echo "::warning::Could not determine last successful run SHA — running anyway."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [ "$LAST_SHA" == "${{ github.sha }}" ]; then
             echo "No new commits since last successful nightly run — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
@@ -103,7 +110,17 @@ jobs:
         shell: pwsh
         run: |
           $output = dotnet list package --vulnerable --include-transitive --format json 2>$null
-          $json = ($output -join "`n") | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to list packages. 'dotnet list package' exited with code $LASTEXITCODE."
+            exit $LASTEXITCODE
+          }
+
+          try {
+            $json = ($output -join "`n") | ConvertFrom-Json
+          } catch {
+            Write-Host "::error::Failed to parse JSON from 'dotnet list package'. Error: $($_.Exception.Message)"
+            exit 1
+          }
 
           $vulns = @()
           foreach ($project in $json.projects) {

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: nightly-quality-gate
+  cancel-in-progress: true
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -237,7 +241,6 @@ jobs:
             exit 0
           fi
 
-          FAILED=0
           RESULTS_DIR="BenchmarkDotNet.Artifacts/results"
 
           # Find all BenchmarkDotNet JSON result files
@@ -314,7 +317,7 @@ jobs:
         run: dotnet restore --source https://api.nuget.org/v3/index.json
 
       - name: Build
-        run: dotnet build --no-restore -c Release
+        run: dotnet build --no-restore -c Release -p:GeneratePackageOnBuild=false
 
       - name: Pack pre-release
         run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release --version-suffix "ci.${{ github.run_number }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -234,7 +234,17 @@ jobs:
 
       - name: Compare against baseline
         run: |
-          command -v jq >/dev/null 2>&1 || { echo "Installing jq..."; sudo apt-get update -qq && sudo apt-get install -yqq jq; }
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "Installing jq..."
+            if [ "$(uname -s)" = "Linux" ]; then
+              sudo apt-get update -qq && sudo apt-get install -yqq jq
+            elif [ "$(uname -s)" = "Darwin" ]; then
+              brew install jq
+            else
+              echo "::error::jq is not installed and no supported package manager found."
+              exit 1
+            fi
+          fi
 
           BASELINE="benchmarks/baseline.json"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: nightly-quality-gate
+  group: nightly-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -27,12 +27,12 @@ jobs:
         if: github.event_name == 'schedule'
         uses: actions/cache@v4
         with:
-          path: .nightly-marker
+          path: ${{ runner.temp }}/nightly-marker
           key: nightly-${{ github.sha }}
 
       - name: Create marker file
         if: github.event_name == 'schedule' && steps.skip-check.outputs.cache-hit != 'true'
-        run: date > .nightly-marker
+        run: date > "$RUNNER_TEMP/nightly-marker"
 
       - name: Set skip output
         id: set-skip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -234,6 +234,8 @@ jobs:
 
       - name: Compare against baseline
         run: |
+          command -v jq >/dev/null 2>&1 || { echo "Installing jq..."; sudo apt-get update -qq && sudo apt-get install -yqq jq; }
+
           BASELINE="benchmarks/baseline.json"
 
           if [ ! -f "$BASELINE" ]; then

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -229,10 +229,10 @@ jobs:
         run: dotnet build JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj --no-restore -c Release
 
       - name: Run SimpleValidationBenchmarks
-        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build --framework net8.0 -- --filter "SimpleValidationBenchmarks"
+        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build --framework net10.0 -- --filter "SimpleValidationBenchmarks"
 
       - name: Run ComplexValidationBenchmarks
-        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build --framework net8.0 -- --filter "ComplexValidationBenchmarks"
+        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build --framework net10.0 -- --filter "ComplexValidationBenchmarks"
 
       - name: Compare against baseline
         shell: pwsh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -233,67 +233,50 @@ jobs:
         run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build -- --filter "ComplexValidationBenchmarks"
 
       - name: Compare against baseline
+        shell: pwsh
         run: |
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "Installing jq..."
-            if [ "$(uname -s)" = "Linux" ]; then
-              sudo apt-get update -qq && sudo apt-get install -yqq jq
-            elif [ "$(uname -s)" = "Darwin" ]; then
-              brew install jq
-            else
-              echo "::error::jq is not installed and no supported package manager found."
-              exit 1
-            fi
-          fi
+          $baseline = 'benchmarks/baseline.json'
 
-          BASELINE="benchmarks/baseline.json"
-
-          if [ ! -f "$BASELINE" ]; then
-            echo "::warning::No baseline.json found — skipping regression check. Run benchmarks locally and commit benchmarks/baseline.json to enable comparison."
+          if (-not (Test-Path $baseline)) {
+            Write-Host '::warning::No baseline.json found — skipping regression check. Run benchmarks locally and commit benchmarks/baseline.json to enable comparison.'
             exit 0
-          fi
+          }
 
-          RESULTS_DIR="BenchmarkDotNet.Artifacts/results"
+          $baselineData = Get-Content $baseline -Raw | ConvertFrom-Json
+          $resultsDir = 'BenchmarkDotNet.Artifacts/results'
+          $failed = $false
 
-          # Find all BenchmarkDotNet JSON result files
-          for RESULT_FILE in "$RESULTS_DIR"/*-report-full.json; do
-            [ -f "$RESULT_FILE" ] || continue
-            echo "Processing: $RESULT_FILE"
+          foreach ($file in Get-ChildItem "$resultsDir/*-report-full.json" -ErrorAction SilentlyContinue) {
+            Write-Host "Processing: $($file.FullName)"
+            $report = Get-Content $file.FullName -Raw | ConvertFrom-Json
 
-            # Extract FormFinch benchmarks and compare against baseline
-            jq -r '.Benchmarks[] | select(.FullName | test("FormFinch_Validate")) | {
-              key: (.Type + "." + .Method + "(" + .Parameters + ")"),
-              mean: .Statistics.Mean
-            } | @base64' "$RESULT_FILE" | while read -r ENTRY; do
-              DECODED=$(echo "$ENTRY" | base64 -d)
-              KEY=$(echo "$DECODED" | jq -r '.key')
-              ACTUAL_NS=$(echo "$DECODED" | jq -r '.mean')
+            foreach ($bench in $report.Benchmarks) {
+              if ($bench.FullName -notmatch 'FormFinch_Validate') { continue }
 
-              BASELINE_NS=$(jq -r --arg k "$KEY" '.benchmarks[$k].mean_ns // empty' "$BASELINE")
+              $key = "$($bench.Type).$($bench.Method)($($bench.Parameters))"
+              $actualNs = $bench.Statistics.Mean
+              $baselineNs = $baselineData.benchmarks.$key.mean_ns
 
-              if [ -z "$BASELINE_NS" ]; then
-                echo "  ⚠ No baseline for: $KEY (skipping)"
+              if (-not $baselineNs) {
+                Write-Host "  Warning: No baseline for: $key (skipping)"
                 continue
-              fi
+              }
 
-              # Calculate regression percentage: (actual - baseline) / baseline * 100
-              REGRESSION=$(echo "$ACTUAL_NS $BASELINE_NS" | awk '{printf "%.1f", (($1 - $2) / $2) * 100}')
-              THRESHOLD=10
+              $regression = [math]::Round((($actualNs - $baselineNs) / $baselineNs) * 100, 1)
 
-              if echo "$REGRESSION $THRESHOLD" | awk '{exit !($1 > $2)}'; then
-                echo "::error::Regression detected: $KEY — ${REGRESSION}% slower (baseline: ${BASELINE_NS}ns, actual: ${ACTUAL_NS}ns)"
-                # Write to a temp file since we're in a subshell (pipe)
-                echo "1" > /tmp/bench_failed
-              else
-                echo "  ✓ $KEY — ${REGRESSION}% (baseline: ${BASELINE_NS}ns, actual: ${ACTUAL_NS}ns)"
-              fi
-            done
-          done
+              if ($regression -gt 10) {
+                Write-Host "::error::Regression detected: $key — ${regression}% slower (baseline: ${baselineNs}ns, actual: ${actualNs}ns)"
+                $failed = $true
+              } else {
+                Write-Host "  OK: $key — ${regression}% (baseline: ${baselineNs}ns, actual: ${actualNs}ns)"
+              }
+            }
+          }
 
-          if [ -f /tmp/bench_failed ]; then
-            echo "::error::One or more benchmarks regressed beyond the 10% threshold."
+          if ($failed) {
+            Write-Host '::error::One or more benchmarks regressed beyond the 10% threshold.'
             exit 1
-          fi
+          }
 
       - name: Upload benchmark artifacts
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,329 @@
+name: Nightly Quality Gate
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  CI: true
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.set-skip.outputs.skip }}
+
+    steps:
+      - name: Check for new commits
+        id: skip-check
+        if: github.event_name == 'schedule'
+        uses: actions/cache@v4
+        with:
+          path: .nightly-marker
+          key: nightly-${{ github.sha }}
+
+      - name: Create marker file
+        if: github.event_name == 'schedule' && steps.skip-check.outputs.cache-hit != 'true'
+        run: date > .nightly-marker
+
+      - name: Set skip output
+        id: set-skip
+        if: github.event_name == 'schedule'
+        run: |
+          if [ "${{ steps.skip-check.outputs.cache-hit }}" == "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip notice
+        if: steps.set-skip.outputs.skip == 'true'
+        run: echo "No new commits since last nightly run — skipping."
+
+      - name: Checkout
+        if: steps.set-skip.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        if: steps.set-skip.outputs.skip != 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        if: steps.set-skip.outputs.skip != 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        if: steps.set-skip.outputs.skip != 'true'
+        run: dotnet restore --source https://api.nuget.org/v3/index.json
+
+      - name: Build
+        if: steps.set-skip.outputs.skip != 'true'
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        if: steps.set-skip.outputs.skip != 'true'
+        run: dotnet test JsonSchemaValidationTests/JsonSchemaValidationTests.csproj --no-build -c Release --settings JsonSchemaValidationTests/default.runsettings --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        if: always() && steps.set-skip.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/test-results.trx'
+          retention-days: 7
+
+  security-scan:
+    name: Security Scan
+    needs: build-and-test
+    if: needs.build-and-test.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore --source https://api.nuget.org/v3/index.json
+
+      - name: Check for vulnerable packages
+        run: |
+          OUTPUT=$(dotnet list package --vulnerable --include-transitive 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "has the following vulnerable packages"; then
+            echo "::error::Vulnerable packages detected!"
+            exit 1
+          fi
+          echo "No vulnerable packages found."
+
+  memory-leak-tests:
+    name: Memory Leak Tests
+    needs: build-and-test
+    if: needs.build-and-test.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore stress tests
+        run: dotnet restore JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj --source https://api.nuget.org/v3/index.json
+
+      - name: Build stress tests
+        run: dotnet build JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj --no-restore -c Release
+
+      - name: Run memory leak tests
+        run: dotnet test JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj --no-build -c Release --filter "FullyQualifiedName~MemoryLeak" --logger "trx;LogFileName=memory-leak-results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-leak-results
+          path: '**/memory-leak-results.trx'
+          retention-days: 7
+
+  stress-tests:
+    name: Stress Tests
+    needs: build-and-test
+    if: needs.build-and-test.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore stress tests
+        run: dotnet restore JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj --source https://api.nuget.org/v3/index.json
+
+      - name: Build stress tests
+        run: dotnet build JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj --no-restore -c Release
+
+      - name: Run stress tests
+        run: dotnet test JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj --no-build -c Release --filter "FullyQualifiedName~StressTests|Category=Fuzzing" --logger "trx;LogFileName=stress-results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stress-results
+          path: '**/stress-results.trx'
+          retention-days: 7
+
+  benchmarks:
+    name: Benchmarks
+    needs: build-and-test
+    if: needs.build-and-test.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore benchmarks
+        run: dotnet restore JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj --source https://api.nuget.org/v3/index.json
+
+      - name: Build benchmarks
+        run: dotnet build JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj --no-restore -c Release
+
+      - name: Run SimpleValidationBenchmarks
+        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build -- --filter "SimpleValidationBenchmarks"
+
+      - name: Run ComplexValidationBenchmarks
+        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build -- --filter "ComplexValidationBenchmarks"
+
+      - name: Compare against baseline
+        run: |
+          BASELINE="benchmarks/baseline.json"
+
+          if [ ! -f "$BASELINE" ]; then
+            echo "::warning::No baseline.json found — skipping regression check. Run benchmarks locally and commit benchmarks/baseline.json to enable comparison."
+            exit 0
+          fi
+
+          FAILED=0
+          RESULTS_DIR="BenchmarkDotNet.Artifacts/results"
+
+          # Find all BenchmarkDotNet JSON result files
+          for RESULT_FILE in "$RESULTS_DIR"/*-report-full.json; do
+            [ -f "$RESULT_FILE" ] || continue
+            echo "Processing: $RESULT_FILE"
+
+            # Extract FormFinch benchmarks and compare against baseline
+            jq -r '.Benchmarks[] | select(.FullName | test("FormFinch_Validate")) | {
+              key: (.Type + "." + .Method + "(" + .Parameters + ")"),
+              mean: .Statistics.Mean
+            } | @base64' "$RESULT_FILE" | while read -r ENTRY; do
+              DECODED=$(echo "$ENTRY" | base64 -d)
+              KEY=$(echo "$DECODED" | jq -r '.key')
+              ACTUAL_NS=$(echo "$DECODED" | jq -r '.mean')
+
+              BASELINE_NS=$(jq -r --arg k "$KEY" '.benchmarks[$k].mean_ns // empty' "$BASELINE")
+
+              if [ -z "$BASELINE_NS" ]; then
+                echo "  ⚠ No baseline for: $KEY (skipping)"
+                continue
+              fi
+
+              # Calculate regression percentage: (actual - baseline) / baseline * 100
+              REGRESSION=$(echo "$ACTUAL_NS $BASELINE_NS" | awk '{printf "%.1f", (($1 - $2) / $2) * 100}')
+              THRESHOLD=10
+
+              if echo "$REGRESSION $THRESHOLD" | awk '{exit !($1 > $2)}'; then
+                echo "::error::Regression detected: $KEY — ${REGRESSION}% slower (baseline: ${BASELINE_NS}ns, actual: ${ACTUAL_NS}ns)"
+                # Write to a temp file since we're in a subshell (pipe)
+                echo "1" > /tmp/bench_failed
+              else
+                echo "  ✓ $KEY — ${REGRESSION}% (baseline: ${BASELINE_NS}ns, actual: ${ACTUAL_NS}ns)"
+              fi
+            done
+          done
+
+          if [ -f /tmp/bench_failed ]; then
+            echo "::error::One or more benchmarks regressed beyond the 10% threshold."
+            exit 1
+          fi
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: BenchmarkDotNet.Artifacts/
+          retention-days: 30
+
+  package:
+    name: Package
+    needs: build-and-test
+    if: needs.build-and-test.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore --source https://api.nuget.org/v3/index.json
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Pack pre-release
+        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release --version-suffix "ci.${{ github.run_number }}"
+
+      - name: Upload NuGet packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: |
+            **/*.nupkg
+            **/*.snupkg
+          retention-days: 90

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,30 +23,18 @@ jobs:
 
     steps:
       - name: Check for new commits
-        id: skip-check
-        if: github.event_name == 'schedule'
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/nightly-marker
-          key: nightly-${{ github.sha }}
-
-      - name: Create marker file
-        if: github.event_name == 'schedule' && steps.skip-check.outputs.cache-hit != 'true'
-        run: date > "$RUNNER_TEMP/nightly-marker"
-
-      - name: Set skip output
         id: set-skip
         if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ steps.skip-check.outputs.cache-hit }}" == "true" ]; then
+          LAST_SHA=$(gh api repos/${{ github.repository }}/actions/workflows/nightly.yml/runs?status=success\&per_page=1 --jq '.workflow_runs[0].head_sha // empty')
+          if [ "$LAST_SHA" == "${{ github.sha }}" ]; then
+            echo "No new commits since last successful nightly run — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Skip notice
-        if: steps.set-skip.outputs.skip == 'true'
-        run: echo "No new commits since last nightly run — skipping."
 
       - name: Checkout
         if: steps.set-skip.outputs.skip != 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,14 +112,28 @@ jobs:
         run: dotnet restore --source https://api.nuget.org/v3/index.json
 
       - name: Check for vulnerable packages
+        shell: pwsh
         run: |
-          OUTPUT=$(dotnet list package --vulnerable --include-transitive 2>&1)
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "has the following vulnerable packages"; then
-            echo "::error::Vulnerable packages detected!"
+          $output = dotnet list package --vulnerable --include-transitive --format json 2>&1
+          $json = $output | ConvertFrom-Json
+
+          $vulns = @()
+          foreach ($project in $json.projects) {
+            foreach ($framework in $project.frameworks) {
+              foreach ($pkg in @($framework.topLevelPackages; $framework.transitivePackages)) {
+                if ($pkg.vulnerabilities) {
+                  $vulns += $pkg
+                }
+              }
+            }
+          }
+
+          if ($vulns.Count -gt 0) {
+            Write-Host "::error::Vulnerable packages detected! ($($vulns.Count) vulnerable package(s) found)"
+            $vulns | ForEach-Object { Write-Host "  - $($_.id) $($_.resolvedVersion)" }
             exit 1
-          fi
-          echo "No vulnerable packages found."
+          }
+          Write-Host 'No vulnerable packages found.'
 
   memory-leak-tests:
     name: Memory Leak Tests
@@ -247,8 +261,14 @@ jobs:
           $baselineData = Get-Content $baseline -Raw | ConvertFrom-Json
           $resultsDir = 'BenchmarkDotNet.Artifacts/results'
           $failed = $false
+          $reportFiles = Get-ChildItem "$resultsDir/*-report-full.json" -ErrorAction SilentlyContinue
 
-          foreach ($file in Get-ChildItem "$resultsDir/*-report-full.json" -ErrorAction SilentlyContinue) {
+          if (-not $reportFiles) {
+            Write-Host '::error::No benchmark report files found. Ensure benchmarks ran with JSON export enabled.'
+            exit 1
+          }
+
+          foreach ($file in $reportFiles) {
             Write-Host "Processing: $($file.FullName)"
             $report = Get-Content $file.FullName -Raw | ConvertFrom-Json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           if [ "${{ steps.skip-check.outputs.cache-hit }}" == "true" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Skip notice
@@ -227,10 +229,10 @@ jobs:
         run: dotnet build JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj --no-restore -c Release
 
       - name: Run SimpleValidationBenchmarks
-        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build -- --filter "SimpleValidationBenchmarks"
+        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build --framework net8.0 -- --filter "SimpleValidationBenchmarks"
 
       - name: Run ComplexValidationBenchmarks
-        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build -- --filter "ComplexValidationBenchmarks"
+        run: dotnet run --project JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release --no-build --framework net8.0 -- --filter "ComplexValidationBenchmarks"
 
       - name: Compare against baseline
         shell: pwsh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,13 +114,16 @@ jobs:
       - name: Check for vulnerable packages
         shell: pwsh
         run: |
-          $output = dotnet list package --vulnerable --include-transitive --format json 2>&1
-          $json = $output | ConvertFrom-Json
+          $output = dotnet list package --vulnerable --include-transitive --format json 2>$null
+          $json = ($output -join "`n") | ConvertFrom-Json
 
           $vulns = @()
           foreach ($project in $json.projects) {
             foreach ($framework in $project.frameworks) {
-              foreach ($pkg in @($framework.topLevelPackages; $framework.transitivePackages)) {
+              $packages = @()
+              if ($framework.topLevelPackages) { $packages += $framework.topLevelPackages }
+              if ($framework.transitivePackages) { $packages += $framework.transitivePackages }
+              foreach ($pkg in $packages) {
                 if ($pkg.vulnerabilities) {
                   $vulns += $pkg
                 }
@@ -334,10 +337,10 @@ jobs:
         run: dotnet restore --source https://api.nuget.org/v3/index.json
 
       - name: Build
-        run: dotnet build --no-restore -c Release -p:GeneratePackageOnBuild=false
+        run: dotnet build --no-restore -c Release -p:GeneratePackageOnBuild=false -p:VersionSuffix="ci.${{ github.run_number }}"
 
       - name: Pack pre-release
-        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release --version-suffix "ci.${{ github.run_number }}"
+        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:VersionSuffix="ci.${{ github.run_number }}"
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Adds a nightly GitHub Actions workflow (`.github/workflows/nightly.yml`) that runs extended quality checks beyond the fast PR CI
- Runs daily at 2 AM UTC on schedule, with manual `workflow_dispatch` trigger support
- Skips automatically when no new commits since last successful nightly run (via GitHub API query)

### Jobs (all run in parallel after build-and-test gate):

| Job | What it does |
|-----|-------------|
| **Build & Test** | Same as PR CI — builds, runs full test suite, gates all downstream jobs |
| **Security Scan** | `dotnet list package --vulnerable --include-transitive --format json` — fails on known CVEs |
| **Memory Leak Tests** | Runs `MemoryLeakTests` from the stress test project (10 tests) |
| **Stress Tests** | Runs `StressTests`, `PropertyBasedTests`, `ReDoSTests` with 15-minute timeout |
| **Benchmarks** | Runs `SimpleValidation` + `ComplexValidation` benchmarks, compares FormFinch results against `benchmarks/baseline.json` (>10% regression = failure). Gracefully warns if no baseline exists yet |
| **Package** | Packs `1.0.0-ci.{run_number}` pre-release NuGet + symbols, uploads as artifact (90-day retention) |

## Test plan

- [ ] Trigger manually via `gh workflow run nightly.yml --ref feature/nightly-quality-gate`
- [ ] Verify build-and-test job passes
- [ ] Verify security scan completes (no vulnerable packages)
- [ ] Verify memory leak tests pass (10 tests)
- [ ] Verify stress tests pass (concurrency + fuzzing + ReDoS)
- [ ] Verify benchmarks run and warn "no baseline" (expected — no `baseline.json` committed yet)
- [ ] Verify NuGet package artifact is downloadable
- [ ] Trigger again without new commits to verify skip logic works

🤖 Generated with [Claude Code](https://claude.com/claude-code)