### PR TITLE
Move public API types to root namespace

### DIFF
--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/DotNetCompetitorBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/DotNetCompetitorBenchmarks.cs
@@ -88,7 +88,7 @@ public class DotNetCompetitorBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/QuickCompetitorBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/QuickCompetitorBenchmarks.cs
@@ -85,7 +85,7 @@ public class QuickCompetitorBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Memory/MemoryAllocationBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Memory/MemoryAllocationBenchmarks.cs
@@ -85,7 +85,7 @@ public class MemoryAllocationBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Throughput/ThroughputBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Throughput/ThroughputBenchmarks.cs
@@ -72,7 +72,7 @@ public class ThroughputBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Validation/ComplexValidationBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Validation/ComplexValidationBenchmarks.cs
@@ -75,7 +75,7 @@ public class ComplexValidationBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Validation/LargeDocumentBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Validation/LargeDocumentBenchmarks.cs
@@ -84,7 +84,7 @@ public class LargeDocumentBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Validation/SimpleValidationBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Validation/SimpleValidationBenchmarks.cs
@@ -72,7 +72,7 @@ public class SimpleValidationBenchmarks
         _jsonSchemaNet = JsonSchema.FromText(schemaJson);
         _jsonSchemaNetOptions = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false
         };
 

--- a/JsonSchemaValidation.Benchmarks/Validators/JsonSchemaNetValidator.cs
+++ b/JsonSchemaValidation.Benchmarks/Validators/JsonSchemaNetValidator.cs
@@ -20,7 +20,7 @@ public sealed class JsonSchemaNetValidator
         _schema = JsonSchema.FromText(schemaJson);
         _options = new EvaluationOptions
         {
-            OutputFormat = OutputFormat.Flag,
+            OutputFormat = Json.Schema.OutputFormat.Flag,
             RequireFormatValidation = false // Default to annotation-only per JSON Schema spec
         };
     }

--- a/JsonSchemaValidation.ManualTests/InteractiveMode.cs
+++ b/JsonSchemaValidation.ManualTests/InteractiveMode.cs
@@ -1,5 +1,3 @@
-using FormFinch.JsonSchemaValidation.Validation.Output;
-
 namespace FormFinch.JsonSchemaValidation.ManualTests;
 
 internal static class InteractiveMode

--- a/JsonSchemaValidation.ManualTests/Scenarios/ErrorQualityScenarios.cs
+++ b/JsonSchemaValidation.ManualTests/Scenarios/ErrorQualityScenarios.cs
@@ -1,5 +1,3 @@
-using FormFinch.JsonSchemaValidation.Validation.Output;
-
 namespace FormFinch.JsonSchemaValidation.ManualTests.Scenarios;
 
 internal static class ErrorQualityScenarios

--- a/JsonSchemaValidation.ManualTests/Scenarios/FormatValidationScenarios.cs
+++ b/JsonSchemaValidation.ManualTests/Scenarios/FormatValidationScenarios.cs
@@ -1,6 +1,3 @@
-using FormFinch.JsonSchemaValidation.DependencyInjection;
-using FormFinch.JsonSchemaValidation.Validation.Output;
-
 namespace FormFinch.JsonSchemaValidation.ManualTests.Scenarios;
 
 internal static class FormatValidationScenarios

--- a/JsonSchemaValidation.ManualTests/Scenarios/OutputFormatScenarios.cs
+++ b/JsonSchemaValidation.ManualTests/Scenarios/OutputFormatScenarios.cs
@@ -1,5 +1,3 @@
-using FormFinch.JsonSchemaValidation.Validation.Output;
-
 namespace FormFinch.JsonSchemaValidation.ManualTests.Scenarios;
 
 internal static class OutputFormatScenarios

--- a/JsonSchemaValidation.ManualTests/Scenarios/StaticApiScenarios.cs
+++ b/JsonSchemaValidation.ManualTests/Scenarios/StaticApiScenarios.cs
@@ -1,6 +1,3 @@
-using FormFinch.JsonSchemaValidation.DependencyInjection;
-using FormFinch.JsonSchemaValidation.Validation.Output;
-
 namespace FormFinch.JsonSchemaValidation.ManualTests.Scenarios;
 
 internal static class StaticApiScenarios

--- a/JsonSchemaValidation.ManualTests/TestRunner.cs
+++ b/JsonSchemaValidation.ManualTests/TestRunner.cs
@@ -1,5 +1,3 @@
-using FormFinch.JsonSchemaValidation.Validation.Output;
-
 namespace FormFinch.JsonSchemaValidation.ManualTests;
 
 /// <summary>

--- a/JsonSchemaValidation/Common/SchemaValidatorExtensions.cs
+++ b/JsonSchemaValidation/Common/SchemaValidatorExtensions.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation.Abstractions;
 using FormFinch.JsonSchemaValidation.Validation;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 
 namespace FormFinch.JsonSchemaValidation.Common
 {

--- a/JsonSchemaValidation/CompiledJsonSchema.cs
+++ b/JsonSchemaValidation/CompiledJsonSchema.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions;
 using FormFinch.JsonSchemaValidation.Common;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 
 namespace FormFinch.JsonSchemaValidation
 {

--- a/JsonSchemaValidation/DependencyInjection/SchemaValidationOptions.cs
+++ b/JsonSchemaValidation/DependencyInjection/SchemaValidationOptions.cs
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 FormFinch VOF
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
-namespace FormFinch.JsonSchemaValidation.DependencyInjection
+using FormFinch.JsonSchemaValidation.DependencyInjection;
+
+// Intentionally in root namespace for public API usability (file stays in DependencyInjection/ for organization).
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace FormFinch.JsonSchemaValidation
+#pragma warning restore IDE0130
 {
     /// <summary>
     /// Options that control JSON Schema validation behavior and supported drafts.

--- a/JsonSchemaValidation/Draft201909/Keywords/FormatValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft201909/Keywords/FormatValidatorFactory.cs
@@ -7,7 +7,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft201909.Keywords.Format;
 using FormFinch.JsonSchemaValidation.Exceptions;
 using FormFinch.JsonSchemaValidation.Repositories;

--- a/JsonSchemaValidation/Draft202012/Keywords/FormatValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft202012/Keywords/FormatValidatorFactory.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft202012.Keywords.Format;
 using FormFinch.JsonSchemaValidation.Exceptions;
 using FormFinch.JsonSchemaValidation.Repositories;

--- a/JsonSchemaValidation/Draft3/Keywords/FormatValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft3/Keywords/FormatValidatorFactory.cs
@@ -9,7 +9,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft3.Keywords.Format;
 using FormFinch.JsonSchemaValidation.Exceptions;
 using FormFinch.JsonSchemaValidation.Repositories;

--- a/JsonSchemaValidation/Draft4/Keywords/FormatValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft4/Keywords/FormatValidatorFactory.cs
@@ -8,7 +8,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft4.Keywords.Format;
 using FormFinch.JsonSchemaValidation.Exceptions;
 using FormFinch.JsonSchemaValidation.Repositories;

--- a/JsonSchemaValidation/Draft6/Keywords/FormatValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft6/Keywords/FormatValidatorFactory.cs
@@ -7,7 +7,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft6.Keywords.Format;
 using FormFinch.JsonSchemaValidation.Exceptions;
 using FormFinch.JsonSchemaValidation.Repositories;

--- a/JsonSchemaValidation/Draft7/Keywords/ContentEncodingValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft7/Keywords/ContentEncodingValidatorFactory.cs
@@ -8,7 +8,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Repositories;
 
 namespace FormFinch.JsonSchemaValidation.Draft7.Keywords

--- a/JsonSchemaValidation/Draft7/Keywords/ContentMediaTypeValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft7/Keywords/ContentMediaTypeValidatorFactory.cs
@@ -8,7 +8,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Repositories;
 
 namespace FormFinch.JsonSchemaValidation.Draft7.Keywords

--- a/JsonSchemaValidation/Draft7/Keywords/FormatValidatorFactory.cs
+++ b/JsonSchemaValidation/Draft7/Keywords/FormatValidatorFactory.cs
@@ -7,7 +7,6 @@
 
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions.Keywords;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft7.Keywords.Format;
 using FormFinch.JsonSchemaValidation.Exceptions;
 using FormFinch.JsonSchemaValidation.Repositories;

--- a/JsonSchemaValidation/IJsonSchema.cs
+++ b/JsonSchemaValidation/IJsonSchema.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using System.Text.Json;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 
 namespace FormFinch.JsonSchemaValidation
 {

--- a/JsonSchemaValidation/JsonSchemaValidator.cs
+++ b/JsonSchemaValidation/JsonSchemaValidator.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions;
 using FormFinch.JsonSchemaValidation.Common;
 using FormFinch.JsonSchemaValidation.DependencyInjection;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidation

--- a/JsonSchemaValidation/PublicAPI.Unshipped.txt
+++ b/JsonSchemaValidation/PublicAPI.Unshipped.txt
@@ -87,34 +87,34 @@ FormFinch.JsonSchemaValidation.DependencyInjection.Draft7Options.ContentAssertio
 FormFinch.JsonSchemaValidation.DependencyInjection.Draft7Options.Draft7Options() -> void
 FormFinch.JsonSchemaValidation.DependencyInjection.Draft7Options.FormatAssertionEnabled.get -> bool
 FormFinch.JsonSchemaValidation.DependencyInjection.Draft7Options.FormatAssertionEnabled.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.DefaultDraftVersion.get -> string!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.DefaultDraftVersion.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft201909.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft201909Options!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft201909.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft202012.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft202012Options!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft202012.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft3.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft3Options!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft3.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft4.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft4Options!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft4.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft6.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft6Options!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft6.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft7.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft7Options!
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.Draft7.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft201909.get -> bool
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft201909.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft202012.get -> bool
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft202012.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft3.get -> bool
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft3.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft4.get -> bool
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft4.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft6.get -> bool
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft6.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft7.get -> bool
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.EnableDraft7.set -> void
-FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions.SchemaValidationOptions() -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.DefaultDraftVersion.get -> string!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.DefaultDraftVersion.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft201909.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft201909Options!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft201909.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft202012.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft202012Options!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft202012.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft3.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft3Options!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft3.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft4.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft4Options!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft4.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft6.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft6Options!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft6.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft7.get -> FormFinch.JsonSchemaValidation.DependencyInjection.Draft7Options!
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.Draft7.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft201909.get -> bool
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft201909.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft202012.get -> bool
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft202012.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft3.get -> bool
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft3.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft4.get -> bool
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft4.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft6.get -> bool
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft6.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft7.get -> bool
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.EnableDraft7.set -> void
+FormFinch.JsonSchemaValidation.SchemaValidationOptions.SchemaValidationOptions() -> void
 FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup
 FormFinch.JsonSchemaValidation.DependencyInjection.ServiceProviderExtensions
 FormFinch.JsonSchemaValidation.Draft202012.Keywords.Format.FormatValidators
@@ -126,31 +126,31 @@ FormFinch.JsonSchemaValidation.IJsonSchema
 FormFinch.JsonSchemaValidation.IJsonSchema.IsValid(string! instanceJson) -> bool
 FormFinch.JsonSchemaValidation.IJsonSchema.IsValid(System.Text.Json.JsonElement instance) -> bool
 FormFinch.JsonSchemaValidation.IJsonSchema.SchemaUri.get -> System.Uri!
-FormFinch.JsonSchemaValidation.IJsonSchema.Validate(string! instanceJson, FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat format = FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!
-FormFinch.JsonSchemaValidation.IJsonSchema.Validate(System.Text.Json.JsonElement instance, FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat format = FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!
+FormFinch.JsonSchemaValidation.IJsonSchema.Validate(string! instanceJson, FormFinch.JsonSchemaValidation.OutputFormat format = FormFinch.JsonSchemaValidation.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.OutputUnit!
+FormFinch.JsonSchemaValidation.IJsonSchema.Validate(System.Text.Json.JsonElement instance, FormFinch.JsonSchemaValidation.OutputFormat format = FormFinch.JsonSchemaValidation.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.OutputUnit!
 FormFinch.JsonSchemaValidation.JsonSchemaValidator
-FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat
-FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic = 1 -> FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat
-FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Detailed = 2 -> FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat
-FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Flag = 0 -> FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.AbsoluteKeywordLocation.get -> string?
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.AbsoluteKeywordLocation.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Annotation.get -> object?
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Annotation.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Annotations.get -> System.Collections.Generic.IList<FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!>?
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Annotations.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Error.get -> string?
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Error.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Errors.get -> System.Collections.Generic.IList<FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!>?
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Errors.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.InstanceLocation.get -> string!
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.InstanceLocation.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.KeywordLocation.get -> string!
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.KeywordLocation.set -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.OutputUnit() -> void
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Valid.get -> bool
-FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit.Valid.set -> void
+FormFinch.JsonSchemaValidation.OutputFormat
+FormFinch.JsonSchemaValidation.OutputFormat.Basic = 1 -> FormFinch.JsonSchemaValidation.OutputFormat
+FormFinch.JsonSchemaValidation.OutputFormat.Detailed = 2 -> FormFinch.JsonSchemaValidation.OutputFormat
+FormFinch.JsonSchemaValidation.OutputFormat.Flag = 0 -> FormFinch.JsonSchemaValidation.OutputFormat
+FormFinch.JsonSchemaValidation.OutputUnit
+FormFinch.JsonSchemaValidation.OutputUnit.AbsoluteKeywordLocation.get -> string?
+FormFinch.JsonSchemaValidation.OutputUnit.AbsoluteKeywordLocation.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.Annotation.get -> object?
+FormFinch.JsonSchemaValidation.OutputUnit.Annotation.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.Annotations.get -> System.Collections.Generic.IList<FormFinch.JsonSchemaValidation.OutputUnit!>?
+FormFinch.JsonSchemaValidation.OutputUnit.Annotations.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.Error.get -> string?
+FormFinch.JsonSchemaValidation.OutputUnit.Error.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.Errors.get -> System.Collections.Generic.IList<FormFinch.JsonSchemaValidation.OutputUnit!>?
+FormFinch.JsonSchemaValidation.OutputUnit.Errors.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.InstanceLocation.get -> string!
+FormFinch.JsonSchemaValidation.OutputUnit.InstanceLocation.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.KeywordLocation.get -> string!
+FormFinch.JsonSchemaValidation.OutputUnit.KeywordLocation.set -> void
+FormFinch.JsonSchemaValidation.OutputUnit.OutputUnit() -> void
+FormFinch.JsonSchemaValidation.OutputUnit.Valid.get -> bool
+FormFinch.JsonSchemaValidation.OutputUnit.Valid.set -> void
 override FormFinch.JsonSchemaValidation.Common.JsonPointer.Equals(object? obj) -> bool
 override FormFinch.JsonSchemaValidation.Common.JsonPointer.GetHashCode() -> int
 override FormFinch.JsonSchemaValidation.Common.JsonPointer.ToString() -> string!
@@ -160,8 +160,8 @@ static FormFinch.JsonSchemaValidation.Common.SchemaHasher.ComputeHash(System.Tex
 static FormFinch.JsonSchemaValidation.Common.SchemaHasher.Instance.get -> FormFinch.JsonSchemaValidation.Common.SchemaHasher!
 static FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup.AddCompiledValidators(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, params FormFinch.JsonSchemaValidation.Abstractions.ICompiledValidator![]! validators) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup.AddCompiledValidators(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Collections.Generic.IEnumerable<FormFinch.JsonSchemaValidation.Abstractions.ICompiledValidator!>! validators) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup.AddJsonSchemaValidation(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions! options) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup.AddJsonSchemaValidation(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions!>? setupAction = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup.AddJsonSchemaValidation(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, FormFinch.JsonSchemaValidation.SchemaValidationOptions! options) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationSetup.AddJsonSchemaValidation(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<FormFinch.JsonSchemaValidation.SchemaValidationOptions!>? setupAction = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static FormFinch.JsonSchemaValidation.DependencyInjection.ServiceProviderExtensions.InitializeSingletonServices(this System.IServiceProvider! serviceProvider) -> void
 static FormFinch.JsonSchemaValidation.Draft202012.Keywords.Format.FormatValidators.IsValidDate(System.Text.Json.JsonElement data) -> bool
 static FormFinch.JsonSchemaValidation.Draft202012.Keywords.Format.FormatValidators.IsValidDateTime(System.Text.Json.JsonElement data) -> bool
@@ -184,13 +184,13 @@ static FormFinch.JsonSchemaValidation.Draft202012.Keywords.Format.FormatValidato
 static FormFinch.JsonSchemaValidation.JsonSchemaValidator.IsValid(string! schemaJson, string! instanceJson) -> bool
 static FormFinch.JsonSchemaValidation.JsonSchemaValidator.IsValid(System.Text.Json.JsonElement schema, System.Text.Json.JsonElement instance) -> bool
 static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Parse(string! schemaJson) -> FormFinch.JsonSchemaValidation.IJsonSchema!
-static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Parse(string! schemaJson, FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions! options) -> FormFinch.JsonSchemaValidation.IJsonSchema!
+static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Parse(string! schemaJson, FormFinch.JsonSchemaValidation.SchemaValidationOptions! options) -> FormFinch.JsonSchemaValidation.IJsonSchema!
 static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Parse(System.Text.Json.JsonElement schema) -> FormFinch.JsonSchemaValidation.IJsonSchema!
-static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Parse(System.Text.Json.JsonElement schema, FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions! options) -> FormFinch.JsonSchemaValidation.IJsonSchema!
-static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(string! schemaJson, string! instanceJson, FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions! options, FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat format = FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!
-static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(string! schemaJson, string! instanceJson, FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat format = FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!
-static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(System.Text.Json.JsonElement schema, System.Text.Json.JsonElement instance, FormFinch.JsonSchemaValidation.DependencyInjection.SchemaValidationOptions! options, FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat format = FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!
-static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(System.Text.Json.JsonElement schema, System.Text.Json.JsonElement instance, FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat format = FormFinch.JsonSchemaValidation.Validation.Output.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.Validation.Output.OutputUnit!
+static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Parse(System.Text.Json.JsonElement schema, FormFinch.JsonSchemaValidation.SchemaValidationOptions! options) -> FormFinch.JsonSchemaValidation.IJsonSchema!
+static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(string! schemaJson, string! instanceJson, FormFinch.JsonSchemaValidation.SchemaValidationOptions! options, FormFinch.JsonSchemaValidation.OutputFormat format = FormFinch.JsonSchemaValidation.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.OutputUnit!
+static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(string! schemaJson, string! instanceJson, FormFinch.JsonSchemaValidation.OutputFormat format = FormFinch.JsonSchemaValidation.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.OutputUnit!
+static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(System.Text.Json.JsonElement schema, System.Text.Json.JsonElement instance, FormFinch.JsonSchemaValidation.SchemaValidationOptions! options, FormFinch.JsonSchemaValidation.OutputFormat format = FormFinch.JsonSchemaValidation.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.OutputUnit!
+static FormFinch.JsonSchemaValidation.JsonSchemaValidator.Validate(System.Text.Json.JsonElement schema, System.Text.Json.JsonElement instance, FormFinch.JsonSchemaValidation.OutputFormat format = FormFinch.JsonSchemaValidation.OutputFormat.Basic) -> FormFinch.JsonSchemaValidation.OutputUnit!
 FormFinch.JsonSchemaValidation.Draft201909.Keywords.Format.FormatValidators
 static FormFinch.JsonSchemaValidation.Draft201909.Keywords.Format.FormatValidators.IsValidDate(System.Text.Json.JsonElement data) -> bool
 static FormFinch.JsonSchemaValidation.Draft201909.Keywords.Format.FormatValidators.IsValidDateTime(System.Text.Json.JsonElement data) -> bool

--- a/JsonSchemaValidation/Repositories/SchemaRepository.cs
+++ b/JsonSchemaValidation/Repositories/SchemaRepository.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions;
 using FormFinch.JsonSchemaValidation.Common;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Draft202012.Keywords.Logic;
 using FormFinch.JsonSchemaValidation.Exceptions;
 

--- a/JsonSchemaValidation/Validation/Output/OutputFormat.cs
+++ b/JsonSchemaValidation/Validation/Output/OutputFormat.cs
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 FormFinch VOF
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
-namespace FormFinch.JsonSchemaValidation.Validation.Output
+
+// Intentionally in root namespace for public API usability (file stays in Validation/Output/ for organization).
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace FormFinch.JsonSchemaValidation
+#pragma warning restore IDE0130
 {
     /// <summary>
     /// Output formats per JSON Schema 2020-12 Section 12.

--- a/JsonSchemaValidation/Validation/Output/OutputUnit.cs
+++ b/JsonSchemaValidation/Validation/Output/OutputUnit.cs
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 FormFinch VOF
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
-namespace FormFinch.JsonSchemaValidation.Validation.Output
+
+// Intentionally in root namespace for public API usability (file stays in Validation/Output/ for organization).
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace FormFinch.JsonSchemaValidation
+#pragma warning restore IDE0130
 {
     /// <summary>
     /// Represents a single output unit per JSON Schema 2020-12 Section 12.

--- a/JsonSchemaValidation/Validation/ValidationResult.cs
+++ b/JsonSchemaValidation/Validation/ValidationResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation.Common;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 
 namespace FormFinch.JsonSchemaValidation.Validation
 {

--- a/JsonSchemaValidationTests/Common/BooleanSchemaTests.cs
+++ b/JsonSchemaValidationTests/Common/BooleanSchemaTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidation.Tests.Common;
 

--- a/JsonSchemaValidationTests/Common/ContainsValidatorTests.cs
+++ b/JsonSchemaValidationTests/Common/ContainsValidatorTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidation.Tests.Common;
 

--- a/JsonSchemaValidationTests/Common/IfThenElseValidatorTests.cs
+++ b/JsonSchemaValidationTests/Common/IfThenElseValidatorTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidation.Tests.Common;
 

--- a/JsonSchemaValidationTests/Common/RefValidatorTests.cs
+++ b/JsonSchemaValidationTests/Common/RefValidatorTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidation.Tests.Common;
 

--- a/JsonSchemaValidationTests/Common/UnevaluatedValidatorTests.cs
+++ b/JsonSchemaValidationTests/Common/UnevaluatedValidatorTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
-using FormFinch.JsonSchemaValidation.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidation.Tests.Common;
 

--- a/JsonSchemaValidationTests/Draft202012/OutputFormat/Examples.cs
+++ b/JsonSchemaValidationTests/Draft202012/OutputFormat/Examples.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using FormFinch.JsonSchemaValidation.Abstractions;
 using FormFinch.JsonSchemaValidation.Common;
 using FormFinch.JsonSchemaValidation.DependencyInjection;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidationTests.Draft202012.OutputFormat;

--- a/JsonSchemaValidationTests/Draft202012/OutputFormat/RegressionTests.cs
+++ b/JsonSchemaValidationTests/Draft202012/OutputFormat/RegressionTests.cs
@@ -2,11 +2,11 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using System.Text.Json;
+using FormFinch.JsonSchemaValidation;
 using FormFinch.JsonSchemaValidation.Abstractions;
 using FormFinch.JsonSchemaValidation.Common;
 using FormFinch.JsonSchemaValidation.DependencyInjection;
 using FormFinch.JsonSchemaValidation.Validation;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FormFinch.JsonSchemaValidationTests.Draft202012.OutputFormat;
@@ -813,7 +813,7 @@ public class RegressionTests
         var instance = JsonDocument.Parse("123").RootElement;
 
         var result = ValidateRoot(schema, instance);
-        var output = result.ToOutputUnit(JsonSchemaValidation.Validation.Output.OutputFormat.Flag);
+        var output = result.ToOutputUnit(JsonSchemaValidation.OutputFormat.Flag);
 
         Assert.False(output.Valid);
         Assert.Null(output.Errors);
@@ -826,7 +826,7 @@ public class RegressionTests
         var instance = JsonDocument.Parse("123").RootElement;
 
         var result = ValidateRoot(schema, instance);
-        var output = result.ToOutputUnit(JsonSchemaValidation.Validation.Output.OutputFormat.Basic);
+        var output = result.ToOutputUnit(JsonSchemaValidation.OutputFormat.Basic);
 
         Assert.False(output.Valid);
         Assert.NotNull(output.Errors);
@@ -839,7 +839,7 @@ public class RegressionTests
         var instance = JsonDocument.Parse("123").RootElement;
 
         var result = ValidateRoot(schema, instance);
-        var output = result.ToOutputUnit(JsonSchemaValidation.Validation.Output.OutputFormat.Detailed);
+        var output = result.ToOutputUnit(JsonSchemaValidation.OutputFormat.Detailed);
 
         Assert.False(output.Valid);
     }

--- a/JsonSchemaValidationTests/NegativeTests/ErrorMessageTests.cs
+++ b/JsonSchemaValidationTests/NegativeTests/ErrorMessageTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0.
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 
 namespace FormFinch.JsonSchemaValidationTests.NegativeTests;
 

--- a/JsonSchemaValidationTests/StaticApiTests.cs
+++ b/JsonSchemaValidationTests/StaticApiTests.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information.
 using FormFinch.JsonSchemaValidation;
 using FormFinch.JsonSchemaValidation.DependencyInjection;
-using FormFinch.JsonSchemaValidation.Validation.Output;
 
 namespace FormFinch.JsonSchemaValidationTests;
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # FormFinch.JsonSchemaValidation
 
-A high-performance JSON Schema validation library for .NET with full draft support, built on `System.Text.Json` with zero external dependencies.
+A high-performance JSON Schema validation library for .NET with full draft support, built on `System.Text.Json`.
 
 ## Features
 
-- **Full draft support**: Draft 3, Draft 4, Draft 6, Draft 7, Draft 2019-09, Draft 2020-12
+- **Draft 2020-12**: Full support for the latest JSON Schema specification, plus backward compatibility with Draft 2019-09, Draft 7, Draft 6, Draft 4, and Draft 3
 - **100% spec compliance**: Passes all JSON-Schema-Test-Suite tests
 - **High performance**: Optimized for speed with minimal allocations
-- **Pure System.Text.Json**: No Newtonsoft.Json or other JSON library dependencies
+- **Pure System.Text.Json**: No external JSON library dependencies
 - **Output formats**: Flag, Basic, and Detailed output per JSON Schema spec
 
 ## Installation
@@ -18,36 +18,52 @@ dotnet add package FormFinch.JsonSchemaValidation
 
 ## Quick Start
 
-```csharp
-using FormFinch.JsonSchemaValidation.DependencyInjection;
-using FormFinch.JsonSchemaValidation.Repositories;
-using System.Text.Json;
+**Schema:**
 
-// Set up dependency injection
-var services = new ServiceCollection();
-services.AddSchemaValidation();
-var provider = services.BuildServiceProvider();
-
-// Get the schema repository and register a schema
-var repository = provider.GetRequiredService<ISchemaRepository>();
-var schema = JsonDocument.Parse("""
+```json
 {
     "type": "object",
     "properties": {
-        "name": { "type": "string" },
-        "age": { "type": "integer", "minimum": 0 }
+        "name": { "type": "string", "minLength": 1 },
+        "age": { "type": "integer", "minimum": 0 },
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": { "type": "string" },
+                "city": { "type": "string" }
+            },
+            "required": ["street", "city"]
+        }
     },
-    "required": ["name"]
+    "required": ["name", "age"]
 }
-""");
-repository.RegisterSchema("https://example.com/person.json", schema.RootElement);
+```
 
-// Validate a document
-var validator = repository.GetValidator("https://example.com/person.json");
-var document = JsonDocument.Parse("""{ "name": "Alice", "age": 30 }""");
+**Valid instance:**
 
-var result = validator.Validate(document.RootElement);
-Console.WriteLine($"Valid: {result.IsValid}");
+```json
+{ "name": "Alice", "age": 30, "address": { "street": "123 Main St", "city": "Springfield" } }
+```
+
+**Invalid instance:**
+
+```json
+{ "name": "", "age": -1, "address": { "city": 123 } }
+```
+
+**Validation:**
+
+```csharp
+using FormFinch.JsonSchemaValidation;
+
+// Simple boolean check
+var isValid = JsonSchemaValidator.IsValid(schema, valid);
+
+// Flat error list
+var basic = JsonSchemaValidator.Validate(schema, invalid);
+
+// Hierarchical errors
+var detailed = JsonSchemaValidator.Validate(schema, invalid, OutputFormat.Detailed);
 ```
 
 ## License
@@ -57,7 +73,7 @@ This library is dual-licensed:
 - **Non-commercial use**: Free under the [PolyForm Noncommercial License 1.0.0](LICENSE)
 - **Commercial use**: Requires a [commercial license](COMMERCIAL.md)
 
-See [COMMERCIAL.md](COMMERCIAL.md) for pricing and terms.
+See [COMMERCIAL.md](COMMERCIAL.md) for details.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -18,28 +18,52 @@ dotnet add package FormFinch.JsonSchemaValidation
 
 ## Quick Start
 
-```csharp
-using FormFinch.JsonSchemaValidation;
+**Schema:**
 
-var schema = """
+```json
 {
     "type": "object",
     "properties": {
         "name": { "type": "string", "minLength": 1 },
-        "age": { "type": "integer", "minimum": 0 }
+        "age": { "type": "integer", "minimum": 0 },
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": { "type": "string" },
+                "city": { "type": "string" }
+            },
+            "required": ["street", "city"]
+        }
     },
     "required": ["name", "age"]
 }
-""";
+```
+
+**Valid instance:**
+
+```json
+{ "name": "Alice", "age": 30, "address": { "street": "123 Main St", "city": "Springfield" } }
+```
+
+**Invalid instance:**
+
+```json
+{ "name": "", "age": -1, "address": { "city": 123 } }
+```
+
+**Validation:**
+
+```csharp
+using FormFinch.JsonSchemaValidation;
 
 // Simple boolean check
-var isValid = JsonSchemaValidator.IsValid(schema, """{ "name": "Alice", "age": 30 }""");
+var isValid = JsonSchemaValidator.IsValid(schema, valid);
 
-// Validate with error details
-var result = JsonSchemaValidator.Validate(schema, """{ "name": "", "age": -1 }""");
+// Flat error list
+var basic = JsonSchemaValidator.Validate(schema, invalid);
 
 // Hierarchical errors
-var detailed = JsonSchemaValidator.Validate(schema, """{ "name": "", "age": -1 }""", OutputFormat.Detailed);
+var detailed = JsonSchemaValidator.Validate(schema, invalid, OutputFormat.Detailed);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -18,52 +18,28 @@ dotnet add package FormFinch.JsonSchemaValidation
 
 ## Quick Start
 
-**Schema:**
+```csharp
+using FormFinch.JsonSchemaValidation;
 
-```json
+var schema = """
 {
     "type": "object",
     "properties": {
         "name": { "type": "string", "minLength": 1 },
-        "age": { "type": "integer", "minimum": 0 },
-        "address": {
-            "type": "object",
-            "properties": {
-                "street": { "type": "string" },
-                "city": { "type": "string" }
-            },
-            "required": ["street", "city"]
-        }
+        "age": { "type": "integer", "minimum": 0 }
     },
     "required": ["name", "age"]
 }
-```
-
-**Valid instance:**
-
-```json
-{ "name": "Alice", "age": 30, "address": { "street": "123 Main St", "city": "Springfield" } }
-```
-
-**Invalid instance:**
-
-```json
-{ "name": "", "age": -1, "address": { "city": 123 } }
-```
-
-**Validation:**
-
-```csharp
-using FormFinch.JsonSchemaValidation;
+""";
 
 // Simple boolean check
-var isValid = JsonSchemaValidator.IsValid(schema, valid);
+var isValid = JsonSchemaValidator.IsValid(schema, """{ "name": "Alice", "age": 30 }""");
 
-// Flat error list
-var basic = JsonSchemaValidator.Validate(schema, invalid);
+// Validate with error details
+var result = JsonSchemaValidator.Validate(schema, """{ "name": "", "age": -1 }""");
 
 // Hierarchical errors
-var detailed = JsonSchemaValidator.Validate(schema, invalid, OutputFormat.Detailed);
+var detailed = JsonSchemaValidator.Validate(schema, """{ "name": "", "age": -1 }""", OutputFormat.Detailed);
 ```
 
 ## License

--- a/docs/API_USABILITY_EVALUATION.md
+++ b/docs/API_USABILITY_EVALUATION.md
@@ -371,7 +371,7 @@ PrintErrors(result);
 | `unevaluatedProperties` / `unevaluatedItems` | ✅ Full |
 | Format validation (19 formats) | ✅ Optional |
 | Output formats (Flag/Basic/Detailed) | ✅ Spec-compliant |
-| System.Text.Json (no external deps) | ✅ |
+| Built on System.Text.Json | ✅ |
 | Thread-safe | ✅ |
 | Schema caching | ✅ Content-hash based |
 

--- a/docs/PUBLIC_API_AUDIT.md
+++ b/docs/PUBLIC_API_AUDIT.md
@@ -36,10 +36,10 @@ These are the types users directly interact with:
 |------|-----------|---------|
 | `JsonSchemaValidator` | Root | Static entry point for validation |
 | `IJsonSchema` | Root | Parsed schema interface |
-| `OutputUnit` | Validation.Output | Spec-compliant validation output |
-| `OutputFormat` | Validation.Output | Output format enum (Flag/Basic/Detailed) |
+| `OutputUnit` | Root | Spec-compliant validation output |
+| `OutputFormat` | Root | Output format enum (Flag/Basic/Detailed) |
 | `SchemaValidationSetup` | DependencyInjection | DI extension methods |
-| `SchemaValidationOptions` | DependencyInjection | Main configuration class |
+| `SchemaValidationOptions` | Root | Main configuration class |
 | `Draft202012Options` | DependencyInjection | Draft 2020-12 options |
 | `Draft201909Options` | DependencyInjection | Draft 2019-09 options |
 | `Draft7Options` | DependencyInjection | Draft 7 options |
@@ -182,7 +182,7 @@ public class MyService
 |------|------------|----------|
 | `ValidationResult` | public | **Make internal** - Internal type, users get `OutputUnit` |
 
-### FormFinch.JsonSchemaValidation.Validation.Output
+### FormFinch.JsonSchemaValidation (Root) — Output Types
 
 | Type | Visibility | Decision |
 |------|------------|----------|
@@ -194,9 +194,10 @@ public class MyService
 | Type | Visibility | Decision |
 |------|------------|----------|
 | `SchemaValidationSetup` | public | **Keep** - DI entry point |
-| `SchemaValidationOptions` | public | **Keep** - Configuration |
 | `Draft*Options` (6 classes) | public | **Keep** - Configuration |
 | `ServiceProviderExtensions` | public | **Keep** - Required for initialization |
+
+*Note: `SchemaValidationOptions` has moved to the root namespace (`FormFinch.JsonSchemaValidation`).*
 
 ### FormFinch.JsonSchemaValidation.Abstractions
 
@@ -287,7 +288,7 @@ public interface IJsonSchema
 }
 ```
 
-### Validation.Output Namespace
+### Root Namespace (Output Types)
 ```csharp
 public enum OutputFormat { Flag, Basic, Detailed }
 
@@ -302,6 +303,8 @@ public class OutputUnit
     IList<OutputUnit>? Errors { get; set; }
     IList<OutputUnit>? Annotations { get; set; }
 }
+
+public class SchemaValidationOptions { /* configuration properties */ }
 ```
 
 ### DependencyInjection Namespace
@@ -318,7 +321,6 @@ public static class ServiceProviderExtensions
     static void InitializeSingletonServices(this IServiceProvider serviceProvider);
 }
 
-public class SchemaValidationOptions { /* configuration properties */ }
 public class Draft202012Options { bool FormatAssertionEnabled { get; set; } }
 public class Draft201909Options { bool FormatAssertionEnabled { get; set; } }
 public class Draft7Options { bool FormatAssertionEnabled { get; set; } bool ContentAssertionEnabled { get; set; } }

--- a/docs/PUBLIC_API_AUDIT.md
+++ b/docs/PUBLIC_API_AUDIT.md
@@ -288,7 +288,7 @@ public interface IJsonSchema
 }
 ```
 
-### Root Namespace (Output Types)
+### Root Namespace (Core Public Types)
 ```csharp
 public enum OutputFormat { Flag, Basic, Detailed }
 


### PR DESCRIPTION
## Summary

- Move `OutputFormat`, `OutputUnit`, and `SchemaValidationOptions` to the root `FormFinch.JsonSchemaValidation` namespace so users only need a single `using` statement for core validation
- Files remain in their original directories with `#pragma warning disable IDE0130` to prevent accidental namespace-to-folder refactoring
- Remove now-redundant `using` statements across 40+ files
- Update `PublicAPI.Unshipped.txt` to reflect new namespace paths
- Fully qualify `Json.Schema.OutputFormat` in benchmark files to resolve name collision with competitor library
- Update README and docs

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors (all projects)
- [x] `dotnet test` — 4158 tests pass on both net8.0 and net10.0
- [x] Verified README sample runs correctly with only `using FormFinch.JsonSchemaValidation;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)