### PR TITLE
chore: Remove private Azure DevOps references (TASK-70, TASK-71)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,20 +103,6 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Override NuGet config
-        run: |
-          # The repo nuget.config references a private Azure DevOps feed that
-          # isn't accessible from CI. Override it with nuget.org only.
-          cat > nuget.config << 'XMLEOF'
-          <?xml version="1.0" encoding="utf-8"?>
-          <configuration>
-            <packageSources>
-              <clear />
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-            </packageSources>
-          </configuration>
-          XMLEOF
-
       - name: Restore
         run: dotnet restore
 

--- a/backlog/tasks/task-32 - Create-GitHub-repository.md
+++ b/backlog/tasks/task-32 - Create-GitHub-repository.md
@@ -4,7 +4,7 @@ title: Create GitHub repository
 status: Done
 assignee: []
 created_date: '2026-01-30 21:57'
-updated_date: '2026-02-04 23:16'
+updated_date: '2026-02-13 15:45'
 labels:
   - infrastructure
   - github
@@ -18,7 +18,6 @@ priority: high
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Migrate repository from Azure DevOps to GitHub as a private repository.
 
-**Source:** `https://formfinch.visualstudio.com/formfinch-next/_git/JsonSchemaValidation`
 **Target:** `https://github.com/formfinch/JsonSchemaValidation` (private)
 
 **Current state:**

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
 	<packageSources>
 		<clear />
-		<add key="formfinch-next-artifacts" value="https://formfinch.pkgs.visualstudio.com/formfinch-next/_packaging/formfinch-next-artifacts/nuget/v3/index.json" />
+		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
 	</packageSources>
 </configuration>


### PR DESCRIPTION
## Summary

- Replace private Azure DevOps NuGet feed in `nuget.config` with public nuget.org feed
- Remove the now-redundant "Override NuGet config" step in `nightly.yml` CI workflow
- Scrub Azure DevOps source URL from backlog task-32

Part of pre-publication audit (TASK-70: secrets scan, TASK-71: internal references).

## Audit results

**TASK-70 (Secrets):** Clean — gitleaks (210 commits, 13 MB) and manual pattern searches found no real secrets.

**TASK-71 (Internal references):** Four findings, all resolved:
| Finding | Action |
|---|---|
| Private Azure DevOps feed in `nuget.config` | Replaced with nuget.org |
| Redundant feed override in `nightly.yml` | Removed |
| Azure DevOps URL in backlog task-32 | Scrubbed |
| Personal email in early git history | Accepted (no security risk) |

## Test plan

- [ ] Verify `dotnet restore` works with updated `nuget.config`
- [ ] Verify nightly workflow runs successfully without the override step

🤖 Generated with [Claude Code](https://claude.com/claude-code)