### PR TITLE
ci: Add release workflow for NuGet publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
         id: version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            RAW="${{ github.event.inputs.version }}"
+            echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
           else
             TAG="${GITHUB_REF#refs/tags/v}"
             echo "version=$TAG" >> "$GITHUB_OUTPUT"
@@ -67,44 +68,36 @@ jobs:
         run: dotnet test JsonSchemaValidationTests/JsonSchemaValidationTests.csproj --no-build -c Release --settings JsonSchemaValidationTests/default.runsettings --logger "trx;LogFileName=test-results.trx"
 
       - name: Pack
-        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }}
+        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./packages
 
       - name: NuGet login
-        if: inputs.dry-run != true
+        if: github.event.inputs.dry-run != 'true'
         uses: nuget/login@v1
         with:
-          nuget-api-key: ${{ secrets.NUGET_USER }}
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Push to NuGet
-        if: inputs.dry-run != true
-        run: dotnet nuget push '**/*.nupkg' --source https://api.nuget.org/v3/index.json --skip-duplicate
+        if: github.event.inputs.dry-run != 'true'
+        run: dotnet nuget push ./packages/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub Release
-        if: inputs.dry-run != true
+        if: github.event.inputs.dry-run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-
-          # For workflow_dispatch, create the tag if it doesn't exist
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            git tag "$TAG" || true
-            git push origin "$TAG" || true
-          fi
-
           gh release create "$TAG" \
             --generate-notes \
             --title "$TAG" \
-            **/*.nupkg **/*.snupkg
+            --target "$GITHUB_SHA" \
+            ./packages/*
 
       - name: Upload NuGet packages
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nuget-packages
-          path: |
-            **/*.nupkg
-            **/*.snupkg
+          path: ./packages/
           retention-days: 7
 
       - name: Upload test results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,17 +81,17 @@ jobs:
         run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version="$VERSION" -o ./packages
 
       - name: NuGet login
-        if: github.event.inputs.dry-run != 'true'
+        if: github.event.inputs['dry-run'] != 'true'
         uses: nuget/login@v1
         with:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Push to NuGet
-        if: github.event.inputs.dry-run != 'true'
+        if: github.event.inputs['dry-run'] != 'true'
         run: dotnet nuget push ./packages/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub Release
-        if: github.event.inputs.dry-run != 'true'
+        if: github.event.inputs['dry-run'] != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi
 
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?$'; then
             echo "::error::Invalid version '$VERSION'. Expected SemVer (e.g. 1.0.0, 1.0.0-rc.1)."
             exit 1
           fi
@@ -96,11 +96,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          gh release create "$TAG" \
-            --generate-notes \
-            --title "$TAG" \
-            --target "$GITHUB_SHA" \
-            ./packages/*
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — uploading assets."
+            gh release upload "$TAG" ./packages/* --clobber
+          else
+            gh release create "$TAG" \
+              --generate-notes \
+              --title "$TAG" \
+              --target "$GITHUB_SHA" \
+              ./packages/*
+          fi
 
       - name: Upload NuGet packages
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.0.0, 1.0.0-rc.1)'
+        required: true
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  CI: true
+
+jobs:
+  release:
+    name: Build, Test & Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${GITHUB_REF#refs/tags/v}"
+            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore --source https://api.nuget.org/v3/index.json
+
+      - name: Build
+        run: dotnet build --no-restore -c Release -p:Version=${{ steps.version.outputs.version }} -p:GeneratePackageOnBuild=false
+
+      - name: Test
+        run: dotnet test JsonSchemaValidationTests/JsonSchemaValidationTests.csproj --no-build -c Release --settings JsonSchemaValidationTests/default.runsettings --logger "trx;LogFileName=test-results.trx"
+
+      - name: Pack
+        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }}
+
+      - name: NuGet login
+        uses: nuget/login@v1
+        with:
+          nuget-api-key: ${{ secrets.NUGET_USER }}
+
+      - name: Push to NuGet
+        run: dotnet nuget push '**/*.nupkg' --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+
+          # For workflow_dispatch, create the tag if it doesn't exist
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            git tag "$TAG" || true
+            git push origin "$TAG" || true
+          fi
+
+          gh release create "$TAG" \
+            --generate-notes \
+            --title "$TAG" \
+            **/*.nupkg **/*.snupkg
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/test-results.trx'
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,17 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             RAW="${{ github.event.inputs.version }}"
-            echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
+            VERSION="${RAW#v}"
           else
-            TAG="${GITHUB_REF#refs/tags/v}"
-            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+            VERSION="${GITHUB_REF#refs/tags/v}"
           fi
+
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+            echo "::error::Invalid version '$VERSION'. Expected SemVer (e.g. 1.0.0, 1.0.0-rc.1)."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,13 +68,17 @@ jobs:
         run: dotnet restore --source https://api.nuget.org/v3/index.json
 
       - name: Build
-        run: dotnet build --no-restore -c Release -p:Version=${{ steps.version.outputs.version }} -p:GeneratePackageOnBuild=false
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet build --no-restore -c Release -p:Version="$VERSION" -p:GeneratePackageOnBuild=false
 
       - name: Test
         run: dotnet test JsonSchemaValidationTests/JsonSchemaValidationTests.csproj --no-build -c Release --settings JsonSchemaValidationTests/default.runsettings --logger "trx;LogFileName=test-results.trx"
 
       - name: Pack
-        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./packages
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version="$VERSION" -o ./packages
 
       - name: NuGet login
         if: github.event.inputs.dry-run != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       version:
         description: 'Version to publish (e.g. 1.0.0, 1.0.0-rc.1)'
         required: true
+      dry-run:
+        description: 'Dry run — build, test, and pack without publishing'
+        type: boolean
+        default: false
 
 concurrency:
   group: release
@@ -66,14 +70,17 @@ jobs:
         run: dotnet pack JsonSchemaValidation/JsonSchemaValidation.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }}
 
       - name: NuGet login
+        if: inputs.dry-run != true
         uses: nuget/login@v1
         with:
           nuget-api-key: ${{ secrets.NUGET_USER }}
 
       - name: Push to NuGet
+        if: inputs.dry-run != true
         run: dotnet nuget push '**/*.nupkg' --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub Release
+        if: inputs.dry-run != true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -89,6 +96,16 @@ jobs:
             --generate-notes \
             --title "$TAG" \
             **/*.nupkg **/*.snupkg
+
+      - name: Upload NuGet packages
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: |
+            **/*.nupkg
+            **/*.snupkg
+          retention-days: 7
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — tag-triggered release workflow for publishing to nuget.org
- Uses NuGet Trusted Publishing (OIDC) for keyless authentication — no stored API keys
- Supports both `v*` tag push and manual `workflow_dispatch` with version input
- Builds, tests, packs, pushes to NuGet, and creates a GitHub Release with attached packages
- Sets `NUGET_USER` repository secret to `FormFinch`

## Workflow steps

1. Determine version from tag (`v1.0.0` → `1.0.0`) or manual input
2. Checkout, setup .NET 8.0 + 10.0, restore, build with `-p:Version=`
3. Run full test suite as sanity check
4. Pack `.nupkg` + `.snupkg`
5. OIDC login via `nuget/login@v1`
6. Push to nuget.org with `--skip-duplicate` (safe re-runs)
7. Create GitHub Release with auto-generated notes and attached packages

## Prerequisites (manual)

Before first use, create a Trusted Publishing policy on nuget.org:
- https://www.nuget.org/account/trustedpublishing
- Package Owner: `FormFinch`, Repo: `formfinch/JsonSchemaValidation`, Workflow: `release.yml`, Environment: (blank)

## Test plan

- [ ] PR CI validates YAML syntax
- [ ] End-to-end test with pre-release tag (e.g., `v1.0.0-rc.1`) after Trusted Publishing is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)