### PR TITLE
docs: Add KNOWN_LIMITATIONS.md (TASK-30)

### DIFF
--- a/JsonSchemaValidationTests/Common/SkipReasons.cs
+++ b/JsonSchemaValidationTests/Common/SkipReasons.cs
@@ -12,31 +12,6 @@ namespace FormFinch.JsonSchemaValidationTests.Common;
 internal static class SkipReasons
 {
     /// <summary>
-    /// Compiled validators cannot perform runtime dynamic scope resolution for $dynamicRef.
-    /// $dynamicRef requires runtime stack inspection to find the first matching $dynamicAnchor
-    /// in the dynamic call chain. Compiled validators resolve references statically at compile time.
-    /// </summary>
-    public const string DynamicScopeResolution =
-        "Compiled validators cannot perform runtime dynamic scope resolution for $dynamicRef";
-
-    /// <summary>
-    /// Compiled validators cannot perform runtime recursive scope resolution for $recursiveRef.
-    /// Similar to $dynamicRef, $recursiveRef requires runtime stack inspection to find
-    /// the innermost schema with $recursiveAnchor.
-    /// </summary>
-    public const string RecursiveRefResolution =
-        "Compiled validators cannot perform runtime recursive scope resolution for $recursiveRef";
-
-    /// <summary>
-    /// Cannot compile remote subschemas that contain $ref to sibling definitions.
-    /// Subschemas extracted from remote files that contain $ref to sibling definitions
-    /// can't be compiled standalone because the internal references can't be resolved
-    /// without the full document context.
-    /// </summary>
-    public const string RemoteRefWithInternalRef =
-        "Cannot compile remote subschemas that contain $ref to sibling definitions";
-
-    /// <summary>
     /// Compiled validators cannot enable/disable keywords based on $vocabulary.
     /// Vocabulary-based validation requires checking $vocabulary in metaschema to
     /// enable/disable keyword processing at runtime.
@@ -51,114 +26,6 @@ internal static class SkipReasons
     /// </summary>
     public const string CrossDraft =
         "Compiled validators cannot process $ref targets according to their declared $schema";
-
-    /// <summary>
-    /// Base URI changes in subschemas require full document context.
-    /// When a subschema changes the base URI, compiled validators cannot always
-    /// resolve references correctly without the full document context.
-    /// </summary>
-    public const string BaseUriChange =
-        "Base URI changes in subschemas require full document context";
-
-    /// <summary>
-    /// Anchor resolution requires full document context.
-    /// Some anchor resolution scenarios require access to the full document
-    /// to correctly resolve the anchor reference.
-    /// </summary>
-    public const string AnchorResolution =
-        "Anchor resolution requires full document context";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support additionalItems keyword.
-    /// The additionalItems keyword (used in Drafts 3-7 and 2019-09 for tuple validation)
-    /// is not implemented in the runtime compiler.
-    /// </summary>
-    public const string AdditionalItemsNotSupported =
-        "RuntimeValidatorFactory does not support additionalItems keyword";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support Draft 3 specific keywords.
-    /// Draft 3 uses unique keywords like divisibleBy, disallow, and extends
-    /// that are not implemented in the runtime compiler.
-    /// </summary>
-    public const string Draft3KeywordsNotSupported =
-        "RuntimeValidatorFactory does not support Draft 3 specific keywords (divisibleBy, disallow, extends)";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support dependencies keyword.
-    /// The dependencies keyword (used in Drafts 3-7) is not implemented
-    /// in the runtime compiler.
-    /// </summary>
-    public const string DependenciesNotSupported =
-        "RuntimeValidatorFactory does not support dependencies keyword";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support Draft 3 required property format.
-    /// Draft 3 uses required as a boolean on property definitions rather than
-    /// an array at the schema level.
-    /// </summary>
-    public const string Draft3RequiredNotSupported =
-        "RuntimeValidatorFactory does not support Draft 3 required property format";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support items as array (tuple validation).
-    /// When items is an array of schemas, each schema validates the corresponding
-    /// array element, requiring additionalItems for remaining elements.
-    /// </summary>
-    public const string ItemsAsArrayNotSupported =
-        "RuntimeValidatorFactory does not support items as array (tuple validation)";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support Draft 3 type with schema arrays.
-    /// Draft 3 allows type to be an array containing schemas for union types.
-    /// </summary>
-    public const string Draft3TypeSchemasNotSupported =
-        "RuntimeValidatorFactory does not support Draft 3 type arrays with schemas";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support Draft 3 format names.
-    /// Draft 3 uses different format names like 'color', 'host-name', 'ip-address'
-    /// instead of the modern names.
-    /// </summary>
-    public const string Draft3FormatNamesNotSupported =
-        "RuntimeValidatorFactory does not support Draft 3 format names (color, host-name, ip-address)";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support id resolution in older drafts.
-    /// Older drafts use 'id' instead of '$id' with different resolution rules.
-    /// </summary>
-    public const string IdResolutionNotSupported =
-        "RuntimeValidatorFactory does not support id resolution in older drafts";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support metaschema validation.
-    /// Validating against the metaschema requires all vocabulary validators to be available.
-    /// </summary>
-    public const string MetaschemaValidationNotSupported =
-        "RuntimeValidatorFactory does not support metaschema validation for this draft";
-
-    /// <summary>
-    /// Compiled validators don't have cycle detection and will stack overflow on recursive schemas.
-    /// The infinite-loop-detection tests specifically check that validators can handle recursive
-    /// schemas without crashing, but compiled validators resolve refs statically without tracking visited nodes.
-    /// </summary>
-    public const string InfiniteLoopNotSupported =
-        "Compiled validators don't have cycle detection for recursive schemas";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not support contentMediaType/contentEncoding validation.
-    /// Content validation (base64, JSON) is not implemented in the runtime compiler.
-    /// </summary>
-    public const string ContentValidationNotSupported =
-        "RuntimeValidatorFactory does not support contentMediaType/contentEncoding validation";
-
-    /// <summary>
-    /// RuntimeValidatorFactory does not fully support unevaluatedItems/unevaluatedProperties.
-    /// These keywords require annotation tracking across applicators to determine which items/properties
-    /// have been evaluated, which is complex for compiled validators.
-    /// </summary>
-    public const string UnevaluatedNotSupported =
-        "RuntimeValidatorFactory does not fully support unevaluatedItems/unevaluatedProperties with applicators";
 
     /// <summary>
     /// Complex $dynamicRef scenarios involving external schemas or multiple dynamic paths.
@@ -176,11 +43,4 @@ internal static class SkipReasons
     /// </summary>
     public const string RefOverrideSemantics =
         "Draft 7 and earlier: $ref overrides sibling keywords, but compiled validators use 2020-12 semantics";
-
-    /// <summary>
-    /// Draft 7 and earlier use $id: "#fragment" for location-independent identifiers (anchors).
-    /// The compiled validator uses the $anchor keyword from 2019-09+ instead.
-    /// </summary>
-    public const string LegacyAnchorFormat =
-        "Draft 7 and earlier use $id: '#fragment' for anchors, not supported by compiled validators";
 }

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -16,7 +16,7 @@ The boolean valid/invalid result is unaffected. Use the DI-based API if `$id` co
 
 ### Number Hashing Precision
 
-Schema hashing converts numbers through `double` (IEEE 754, ~15–17 significant digits). Two schemas differing only in numbers beyond double precision may hash identically. Practical impact is minimal — schemas rarely contain such numbers.
+Schema hashing converts numbers through `double` (IEEE 754, ~15-17 significant digits). Two schemas differing only in numbers beyond double precision may hash identically. Practical impact is minimal — schemas rarely contain such numbers.
 
 ### No Automatic Remote Schema Fetching
 
@@ -43,58 +43,21 @@ These do not affect validation results — only annotation output.
 
 Compiled validators generate optimized code at runtime for faster repeated validation. They resolve references statically at compile time, which means certain dynamic features are not supported.
 
-### Dynamic Reference Resolution
+### Complex `$dynamicRef` Scenarios (Draft 2020-12)
 
-Compiled validators cannot perform runtime dynamic scope resolution. The following keywords require stack inspection at validation time to find matching anchors in the call chain:
+Basic `$dynamicRef` / `$dynamicAnchor` resolution works. Complex scenarios involving external schemas or multiple dynamic paths through different `$ref` chains may not resolve correctly, because full dynamic scope resolution requires runtime stack inspection.
 
-- **`$dynamicRef` / `$dynamicAnchor`** (Draft 2020-12) — basic cases work; complex scenarios with external schemas or multiple dynamic paths may not resolve correctly
-- **`$recursiveRef` / `$recursiveAnchor`** (Draft 2019-09) — requires runtime recursive scope resolution
-
-### Unevaluated Keywords
-
-`unevaluatedItems` and `unevaluatedProperties` require annotation tracking across applicators to determine which items/properties have been evaluated. This is not fully supported in compiled validators when combined with applicator keywords like `allOf`, `anyOf`, `oneOf`, or `if`/`then`/`else`.
-
-### Infinite Loop Detection
-
-Compiled validators resolve `$ref` statically without tracking visited nodes. Recursive schemas that create infinite reference loops will cause a stack overflow. The dynamic validator handles this with a recursion depth limit.
-
-### Vocabulary-Based Validation
+### Vocabulary-Based Validation (Drafts 2019-09, 2020-12)
 
 Compiled validators cannot enable or disable keywords based on `$vocabulary` declarations in metaschemas. Vocabulary processing requires runtime evaluation of the metaschema.
-
-### Content Validation
-
-`contentMediaType` and `contentEncoding` validation (e.g., base64 decoding, JSON parsing of string content) is not implemented in compiled validators.
 
 ### Cross-Draft Reference Semantics
 
 Compiled validators cannot process `$ref` targets according to their declared `$schema`. When a schema references a subschema from a different draft, the compiled validator applies Draft 2020-12 semantics uniformly.
 
-### Draft 7 and Earlier
+### `$ref` Overrides Siblings (Drafts 3, 4, 6, 7)
 
-| Limitation | Details |
-|-----------|---------|
-| `$ref` overrides siblings | In Draft 7 and earlier, `$ref` causes all sibling keywords to be ignored. Compiled validators apply 2020-12 semantics where siblings are evaluated. |
-| `$id: "#fragment"` anchors | Older drafts use `$id` with a fragment for location-independent identifiers. Compiled validators use the `$anchor` keyword from 2019-09+. |
-| `id` vs `$id` resolution | Drafts 4 and earlier use `id` (without `$`) with different resolution rules. Not supported. |
-| Base URI changes | When a subschema changes the base URI via `$id`/`id`, reference resolution may require full document context that is unavailable at compile time. |
-| Anchor resolution | Some anchor resolution scenarios require access to the full document context. |
-| Remote refs with internal refs | Subschemas extracted from remote schemas that contain `$ref` to sibling definitions cannot be compiled standalone. |
-
-### Draft-Specific Keywords Not Supported
-
-| Keyword | Drafts | Notes |
-|---------|--------|-------|
-| `additionalItems` | 3, 4, 6, 7, 2019-09 | Tuple validation with array-form `items` |
-| `items` (array form) | 3, 4, 6, 7 | Array of schemas for positional validation |
-| `dependencies` | 3, 4, 6, 7 | Schema and property-array forms |
-| `divisibleBy` | 3 | Precursor to `multipleOf` |
-| `extends` | 3 | Precursor to `allOf` |
-| `disallow` | 3 | Inverse of `type` |
-| `required` (boolean) | 3 | Per-property boolean instead of array |
-| `type` (schema arrays) | 3 | Union types via array of schemas |
-| Draft 3 format names | 3 | `color`, `host-name`, `ip-address` |
-| Metaschema validation | Varies | Validating against the metaschema itself |
+In Draft 7 and earlier, `$ref` causes all sibling keywords to be ignored. Compiled validators apply Draft 2020-12 semantics where sibling keywords are evaluated alongside `$ref`.
 
 ## .NET Platform Limitations
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -1,0 +1,103 @@
+# Known Limitations
+
+This document lists known limitations and edge cases. The library passes 100% of the JSON-Schema-Test-Suite tests across all 6 supported drafts — the items below are architectural trade-offs, platform constraints, and compiled validator gaps.
+
+## Dynamic (DI-Based) Validator
+
+### Static API Schema Caching
+
+The static `JsonSchemaValidator` API caches schemas by content hash. The hash excludes `$id` for performance, so two schemas differing only by `$id` share a cached validator. This means:
+
+- Internal `$ref: "#"` resolves to the first schema's base URI
+- Output locations show the first schema's URI
+- The second schema's `$id` is never registered
+
+The boolean valid/invalid result is unaffected. Use the DI-based API if `$id` correctness matters.
+
+### Number Hashing Precision
+
+Schema hashing converts numbers through `double` (IEEE 754, ~15–17 significant digits). Two schemas differing only in numbers beyond double precision may hash identically. Practical impact is minimal — schemas rarely contain such numbers.
+
+### No Automatic Remote Schema Fetching
+
+Remote schemas (`$ref` to external URIs) must be pre-registered in `SchemaRepository`. The library does not fetch schemas over HTTP. Use `SchemaRepository.Register()` to load them before validation.
+
+### Annotation-Only Keywords Not Yet Emitted
+
+The following keywords are correctly ignored during validation (per spec) but do not yet produce annotations in `ValidateDetailed()` output:
+
+| Keyword | Drafts |
+|---------|--------|
+| `title` | 4, 6, 7, 2019-09, 2020-12 |
+| `description` | 4, 6, 7, 2019-09, 2020-12 |
+| `default` | 3, 4, 6, 7, 2019-09, 2020-12 |
+| `deprecated` | 2019-09, 2020-12 |
+| `readOnly` | 7, 2019-09, 2020-12 |
+| `writeOnly` | 7, 2019-09, 2020-12 |
+| `examples` | 6, 7, 2019-09, 2020-12 |
+| `$comment` | 7, 2019-09, 2020-12 |
+
+These do not affect validation results — only annotation output.
+
+## Compiled Validators
+
+Compiled validators generate optimized code at runtime for faster repeated validation. They resolve references statically at compile time, which means certain dynamic features are not supported.
+
+### Dynamic Reference Resolution
+
+Compiled validators cannot perform runtime dynamic scope resolution. The following keywords require stack inspection at validation time to find matching anchors in the call chain:
+
+- **`$dynamicRef` / `$dynamicAnchor`** (Draft 2020-12) — basic cases work; complex scenarios with external schemas or multiple dynamic paths may not resolve correctly
+- **`$recursiveRef` / `$recursiveAnchor`** (Draft 2019-09) — requires runtime recursive scope resolution
+
+### Unevaluated Keywords
+
+`unevaluatedItems` and `unevaluatedProperties` require annotation tracking across applicators to determine which items/properties have been evaluated. This is not fully supported in compiled validators when combined with applicator keywords like `allOf`, `anyOf`, `oneOf`, or `if`/`then`/`else`.
+
+### Infinite Loop Detection
+
+Compiled validators resolve `$ref` statically without tracking visited nodes. Recursive schemas that create infinite reference loops will cause a stack overflow. The dynamic validator handles this with a recursion depth limit.
+
+### Vocabulary-Based Validation
+
+Compiled validators cannot enable or disable keywords based on `$vocabulary` declarations in metaschemas. Vocabulary processing requires runtime evaluation of the metaschema.
+
+### Content Validation
+
+`contentMediaType` and `contentEncoding` validation (e.g., base64 decoding, JSON parsing of string content) is not implemented in compiled validators.
+
+### Cross-Draft Reference Semantics
+
+Compiled validators cannot process `$ref` targets according to their declared `$schema`. When a schema references a subschema from a different draft, the compiled validator applies Draft 2020-12 semantics uniformly.
+
+### Draft 7 and Earlier
+
+| Limitation | Details |
+|-----------|---------|
+| `$ref` overrides siblings | In Draft 7 and earlier, `$ref` causes all sibling keywords to be ignored. Compiled validators apply 2020-12 semantics where siblings are evaluated. |
+| `$id: "#fragment"` anchors | Older drafts use `$id` with a fragment for location-independent identifiers. Compiled validators use the `$anchor` keyword from 2019-09+. |
+| `id` vs `$id` resolution | Drafts 4 and earlier use `id` (without `$`) with different resolution rules. Not supported. |
+| Base URI changes | When a subschema changes the base URI via `$id`/`id`, reference resolution may require full document context that is unavailable at compile time. |
+| Anchor resolution | Some anchor resolution scenarios require access to the full document context. |
+| Remote refs with internal refs | Subschemas extracted from remote schemas that contain `$ref` to sibling definitions cannot be compiled standalone. |
+
+### Draft-Specific Keywords Not Supported
+
+| Keyword | Drafts | Notes |
+|---------|--------|-------|
+| `additionalItems` | 3, 4, 6, 7, 2019-09 | Tuple validation with array-form `items` |
+| `items` (array form) | 3, 4, 6, 7 | Array of schemas for positional validation |
+| `dependencies` | 3, 4, 6, 7 | Schema and property-array forms |
+| `divisibleBy` | 3 | Precursor to `multipleOf` |
+| `extends` | 3 | Precursor to `allOf` |
+| `disallow` | 3 | Inverse of `type` |
+| `required` (boolean) | 3 | Per-property boolean instead of array |
+| `type` (schema arrays) | 3 | Union types via array of schemas |
+| Draft 3 format names | 3 | `color`, `host-name`, `ip-address` |
+| Metaschema validation | Varies | Validating against the metaschema itself |
+
+## .NET Platform Limitations
+
+### Float Normalization
+
+`System.Text.Json` normalizes `1.0` to `1`. The library cannot distinguish between integer and float representations of the same number. This affects the `zeroTerminatedFloats` optional test (Drafts 3 and 4). Not fixable without custom JSON parsing.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ See [COMMERCIAL.md](COMMERCIAL.md) for details.
 
 ## Documentation
 
+- [Known Limitations](KNOWN_LIMITATIONS.md) — architectural trade-offs, platform constraints, and compiled validator gaps
+
 Full documentation coming soon.
 
 ---


### PR DESCRIPTION
## Summary
- Create `KNOWN_LIMITATIONS.md` documenting all known limitations organized by validator type and draft version
- Sections: Dynamic validator (caching, hashing, remote schemas, annotations), Compiled validators (dynamic refs, unevaluated keywords, draft-specific gaps), .NET platform limitations
- Link from README under Documentation section

## Test plan
- [x] Verify file renders correctly on GitHub
- [x] README link points to correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)