### PR TITLE
feat: Add JavaScript code-gen target (closes #25)

### DIFF
--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -63,7 +63,9 @@ public static class JsCapabilityGate
             "propertyNames",
             "unevaluatedProperties",
             "unevaluatedItems",
-            "contentSchema",
+            // contentSchema is annotation-only in this codebase (and in the default
+            // 2020-12 content vocabulary), so recursing into it would falsely reject
+            // schemas that use deferred keywords inside content metadata.
         },
     };
 

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -146,10 +146,13 @@ public static class JsCapabilityGate
         // Draft 7 and earlier: $ref masks all sibling keywords at emission time
         // (see JsSchemaCodeGenerator.refMasksSiblings). Mirror that here so the
         // gate doesn't reject schemas based on keywords the emitter will ignore.
-        // We still check the $ref value itself for external-ref rejection.
+        // Match the emitter's "usable $ref" check — an empty or non-string $ref
+        // doesn't actually mask siblings in the emitter, so we don't mask here
+        // either.
         var refMasksSiblings = draft <= SchemaDraft.Draft7 &&
                                node.TryGetProperty("$ref", out var maskedRef) &&
-                               maskedRef.ValueKind == JsonValueKind.String;
+                               maskedRef.ValueKind == JsonValueKind.String &&
+                               !string.IsNullOrEmpty(maskedRef.GetString());
 
         foreach (var prop in node.EnumerateObject())
         {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -108,6 +108,11 @@ public static class JsCapabilityGate
             "properties",
             "patternProperties",
             "$defs",
+            // definitions: not a standard 2020-12 keyword, but the shared
+            // SubschemaExtractor still walks it and #/definitions/... refs
+            // are legal JSON Pointers. Include so the gate matches emission
+            // reachability and so extractor-collected subschemas get emitted.
+            "definitions",
             "dependentSchemas",
         },
     };

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -8,22 +8,14 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
 
 /// <summary>
 /// Gates the JS target to features actually supported by the MVP emitter.
-/// Walks only through known schema-valued keywords so that annotation/data
-/// keywords (default, examples, enum, const) aren't confused for subschemas.
-/// Returns early with a descriptive message when a deferred feature is found.
+/// Walking is draft-aware: deferred-feature rejection and applicator recursion
+/// only apply when the keyword actually exists in the detected draft, so a
+/// Draft 4 schema using a post-Draft-4 name (e.g. unevaluatedProperties,
+/// $dynamicRef, propertyNames) is correctly accepted as an unknown-keyword
+/// annotation per spec, not rejected.
 /// </summary>
 public static class JsCapabilityGate
 {
-    private static readonly HashSet<string> DeferredKeywords = new(StringComparer.Ordinal)
-    {
-        "unevaluatedProperties",
-        "unevaluatedItems",
-        "$dynamicRef",
-        "$dynamicAnchor",
-        "$recursiveRef",
-        "$recursiveAnchor",
-    };
-
     private static readonly HashSet<SchemaDraft> SupportedDrafts = new()
     {
         SchemaDraft.Draft4,
@@ -31,39 +23,84 @@ public static class JsCapabilityGate
     };
 
     /// <summary>
-    /// Keywords whose value is itself a schema (object or boolean).
+    /// Per-draft deferred-keyword set: reject only when the keyword exists in
+    /// the target draft. Empty for Draft 4 because none of these keywords were
+    /// part of that draft.
     /// </summary>
-    private static readonly HashSet<string> SchemaValuedKeywords = new(StringComparer.Ordinal)
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> DeferredPerDraft = new()
     {
-        "not",
-        "if", "then", "else",
-        "contains",
-        "additionalProperties",
-        "additionalItems",
-        "propertyNames",
-        "unevaluatedProperties",
-        "unevaluatedItems",
-        "contentSchema",
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal),
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "unevaluatedProperties",
+            "unevaluatedItems",
+            "$dynamicRef",
+            "$dynamicAnchor",
+            "$recursiveRef",
+            "$recursiveAnchor",
+        },
     };
 
     /// <summary>
-    /// Keywords whose value is an array of schemas.
+    /// Per-draft keywords whose value is itself a schema (object or boolean).
+    /// Recursion only happens for keywords defined in the current draft; others
+    /// are treated as unknown annotations and not traversed.
     /// </summary>
-    private static readonly HashSet<string> SchemaArrayKeywords = new(StringComparer.Ordinal)
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaValuedPerDraft = new()
     {
-        "allOf", "anyOf", "oneOf",
-        "prefixItems",
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "additionalProperties",
+            "additionalItems",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "if", "then", "else",
+            "contains",
+            "additionalProperties",
+            "propertyNames",
+            "unevaluatedProperties",
+            "unevaluatedItems",
+            "contentSchema",
+        },
     };
 
     /// <summary>
-    /// Keywords whose value is a map of name/pattern to schema.
+    /// Per-draft keywords whose value is an array of schemas.
     /// </summary>
-    private static readonly HashSet<string> SchemaMapKeywords = new(StringComparer.Ordinal)
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaArrayPerDraft = new()
     {
-        "properties",
-        "patternProperties",
-        "$defs", "definitions",
-        "dependentSchemas",
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+            "prefixItems",
+        },
+    };
+
+    /// <summary>
+    /// Per-draft keywords whose value is a map of name/pattern to schema.
+    /// </summary>
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaMapPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "definitions",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "$defs",
+            "dependentSchemas",
+        },
     };
 
     /// <summary>
@@ -77,30 +114,24 @@ public static class JsCapabilityGate
             return $"JS target MVP supports Draft 4 and Draft 2020-12 only; detected {detectedDraft}. " +
                    "Other drafts are tracked as follow-up work.";
         }
-        return Walk(root);
+        return Walk(root, detectedDraft);
     }
 
-    private static string? Walk(JsonElement node)
+    private static string? Walk(JsonElement node, SchemaDraft draft)
     {
-        switch (node.ValueKind)
-        {
-            case JsonValueKind.Object:
-                return WalkObject(node);
-            case JsonValueKind.True:
-            case JsonValueKind.False:
-                // Boolean schemas are valid; nothing to inspect.
-                return null;
-            default:
-                // Primitives cannot host schema keywords.
-                return null;
-        }
+        return node.ValueKind == JsonValueKind.Object ? WalkObject(node, draft) : null;
     }
 
-    private static string? WalkObject(JsonElement node)
+    private static string? WalkObject(JsonElement node, SchemaDraft draft)
     {
+        var deferred = DeferredPerDraft[draft];
+        var schemaValued = SchemaValuedPerDraft[draft];
+        var schemaArray = SchemaArrayPerDraft[draft];
+        var schemaMap = SchemaMapPerDraft[draft];
+
         foreach (var prop in node.EnumerateObject())
         {
-            if (DeferredKeywords.Contains(prop.Name))
+            if (deferred.Contains(prop.Name))
             {
                 return $"JS target MVP does not support '{prop.Name}'. " +
                        "Deferred to follow-up: unevaluated*, $dynamicRef/$dynamicAnchor, " +
@@ -117,20 +148,30 @@ public static class JsCapabilityGate
                 }
             }
 
-            // Special case for "items": can be a single schema (all drafts) or an
-            // array of schemas (Draft 4 + 2019-09). Recurse into whichever shape it is.
+            // Draft-specific "items": single schema in 2020-12; single or array in Draft 4.
+            // Only traverse when items is a known keyword in the current draft (it is in both
+            // MVP drafts, but the shape differs).
             if (prop.Name == "items")
             {
-                var rejection = prop.Value.ValueKind == JsonValueKind.Array
-                    ? WalkSchemaArray(prop.Value)
-                    : Walk(prop.Value);
-                if (rejection != null) return rejection;
+                if (draft == SchemaDraft.Draft4 && prop.Value.ValueKind == JsonValueKind.Array)
+                {
+                    var rejection = WalkSchemaArray(prop.Value, draft);
+                    if (rejection != null) return rejection;
+                }
+                else
+                {
+                    var rejection = Walk(prop.Value, draft);
+                    if (rejection != null) return rejection;
+                }
                 continue;
             }
 
-            // Draft 4-7 "dependencies": each value is either an array of property
+            // Draft 4 "dependencies": each value is either an array of property
             // names (data) or a schema. Only recurse into schema-shaped values.
-            if (prop.Name == "dependencies" && prop.Value.ValueKind == JsonValueKind.Object)
+            // In Draft 2020-12 "dependencies" is no longer a keyword; treat as
+            // unknown annotation and do not recurse.
+            if (prop.Name == "dependencies" && draft == SchemaDraft.Draft4 &&
+                prop.Value.ValueKind == JsonValueKind.Object)
             {
                 foreach (var dep in prop.Value.EnumerateObject())
                 {
@@ -138,52 +179,51 @@ public static class JsCapabilityGate
                         dep.Value.ValueKind == JsonValueKind.True ||
                         dep.Value.ValueKind == JsonValueKind.False)
                     {
-                        var rejection = Walk(dep.Value);
+                        var rejection = Walk(dep.Value, draft);
                         if (rejection != null) return rejection;
                     }
                 }
                 continue;
             }
 
-            if (SchemaValuedKeywords.Contains(prop.Name))
+            if (schemaValued.Contains(prop.Name))
             {
-                var rejection = Walk(prop.Value);
+                var rejection = Walk(prop.Value, draft);
                 if (rejection != null) return rejection;
             }
-            else if (SchemaArrayKeywords.Contains(prop.Name) &&
+            else if (schemaArray.Contains(prop.Name) &&
                      prop.Value.ValueKind == JsonValueKind.Array)
             {
-                var rejection = WalkSchemaArray(prop.Value);
+                var rejection = WalkSchemaArray(prop.Value, draft);
                 if (rejection != null) return rejection;
             }
-            else if (SchemaMapKeywords.Contains(prop.Name) &&
+            else if (schemaMap.Contains(prop.Name) &&
                      prop.Value.ValueKind == JsonValueKind.Object)
             {
-                var rejection = WalkSchemaMap(prop.Value);
+                var rejection = WalkSchemaMap(prop.Value, draft);
                 if (rejection != null) return rejection;
             }
-            // All other property values (default, examples, enum, const, type,
-            // required, pattern, numeric constraints, format, etc.) are data or
-            // annotations and are intentionally not walked.
+            // All other property values (data, annotations, unknown-in-this-draft
+            // keywords) are intentionally not walked.
         }
         return null;
     }
 
-    private static string? WalkSchemaArray(JsonElement array)
+    private static string? WalkSchemaArray(JsonElement array, SchemaDraft draft)
     {
         foreach (var item in array.EnumerateArray())
         {
-            var rejection = Walk(item);
+            var rejection = Walk(item, draft);
             if (rejection != null) return rejection;
         }
         return null;
     }
 
-    private static string? WalkSchemaMap(JsonElement map)
+    private static string? WalkSchemaMap(JsonElement map, SchemaDraft draft)
     {
         foreach (var entry in map.EnumerateObject())
         {
-            var rejection = Walk(entry.Value);
+            var rejection = Walk(entry.Value, draft);
             if (rejection != null) return rejection;
         }
         return null;

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -8,16 +8,12 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
 
 /// <summary>
 /// Gates the JS target to features actually supported by the MVP emitter.
-/// The shared analyzer under-reports JS-specific limitations, so the gate
-/// walks the schema and rejects deferred features before emission begins.
-/// Returning early avoids emitting code that silently diverges from C# behavior.
+/// Walks only through known schema-valued keywords so that annotation/data
+/// keywords (default, examples, enum, const) aren't confused for subschemas.
+/// Returns early with a descriptive message when a deferred feature is found.
 /// </summary>
 public static class JsCapabilityGate
 {
-    /// <summary>
-    /// Keywords whose MVP JS emitter coverage is deferred to follow-up issues.
-    /// Present in any subschema = reject.
-    /// </summary>
     private static readonly HashSet<string> DeferredKeywords = new(StringComparer.Ordinal)
     {
         "unevaluatedProperties",
@@ -28,14 +24,46 @@ public static class JsCapabilityGate
         "$recursiveAnchor",
     };
 
-    /// <summary>
-    /// Drafts the MVP JS emitter supports. Others are rejected explicitly rather
-    /// than silently producing Draft-2020-12-shaped output.
-    /// </summary>
     private static readonly HashSet<SchemaDraft> SupportedDrafts = new()
     {
         SchemaDraft.Draft4,
         SchemaDraft.Draft202012,
+    };
+
+    /// <summary>
+    /// Keywords whose value is itself a schema (object or boolean).
+    /// </summary>
+    private static readonly HashSet<string> SchemaValuedKeywords = new(StringComparer.Ordinal)
+    {
+        "not",
+        "if", "then", "else",
+        "contains",
+        "additionalProperties",
+        "additionalItems",
+        "propertyNames",
+        "unevaluatedProperties",
+        "unevaluatedItems",
+        "contentSchema",
+    };
+
+    /// <summary>
+    /// Keywords whose value is an array of schemas.
+    /// </summary>
+    private static readonly HashSet<string> SchemaArrayKeywords = new(StringComparer.Ordinal)
+    {
+        "allOf", "anyOf", "oneOf",
+        "prefixItems",
+    };
+
+    /// <summary>
+    /// Keywords whose value is a map of name/pattern to schema.
+    /// </summary>
+    private static readonly HashSet<string> SchemaMapKeywords = new(StringComparer.Ordinal)
+    {
+        "properties",
+        "patternProperties",
+        "$defs", "definitions",
+        "dependentSchemas",
     };
 
     /// <summary>
@@ -49,9 +77,7 @@ public static class JsCapabilityGate
             return $"JS target MVP supports Draft 4 and Draft 2020-12 only; detected {detectedDraft}. " +
                    "Other drafts are tracked as follow-up work.";
         }
-
-        var rejection = Walk(root);
-        return rejection;
+        return Walk(root);
     }
 
     private static string? Walk(JsonElement node)
@@ -59,52 +85,113 @@ public static class JsCapabilityGate
         switch (node.ValueKind)
         {
             case JsonValueKind.Object:
-                foreach (var prop in node.EnumerateObject())
-                {
-                    if (DeferredKeywords.Contains(prop.Name))
-                    {
-                        return $"JS target MVP does not support '{prop.Name}'. " +
-                               "Deferred to follow-up: unevaluated*, $dynamicRef/$dynamicAnchor, " +
-                               "$recursiveRef/$recursiveAnchor.";
-                    }
-
-                    if (prop.Name == "$ref" && prop.Value.ValueKind == JsonValueKind.String)
-                    {
-                        var refValue = prop.Value.GetString();
-                        if (!string.IsNullOrEmpty(refValue) && IsExternalRef(refValue))
-                        {
-                            return $"JS target MVP does not support external $ref '{refValue}'. " +
-                                   "Local refs (starting with '#') are supported; external refs are deferred.";
-                        }
-                    }
-
-                    var childRejection = Walk(prop.Value);
-                    if (childRejection != null)
-                    {
-                        return childRejection;
-                    }
-                }
-                break;
-
-            case JsonValueKind.Array:
-                foreach (var item in node.EnumerateArray())
-                {
-                    var childRejection = Walk(item);
-                    if (childRejection != null)
-                    {
-                        return childRejection;
-                    }
-                }
-                break;
+                return WalkObject(node);
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                // Boolean schemas are valid; nothing to inspect.
+                return null;
+            default:
+                // Primitives cannot host schema keywords.
+                return null;
         }
+    }
 
+    private static string? WalkObject(JsonElement node)
+    {
+        foreach (var prop in node.EnumerateObject())
+        {
+            if (DeferredKeywords.Contains(prop.Name))
+            {
+                return $"JS target MVP does not support '{prop.Name}'. " +
+                       "Deferred to follow-up: unevaluated*, $dynamicRef/$dynamicAnchor, " +
+                       "$recursiveRef/$recursiveAnchor.";
+            }
+
+            if (prop.Name == "$ref" && prop.Value.ValueKind == JsonValueKind.String)
+            {
+                var refValue = prop.Value.GetString();
+                if (!string.IsNullOrEmpty(refValue) && IsExternalRef(refValue))
+                {
+                    return $"JS target MVP does not support external $ref '{refValue}'. " +
+                           "Local refs (starting with '#') are supported; external refs are deferred.";
+                }
+            }
+
+            // Special case for "items": can be a single schema (all drafts) or an
+            // array of schemas (Draft 4 + 2019-09). Recurse into whichever shape it is.
+            if (prop.Name == "items")
+            {
+                var rejection = prop.Value.ValueKind == JsonValueKind.Array
+                    ? WalkSchemaArray(prop.Value)
+                    : Walk(prop.Value);
+                if (rejection != null) return rejection;
+                continue;
+            }
+
+            // Draft 4-7 "dependencies": each value is either an array of property
+            // names (data) or a schema. Only recurse into schema-shaped values.
+            if (prop.Name == "dependencies" && prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var dep in prop.Value.EnumerateObject())
+                {
+                    if (dep.Value.ValueKind == JsonValueKind.Object ||
+                        dep.Value.ValueKind == JsonValueKind.True ||
+                        dep.Value.ValueKind == JsonValueKind.False)
+                    {
+                        var rejection = Walk(dep.Value);
+                        if (rejection != null) return rejection;
+                    }
+                }
+                continue;
+            }
+
+            if (SchemaValuedKeywords.Contains(prop.Name))
+            {
+                var rejection = Walk(prop.Value);
+                if (rejection != null) return rejection;
+            }
+            else if (SchemaArrayKeywords.Contains(prop.Name) &&
+                     prop.Value.ValueKind == JsonValueKind.Array)
+            {
+                var rejection = WalkSchemaArray(prop.Value);
+                if (rejection != null) return rejection;
+            }
+            else if (SchemaMapKeywords.Contains(prop.Name) &&
+                     prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                var rejection = WalkSchemaMap(prop.Value);
+                if (rejection != null) return rejection;
+            }
+            // All other property values (default, examples, enum, const, type,
+            // required, pattern, numeric constraints, format, etc.) are data or
+            // annotations and are intentionally not walked.
+        }
+        return null;
+    }
+
+    private static string? WalkSchemaArray(JsonElement array)
+    {
+        foreach (var item in array.EnumerateArray())
+        {
+            var rejection = Walk(item);
+            if (rejection != null) return rejection;
+        }
+        return null;
+    }
+
+    private static string? WalkSchemaMap(JsonElement map)
+    {
+        foreach (var entry in map.EnumerateObject())
+        {
+            var rejection = Walk(entry.Value);
+            if (rejection != null) return rejection;
+        }
         return null;
     }
 
     /// <summary>
-    /// A $ref is "external" (from the MVP's perspective) if it targets a URI
-    /// rather than a pure fragment within the current document.
-    /// Refs beginning with '#' are treated as local JSON Pointer refs.
+    /// A $ref is "external" from the MVP's perspective when it targets something
+    /// other than a fragment within the current document (anything not starting with '#').
     /// </summary>
     private static bool IsExternalRef(string refValue)
     {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+
+/// <summary>
+/// Gates the JS target to features actually supported by the MVP emitter.
+/// The shared analyzer under-reports JS-specific limitations, so the gate
+/// walks the schema and rejects deferred features before emission begins.
+/// Returning early avoids emitting code that silently diverges from C# behavior.
+/// </summary>
+public static class JsCapabilityGate
+{
+    /// <summary>
+    /// Keywords whose MVP JS emitter coverage is deferred to follow-up issues.
+    /// Present in any subschema = reject.
+    /// </summary>
+    private static readonly HashSet<string> DeferredKeywords = new(StringComparer.Ordinal)
+    {
+        "unevaluatedProperties",
+        "unevaluatedItems",
+        "$dynamicRef",
+        "$dynamicAnchor",
+        "$recursiveRef",
+        "$recursiveAnchor",
+    };
+
+    /// <summary>
+    /// Drafts the MVP JS emitter supports. Others are rejected explicitly rather
+    /// than silently producing Draft-2020-12-shaped output.
+    /// </summary>
+    private static readonly HashSet<SchemaDraft> SupportedDrafts = new()
+    {
+        SchemaDraft.Draft4,
+        SchemaDraft.Draft202012,
+    };
+
+    /// <summary>
+    /// Returns a rejection message if the schema uses deferred features,
+    /// or null if the schema is emit-safe for the MVP JS target.
+    /// </summary>
+    public static string? CheckSupported(JsonElement root, SchemaDraft detectedDraft)
+    {
+        if (!SupportedDrafts.Contains(detectedDraft))
+        {
+            return $"JS target MVP supports Draft 4 and Draft 2020-12 only; detected {detectedDraft}. " +
+                   "Other drafts are tracked as follow-up work.";
+        }
+
+        var rejection = Walk(root);
+        return rejection;
+    }
+
+    private static string? Walk(JsonElement node)
+    {
+        switch (node.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in node.EnumerateObject())
+                {
+                    if (DeferredKeywords.Contains(prop.Name))
+                    {
+                        return $"JS target MVP does not support '{prop.Name}'. " +
+                               "Deferred to follow-up: unevaluated*, $dynamicRef/$dynamicAnchor, " +
+                               "$recursiveRef/$recursiveAnchor.";
+                    }
+
+                    if (prop.Name == "$ref" && prop.Value.ValueKind == JsonValueKind.String)
+                    {
+                        var refValue = prop.Value.GetString();
+                        if (!string.IsNullOrEmpty(refValue) && IsExternalRef(refValue))
+                        {
+                            return $"JS target MVP does not support external $ref '{refValue}'. " +
+                                   "Local refs (starting with '#') are supported; external refs are deferred.";
+                        }
+                    }
+
+                    var childRejection = Walk(prop.Value);
+                    if (childRejection != null)
+                    {
+                        return childRejection;
+                    }
+                }
+                break;
+
+            case JsonValueKind.Array:
+                foreach (var item in node.EnumerateArray())
+                {
+                    var childRejection = Walk(item);
+                    if (childRejection != null)
+                    {
+                        return childRejection;
+                    }
+                }
+                break;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A $ref is "external" (from the MVP's perspective) if it targets a URI
+    /// rather than a pure fragment within the current document.
+    /// Refs beginning with '#' are treated as local JSON Pointer refs.
+    /// </summary>
+    private static bool IsExternalRef(string refValue)
+    {
+        return !refValue.StartsWith('#');
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -16,6 +16,13 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
 /// </summary>
 public static class JsCapabilityGate
 {
+    /// <summary>
+    /// Stable prefix every gate-rejection message starts with. Callers (tests,
+    /// tooling) can pattern-match this constant to classify a codegen failure as
+    /// "gate rejection" without parsing free-form wording.
+    /// </summary>
+    public const string RejectionPrefix = "JS target MVP";
+
     private static readonly HashSet<SchemaDraft> SupportedDrafts = new()
     {
         SchemaDraft.Draft4,
@@ -131,8 +138,20 @@ public static class JsCapabilityGate
         var schemaArray = SchemaArrayPerDraft[draft];
         var schemaMap = SchemaMapPerDraft[draft];
 
+        // Draft 7 and earlier: $ref masks all sibling keywords at emission time
+        // (see JsSchemaCodeGenerator.refMasksSiblings). Mirror that here so the
+        // gate doesn't reject schemas based on keywords the emitter will ignore.
+        // We still check the $ref value itself for external-ref rejection.
+        var refMasksSiblings = draft <= SchemaDraft.Draft7 &&
+                               node.TryGetProperty("$ref", out var maskedRef) &&
+                               maskedRef.ValueKind == JsonValueKind.String;
+
         foreach (var prop in node.EnumerateObject())
         {
+            if (refMasksSiblings && prop.Name != "$ref")
+            {
+                continue;
+            }
             if (deferred.Contains(prop.Name))
             {
                 return $"JS target MVP does not support '{prop.Name}'. " +

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+using FormFinch.JsonSchemaValidation.Common;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+
+/// <summary>
+/// Orchestrates JavaScript (ESM) validator emission for a JSON Schema.
+/// Reuses the language-agnostic schema analysis from JsonSchemaValidation.CodeGeneration
+/// and delegates per-keyword emission to IJsKeywordCodeGenerator implementations.
+/// </summary>
+public sealed class JsSchemaCodeGenerator
+{
+    private readonly List<IJsKeywordCodeGenerator> _keywordGenerators;
+    private readonly SubschemaExtractor _extractor = new();
+
+    /// <summary>
+    /// The default draft version to use when a schema doesn't have an explicit $schema keyword.
+    /// If null, defaults to Draft 2020-12.
+    /// </summary>
+    public SchemaDraft? DefaultDraft { get; set; }
+
+    /// <summary>
+    /// The import specifier used for the shared JS runtime module.
+    /// Defaults to a relative ESM import sibling to the emitted validator.
+    /// </summary>
+    public string RuntimeImportSpecifier { get; set; } = "./jsv-runtime.js";
+
+    public JsSchemaCodeGenerator()
+    {
+        _keywordGenerators =
+        [
+            new JsRefCodeGenerator(),
+            new JsTypeCodeGenerator(),
+            new JsRequiredCodeGenerator(),
+            new JsEnumCodeGenerator(),
+            new JsConstCodeGenerator(),
+            new JsPropertyNamesCodeGenerator(),
+            new JsDependentRequiredCodeGenerator(),
+            new JsDependentSchemasCodeGenerator(),
+            new JsDependenciesCodeGenerator(),
+            new JsNumericConstraintsCodeGenerator(),
+            new JsStringConstraintsCodeGenerator(),
+            new JsArrayConstraintsCodeGenerator(),
+            new JsObjectConstraintsCodeGenerator(),
+            new JsPatternCodeGenerator(),
+            new JsPrefixItemsCodeGenerator(),
+            new JsAdditionalItemsCodeGenerator(),
+            new JsItemsCodeGenerator(),
+            new JsContainsCodeGenerator(),
+            new JsPropertiesCodeGenerator(),
+            new JsPatternPropertiesCodeGenerator(),
+            new JsAdditionalPropertiesCodeGenerator(),
+            new JsAllOfCodeGenerator(),
+            new JsAnyOfCodeGenerator(),
+            new JsOneOfCodeGenerator(),
+            new JsNotCodeGenerator(),
+            new JsIfThenElseCodeGenerator(),
+            new JsFormatCodeGenerator(),
+        ];
+        _keywordGenerators.Sort((a, b) => b.Priority.CompareTo(a.Priority));
+    }
+
+    /// <summary>
+    /// Generates an ESM JavaScript validator module from a schema file.
+    /// </summary>
+    public GenerationResult Generate(string schemaPath)
+    {
+        try
+        {
+            var json = File.ReadAllText(schemaPath);
+            using var doc = JsonDocument.Parse(json);
+            return Generate(doc.RootElement, schemaPath);
+        }
+        catch (Exception ex)
+        {
+            return GenerationResult.Failed($"Failed to read schema: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Generates an ESM JavaScript validator module from a schema element.
+    /// </summary>
+    public GenerationResult Generate(JsonElement schema, string? sourcePath = null)
+    {
+        try
+        {
+            var draftResult = SchemaDraftDetector.DetectDraft(schema, DefaultDraft);
+            if (!draftResult.Success)
+            {
+                return GenerationResult.Failed(draftResult.ErrorMessage!);
+            }
+            var detectedDraft = draftResult.Draft;
+
+            var gateRejection = JsCapabilityGate.CheckSupported(schema, detectedDraft);
+            if (gateRejection != null)
+            {
+                return GenerationResult.Failed(gateRejection);
+            }
+
+            var schemaUri = ExtractSchemaUri(schema);
+            Uri? baseUri = null;
+            if (!string.IsNullOrEmpty(schemaUri))
+            {
+                Uri.TryCreate(schemaUri, UriKind.Absolute, out baseUri);
+            }
+
+            var uniqueSchemas = _extractor.ExtractUniqueSubschemas(schema, baseUri, DefaultDraft);
+            var rootHash = SchemaHasher.ComputeHash(schema);
+
+            var methods = new StringBuilder();
+            var runtimeImports = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var (_, subschemaInfo) in uniqueSchemas)
+            {
+                methods.AppendLine(GenerateValidationFunction(subschemaInfo, uniqueSchemas, detectedDraft, runtimeImports));
+                methods.AppendLine();
+            }
+
+            var module = GenerateModule(schemaUri, rootHash, methods.ToString(), runtimeImports);
+            var fileName = DeriveFileName(schemaUri, sourcePath);
+            return GenerationResult.Succeeded(module, fileName);
+        }
+        catch (Exception ex)
+        {
+            return GenerationResult.Failed($"Code generation failed: {ex.Message}");
+        }
+    }
+
+    private string GenerateValidationFunction(
+        SubschemaInfo subschemaInfo,
+        Dictionary<string, SubschemaInfo> allSchemas,
+        SchemaDraft detectedDraft,
+        SortedSet<string> runtimeImports)
+    {
+        var context = CreateContext(subschemaInfo, allSchemas, detectedDraft);
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"function validate_{subschemaInfo.Hash}(v) {{");
+
+        if (subschemaInfo.Schema.ValueKind == JsonValueKind.True)
+        {
+            sb.AppendLine("  return true;");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        if (subschemaInfo.Schema.ValueKind == JsonValueKind.False)
+        {
+            sb.AppendLine("  return false;");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        // Draft 7 and earlier: $ref overrides all sibling keywords.
+        var refMasksSiblings = detectedDraft <= SchemaDraft.Draft7
+            && subschemaInfo.Schema.ValueKind == JsonValueKind.Object
+            && subschemaInfo.Schema.TryGetProperty("$ref", out _);
+
+        foreach (var generator in _keywordGenerators)
+        {
+            if (refMasksSiblings && generator.Keyword != "$ref")
+            {
+                continue;
+            }
+
+            if (!generator.CanGenerate(subschemaInfo.Schema))
+            {
+                continue;
+            }
+
+            foreach (var import in generator.GetRuntimeImports(context))
+            {
+                runtimeImports.Add(import);
+            }
+
+            var code = generator.GenerateCode(context);
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                continue;
+            }
+
+            foreach (var line in code.Split('\n'))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    sb.AppendLine();
+                }
+                else
+                {
+                    sb.AppendLine($"  {line.TrimEnd()}");
+                }
+            }
+        }
+
+        sb.AppendLine("  return true;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private JsCodeGenerationContext CreateContext(
+        SubschemaInfo subschemaInfo,
+        Dictionary<string, SubschemaInfo> allSchemas,
+        SchemaDraft detectedDraft)
+    {
+        return new JsCodeGenerationContext
+        {
+            CurrentSchema = subschemaInfo.Schema,
+            CurrentHash = subschemaInfo.Hash,
+            GetSubschemaHash = element => SchemaHasher.ComputeHash(element),
+            ResolveLocalRef = refValue => _extractor.ResolveLocalRef(refValue),
+            GetSubschemaInfo = hash => allSchemas.TryGetValue(hash, out var info) ? info : null,
+            DetectedDraft = detectedDraft
+        };
+    }
+
+    private string GenerateModule(
+        string? schemaUri,
+        string rootHash,
+        string methods,
+        SortedSet<string> runtimeImports)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// @ts-check");
+        sb.AppendLine("// This code was generated by jsv-codegen (JS target).");
+        sb.AppendLine("// Do not edit this file manually.");
+        sb.AppendLine();
+
+        if (runtimeImports.Count > 0)
+        {
+            sb.Append("import { ");
+            sb.Append(string.Join(", ", runtimeImports));
+            sb.AppendLine($" }} from \"{EscapeString(RuntimeImportSpecifier)}\";");
+            sb.AppendLine();
+        }
+
+        sb.Append(methods);
+        sb.AppendLine();
+
+        sb.AppendLine("/**");
+        sb.AppendLine(" * Validates a JSON value against the compiled schema.");
+        sb.AppendLine(" * @param {unknown} data");
+        sb.AppendLine(" * @returns {boolean}");
+        sb.AppendLine(" */");
+        sb.AppendLine($"export function validate(data) {{ return validate_{rootHash}(data); }}");
+        sb.AppendLine();
+
+        var schemaUriLiteral = string.IsNullOrEmpty(schemaUri)
+            ? "null"
+            : $"\"{EscapeString(schemaUri)}\"";
+        sb.AppendLine($"export const schemaUri = {schemaUriLiteral};");
+        sb.AppendLine();
+
+        sb.AppendLine("export default { validate, schemaUri };");
+        return sb.ToString();
+    }
+
+    private static string? ExtractSchemaUri(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        if (schema.TryGetProperty("$id", out var idElement) && idElement.ValueKind == JsonValueKind.String)
+        {
+            return idElement.GetString();
+        }
+        if (schema.TryGetProperty("id", out var legacyIdElement) && legacyIdElement.ValueKind == JsonValueKind.String)
+        {
+            return legacyIdElement.GetString();
+        }
+        return null;
+    }
+
+    private static string DeriveFileName(string? schemaUri, string? sourcePath)
+    {
+        if (!string.IsNullOrEmpty(schemaUri))
+        {
+            var uri = new Uri(schemaUri);
+            var lastSegment = uri.Segments.LastOrDefault()?.TrimEnd('/');
+            if (!string.IsNullOrEmpty(lastSegment))
+            {
+                return $"{SanitizeFileName(Path.GetFileNameWithoutExtension(lastSegment))}.js";
+            }
+        }
+        if (!string.IsNullOrEmpty(sourcePath))
+        {
+            return $"{SanitizeFileName(Path.GetFileNameWithoutExtension(sourcePath))}.js";
+        }
+        return "validator.js";
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            sb.Append(char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '_');
+        }
+        return sb.Length > 0 ? sb.ToString() : "validator";
+    }
+
+    private static string EscapeString(string s)
+    {
+        return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
@@ -212,6 +212,9 @@ public sealed class JsSchemaCodeGenerator
             CurrentHash = subschemaInfo.Hash,
             GetSubschemaHash = element => SchemaHasher.ComputeHash(element),
             ResolveLocalRef = refValue => _extractor.ResolveLocalRef(refValue),
+            ResolveLocalRefInResource = (refValue, resourceRoot) =>
+                _extractor.ResolveLocalRefInResource(refValue, resourceRoot),
+            ResourceRoot = subschemaInfo.ResourceRoot,
             GetSubschemaInfo = hash => allSchemas.TryGetValue(hash, out var info) ? info : null,
             DetectedDraft = detectedDraft
         };
@@ -277,9 +280,13 @@ public sealed class JsSchemaCodeGenerator
 
     private static string DeriveFileName(string? schemaUri, string? sourcePath)
     {
-        if (!string.IsNullOrEmpty(schemaUri))
+        // Only derive from the URI when it's absolute and hierarchical; relative
+        // $ids like "person" or "schemas/person.json" are valid in JSON Schema but
+        // cannot be parsed as absolute URIs. Fall back to sourcePath in that case.
+        if (!string.IsNullOrEmpty(schemaUri) &&
+            Uri.TryCreate(schemaUri, UriKind.Absolute, out var uri) &&
+            uri.IsAbsoluteUri && !uri.IsFile)
         {
-            var uri = new Uri(schemaUri);
             var lastSegment = uri.Segments.LastOrDefault()?.TrimEnd('/');
             if (!string.IsNullOrEmpty(lastSegment))
             {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
@@ -168,10 +168,15 @@ public sealed class JsSchemaCodeGenerator
             return sb.ToString();
         }
 
-        // Draft 7 and earlier: $ref overrides all sibling keywords.
+        // Draft 7 and earlier: $ref overrides all sibling keywords — but only
+        // when $ref is a USABLE string. A $ref: "" or $ref: {} would otherwise
+        // mask every sibling without JsRefCodeGenerator emitting anything,
+        // compiling to an always-true validator.
         var refMasksSiblings = detectedDraft <= SchemaDraft.Draft7
             && subschemaInfo.Schema.ValueKind == JsonValueKind.Object
-            && subschemaInfo.Schema.TryGetProperty("$ref", out _);
+            && subschemaInfo.Schema.TryGetProperty("$ref", out var maskingRef)
+            && maskingRef.ValueKind == JsonValueKind.String
+            && !string.IsNullOrEmpty(maskingRef.GetString());
 
         foreach (var generator in _keywordGenerators)
         {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
@@ -236,7 +236,7 @@ public sealed class JsSchemaCodeGenerator
         {
             sb.Append("import { ");
             sb.Append(string.Join(", ", runtimeImports));
-            sb.AppendLine($" }} from \"{EscapeString(RuntimeImportSpecifier)}\";");
+            sb.AppendLine($" }} from {JsLiteral.String(RuntimeImportSpecifier)};");
             sb.AppendLine();
         }
 
@@ -253,7 +253,7 @@ public sealed class JsSchemaCodeGenerator
 
         var schemaUriLiteral = string.IsNullOrEmpty(schemaUri)
             ? "null"
-            : $"\"{EscapeString(schemaUri)}\"";
+            : JsLiteral.String(schemaUri);
         sb.AppendLine($"export const schemaUri = {schemaUriLiteral};");
         sb.AppendLine();
 
@@ -308,10 +308,5 @@ public sealed class JsSchemaCodeGenerator
             sb.Append(char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '_');
         }
         return sb.Length > 0 ? sb.ToString() : "validator";
-    }
-
-    private static string EscapeString(string s)
-    {
-        return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaCodeGenerator.cs
@@ -113,10 +113,23 @@ public sealed class JsSchemaCodeGenerator
             var uniqueSchemas = _extractor.ExtractUniqueSubschemas(schema, baseUri, DefaultDraft);
             var rootHash = SchemaHasher.ComputeHash(schema);
 
+            // Reachability pass: filter out subschemas reached only through
+            // annotation-only keywords (contentSchema, default, examples, ...) so
+            // we don't emit validators for them — those would run JS emitters on
+            // metadata and can legitimately fail (e.g., items-as-array in 2020-12
+            // inside contentSchema). Also detects ambiguous-resource ref collapse
+            // and rejects pre-emission.
+            var reach = JsSchemaReachability.Analyze(schema, detectedDraft, uniqueSchemas);
+            if (reach.Rejection != null)
+            {
+                return GenerationResult.Failed(reach.Rejection);
+            }
+
             var methods = new StringBuilder();
             var runtimeImports = new SortedSet<string>(StringComparer.Ordinal);
-            foreach (var (_, subschemaInfo) in uniqueSchemas)
+            foreach (var (hash, subschemaInfo) in uniqueSchemas)
             {
+                if (!reach.ReachableHashes.Contains(hash)) continue;
                 methods.AppendLine(GenerateValidationFunction(subschemaInfo, uniqueSchemas, detectedDraft, runtimeImports));
                 methods.AppendLine();
             }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.Common;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+
+/// <summary>
+/// Walks a schema using the JS target's own notion of applicator keywords
+/// (the same sets the capability gate uses), producing:
+///
+/// 1. The set of subschema hashes that are actually reachable from the root
+///    via JS-emittable keywords. Subschemas under annotation-only keywords
+///    like contentSchema, default, examples are excluded so they do not get
+///    turned into dead — and sometimes invalid — validator functions.
+///
+/// 2. A resource-root identity per hash, so we can detect when two text-
+///    identical ref-containing subschemas appear under different resource
+///    roots. The shared SubschemaExtractor deduplicates by content hash and
+///    keeps only the first resource root, which would make local-ref
+///    resolution resolve against the wrong resource at the second call site.
+///    The safest MVP behavior is to detect that case and reject the schema
+///    rather than silently validate against the wrong target.
+/// </summary>
+internal static class JsSchemaReachability
+{
+    // Keyword-shape sets kept in sync with JsCapabilityGate. Duplicated here
+    // rather than shared to avoid accidental gate-mutation coupling; these
+    // drive emission, the gate drives rejection.
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaValuedPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "additionalProperties",
+            "additionalItems",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "if", "then", "else",
+            "contains",
+            "additionalProperties",
+            "propertyNames",
+        },
+    };
+
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaArrayPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+            "prefixItems",
+        },
+    };
+
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaMapPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "definitions",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "$defs",
+            "dependentSchemas",
+        },
+    };
+
+    public sealed record Result(
+        HashSet<string> ReachableHashes,
+        string? Rejection);
+
+    public static Result Analyze(
+        JsonElement root,
+        SchemaDraft draft,
+        IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas)
+    {
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+        // Identity map: hash -> set of resource-root hashes under which this
+        // subschema was seen. A hash that shows up under more than one resource
+        // root AND contains a local $ref is the ambiguous case we reject.
+        var resourceRootsByHash = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+
+        string? rejection = null;
+        Walk(root, currentResourceRootHash: SchemaHasher.ComputeHash(root),
+            draft, reachable, resourceRootsByHash, ref rejection);
+
+        if (rejection != null)
+        {
+            return new Result(reachable, rejection);
+        }
+
+        // Second pass: flag ambiguous-resource ref-containing subschemas.
+        foreach (var (hash, resourceRoots) in resourceRootsByHash)
+        {
+            if (resourceRoots.Count <= 1) continue;
+            if (!uniqueSchemas.TryGetValue(hash, out var info)) continue;
+            if (info.Schema.ValueKind == JsonValueKind.Object &&
+                info.Schema.TryGetProperty("$ref", out var refElem) &&
+                refElem.ValueKind == JsonValueKind.String)
+            {
+                return new Result(reachable,
+                    "JS target MVP cannot safely compile a schema where an identical $ref-containing " +
+                    "subschema appears under multiple nested $id resources: the shared analyzer " +
+                    "collapses them by content hash, so the emitted validator would resolve the ref " +
+                    "against the wrong resource. Differentiate the subschemas (e.g., include the $id " +
+                    "in the containing object) or split the schema so each resource's refs are unique.");
+            }
+        }
+
+        return new Result(reachable, null);
+    }
+
+    private static void Walk(
+        JsonElement node,
+        string currentResourceRootHash,
+        SchemaDraft draft,
+        HashSet<string> reachable,
+        Dictionary<string, HashSet<string>> resourceRootsByHash,
+        ref string? rejection)
+    {
+        if (rejection != null) return;
+        if (node.ValueKind == JsonValueKind.True || node.ValueKind == JsonValueKind.False)
+        {
+            var boolHash = SchemaHasher.ComputeHash(node);
+            reachable.Add(boolHash);
+            RecordResourceRoot(resourceRootsByHash, boolHash, currentResourceRootHash);
+            return;
+        }
+        if (node.ValueKind != JsonValueKind.Object) return;
+
+        var hash = SchemaHasher.ComputeHash(node);
+        reachable.Add(hash);
+        RecordResourceRoot(resourceRootsByHash, hash, currentResourceRootHash);
+
+        // An $id on this object opens a new resource boundary.
+        var nextResourceRootHash = DetectResourceRootHash(node, currentResourceRootHash, draft);
+
+        var schemaValued = SchemaValuedPerDraft[draft];
+        var schemaArray = SchemaArrayPerDraft[draft];
+        var schemaMap = SchemaMapPerDraft[draft];
+
+        foreach (var prop in node.EnumerateObject())
+        {
+            // items: shape depends on draft.
+            if (prop.Name == "items")
+            {
+                if (draft == SchemaDraft.Draft4 && prop.Value.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var item in prop.Value.EnumerateArray())
+                    {
+                        Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                    }
+                }
+                else
+                {
+                    Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                }
+                continue;
+            }
+
+            // Draft 4 dependencies: schema-valued entries only.
+            if (prop.Name == "dependencies" && draft == SchemaDraft.Draft4 &&
+                prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var dep in prop.Value.EnumerateObject())
+                {
+                    if (dep.Value.ValueKind == JsonValueKind.Object ||
+                        dep.Value.ValueKind == JsonValueKind.True ||
+                        dep.Value.ValueKind == JsonValueKind.False)
+                    {
+                        Walk(dep.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                    }
+                }
+                continue;
+            }
+
+            if (schemaValued.Contains(prop.Name))
+            {
+                Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+            }
+            else if (schemaArray.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in prop.Value.EnumerateArray())
+                {
+                    Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                }
+            }
+            else if (schemaMap.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var entry in prop.Value.EnumerateObject())
+                {
+                    Walk(entry.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                }
+            }
+            // Data / annotation keywords (contentSchema, default, examples, enum,
+            // const, etc.) intentionally not walked — any subschema-shaped text
+            // inside them is annotation, not a validation applicator.
+        }
+    }
+
+    private static string DetectResourceRootHash(JsonElement node, string currentRootHash, SchemaDraft draft)
+    {
+        // Nested $id (Draft 2020-12) or id (Draft 4) opens a new resource.
+        var idKey = draft == SchemaDraft.Draft4 ? "id" : "$id";
+        if (node.TryGetProperty(idKey, out var idElem) && idElem.ValueKind == JsonValueKind.String)
+        {
+            return SchemaHasher.ComputeHash(node);
+        }
+        return currentRootHash;
+    }
+
+    private static void RecordResourceRoot(
+        Dictionary<string, HashSet<string>> map,
+        string subschemaHash,
+        string resourceRootHash)
+    {
+        if (!map.TryGetValue(subschemaHash, out var set))
+        {
+            set = new HashSet<string>(StringComparer.Ordinal);
+            map[subschemaHash] = set;
+        }
+        set.Add(resourceRootHash);
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
@@ -73,6 +73,7 @@ internal static class JsSchemaReachability
             "properties",
             "patternProperties",
             "$defs",
+            "definitions", // legacy keyword, still walked by SubschemaExtractor
             "dependentSchemas",
         },
     };

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
@@ -95,7 +95,7 @@ internal static class JsSchemaReachability
 
         string? rejection = null;
         Walk(root, currentResourceRootHash: SchemaHasher.ComputeHash(root),
-            draft, reachable, resourceRootsByHash, ref rejection);
+            draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
 
         if (rejection != null)
         {
@@ -129,7 +129,8 @@ internal static class JsSchemaReachability
         SchemaDraft draft,
         HashSet<string> reachable,
         Dictionary<string, HashSet<string>> resourceRootsByHash,
-        ref string? rejection)
+        ref string? rejection,
+        IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas)
     {
         if (rejection != null) return;
         if (node.ValueKind == JsonValueKind.True || node.ValueKind == JsonValueKind.False)
@@ -142,8 +143,35 @@ internal static class JsSchemaReachability
         if (node.ValueKind != JsonValueKind.Object) return;
 
         var hash = SchemaHasher.ComputeHash(node);
-        reachable.Add(hash);
+        // Early-return on revisit to break ref cycles safely.
+        if (!reachable.Add(hash))
+        {
+            RecordResourceRoot(resourceRootsByHash, hash, currentResourceRootHash);
+            return;
+        }
         RecordResourceRoot(resourceRootsByHash, hash, currentResourceRootHash);
+
+        // Follow local $ref to mark the referenced subschema reachable. Without
+        // this step a ref that targets a subschema under a non-applicator
+        // keyword (extension keywords, annotations) would never have a
+        // validate_<hash> function emitted, and the generated JS would raise
+        // ReferenceError at runtime. External refs are rejected by the gate.
+        if (node.TryGetProperty("$ref", out var refElem) &&
+            refElem.ValueKind == JsonValueKind.String)
+        {
+            var refValue = refElem.GetString();
+            if (!string.IsNullOrEmpty(refValue) && refValue.StartsWith('#'))
+            {
+                // Any collected subschema whose JsonPointerPath matches the ref
+                // is considered the target. If the target's subschema is in
+                // uniqueSchemas, walk it so it and its dependencies get marked.
+                var target = ResolveLocalRef(refValue, uniqueSchemas);
+                if (target.HasValue)
+                {
+                    Walk(target.Value, currentResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                }
+            }
+        }
 
         // An $id on this object opens a new resource boundary.
         var nextResourceRootHash = DetectResourceRootHash(node, currentResourceRootHash, draft);
@@ -161,12 +189,12 @@ internal static class JsSchemaReachability
                 {
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                        Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
                     }
                 }
                 else
                 {
-                    Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                    Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
                 }
                 continue;
             }
@@ -181,7 +209,7 @@ internal static class JsSchemaReachability
                         dep.Value.ValueKind == JsonValueKind.True ||
                         dep.Value.ValueKind == JsonValueKind.False)
                     {
-                        Walk(dep.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                        Walk(dep.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
                     }
                 }
                 continue;
@@ -189,26 +217,48 @@ internal static class JsSchemaReachability
 
             if (schemaValued.Contains(prop.Name))
             {
-                Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
             }
             else if (schemaArray.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Array)
             {
                 foreach (var item in prop.Value.EnumerateArray())
                 {
-                    Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                    Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
                 }
             }
             else if (schemaMap.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Object)
             {
                 foreach (var entry in prop.Value.EnumerateObject())
                 {
-                    Walk(entry.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection);
+                    Walk(entry.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
                 }
             }
             // Data / annotation keywords (contentSchema, default, examples, enum,
             // const, etc.) intentionally not walked — any subschema-shaped text
             // inside them is annotation, not a validation applicator.
         }
+    }
+
+    /// <summary>
+    /// Resolves a local JSON Pointer ref ("#/foo/bar") against the set of
+    /// already-extracted subschemas. Returns the target JsonElement when a
+    /// subschema's JsonPointerPath matches the ref's fragment, else null.
+    /// </summary>
+    private static JsonElement? ResolveLocalRef(
+        string refValue,
+        IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas)
+    {
+        if (string.IsNullOrEmpty(refValue) || !refValue.StartsWith('#')) return null;
+        var fragment = refValue.Substring(1); // strip leading '#'; empty means root
+        foreach (var info in uniqueSchemas.Values)
+        {
+            var path = info.JsonPointerPath ?? string.Empty;
+            if (path == fragment)
+            {
+                return info.Schema;
+            }
+        }
+        return null;
     }
 
     private static string DetectResourceRootHash(JsonElement node, string currentRootHash, SchemaDraft draft)

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsSchemaReachability.cs
@@ -93,14 +93,8 @@ internal static class JsSchemaReachability
         // root AND contains a local $ref is the ambiguous case we reject.
         var resourceRootsByHash = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
 
-        string? rejection = null;
         Walk(root, currentResourceRootHash: SchemaHasher.ComputeHash(root),
-            draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
-
-        if (rejection != null)
-        {
-            return new Result(reachable, rejection);
-        }
+            draft, reachable, resourceRootsByHash, uniqueSchemas);
 
         // Second pass: flag ambiguous-resource ref-containing subschemas.
         foreach (var (hash, resourceRoots) in resourceRootsByHash)
@@ -129,10 +123,8 @@ internal static class JsSchemaReachability
         SchemaDraft draft,
         HashSet<string> reachable,
         Dictionary<string, HashSet<string>> resourceRootsByHash,
-        ref string? rejection,
         IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas)
     {
-        if (rejection != null) return;
         if (node.ValueKind == JsonValueKind.True || node.ValueKind == JsonValueKind.False)
         {
             var boolHash = SchemaHasher.ComputeHash(node);
@@ -168,7 +160,7 @@ internal static class JsSchemaReachability
                 var target = ResolveLocalRef(refValue, uniqueSchemas);
                 if (target.HasValue)
                 {
-                    Walk(target.Value, currentResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                    Walk(target.Value, currentResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
                 }
             }
         }
@@ -189,12 +181,12 @@ internal static class JsSchemaReachability
                 {
                     foreach (var item in prop.Value.EnumerateArray())
                     {
-                        Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                        Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
                     }
                 }
                 else
                 {
-                    Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                    Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
                 }
                 continue;
             }
@@ -209,7 +201,7 @@ internal static class JsSchemaReachability
                         dep.Value.ValueKind == JsonValueKind.True ||
                         dep.Value.ValueKind == JsonValueKind.False)
                     {
-                        Walk(dep.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                        Walk(dep.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
                     }
                 }
                 continue;
@@ -217,20 +209,20 @@ internal static class JsSchemaReachability
 
             if (schemaValued.Contains(prop.Name))
             {
-                Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                Walk(prop.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
             }
             else if (schemaArray.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Array)
             {
                 foreach (var item in prop.Value.EnumerateArray())
                 {
-                    Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                    Walk(item, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
                 }
             }
             else if (schemaMap.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Object)
             {
                 foreach (var entry in prop.Value.EnumerateObject())
                 {
-                    Walk(entry.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, ref rejection, uniqueSchemas);
+                    Walk(entry.Value, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas);
                 }
             }
             // Data / annotation keywords (contentSchema, default, examples, enum,

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/JsonSchemaValidation.CodeGeneration.JavaScript.csproj
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/JsonSchemaValidation.CodeGeneration.JavaScript.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>FormFinch.JsonSchemaValidation.CodeGenerator</RootNamespace>
-    <AssemblyName>jsv-codegen</AssemblyName>
+    <RootNamespace>FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript</RootNamespace>
+    <AssemblyName>FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript</AssemblyName>
   </PropertyGroup>
   <PropertyGroup>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
@@ -13,6 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration\JsonSchemaValidation.CodeGeneration.csproj" />
-    <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration.JavaScript\JsonSchemaValidation.CodeGeneration.JavaScript.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Runtime\jsv-runtime.js" LogicalName="FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime.jsv-runtime.js" />
   </ItemGroup>
 </Project>

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/IJsKeywordCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/IJsKeywordCodeGenerator.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Interface for keyword-specific JavaScript code generators.
+/// Parallel to IKeywordCodeGenerator but emits ESM JavaScript instead of C#.
+/// </summary>
+public interface IJsKeywordCodeGenerator
+{
+    /// <summary>
+    /// The JSON Schema keyword this generator handles.
+    /// </summary>
+    string Keyword { get; }
+
+    /// <summary>
+    /// Priority for code generation. Higher values run first.
+    /// Type checks should run first (100), then constraints (50), then applicators (0).
+    /// </summary>
+    int Priority { get; }
+
+    /// <summary>
+    /// Returns true if this generator can handle the keyword in the given schema.
+    /// </summary>
+    bool CanGenerate(JsonElement schema);
+
+    /// <summary>
+    /// Generates validation code for the keyword.
+    /// </summary>
+    string GenerateCode(JsCodeGenerationContext context);
+
+    /// <summary>
+    /// Returns any helper imports required from the runtime module.
+    /// Consumed by the orchestrator to build a single deduplicated import statement.
+    /// </summary>
+    IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context);
+}
+
+/// <summary>
+/// Context provided to JavaScript keyword code generators.
+/// </summary>
+public sealed class JsCodeGenerationContext
+{
+    /// <summary>
+    /// The current schema being processed.
+    /// </summary>
+    public required JsonElement CurrentSchema { get; init; }
+
+    /// <summary>
+    /// The hash of the current schema.
+    /// </summary>
+    public required string CurrentHash { get; init; }
+
+    /// <summary>
+    /// Function to get the hash for a subschema.
+    /// </summary>
+    public required Func<JsonElement, string> GetSubschemaHash { get; init; }
+
+    /// <summary>
+    /// Function to resolve a local $ref (e.g., "#/$defs/foo") to the target schema.
+    /// Returns null if the reference cannot be resolved.
+    /// </summary>
+    public required Func<string, JsonElement?> ResolveLocalRef { get; init; }
+
+    /// <summary>
+    /// Function to resolve subschema metadata by hash.
+    /// </summary>
+    public required Func<string, SubschemaInfo?> GetSubschemaInfo { get; init; }
+
+    /// <summary>
+    /// The detected JSON Schema draft version for this schema.
+    /// Used to honor draft-specific keyword behavior.
+    /// </summary>
+    public SchemaDraft DetectedDraft { get; init; } = SchemaDraft.Draft202012;
+
+    /// <summary>
+    /// The JS expression for the element being validated (usually "v").
+    /// </summary>
+    public string ElementExpr { get; init; } = "v";
+
+    /// <summary>
+    /// Generates a call to validate a subschema with the current element expression.
+    /// </summary>
+    public string GenerateValidateCall(string hash)
+    {
+        return $"validate_{hash}({ElementExpr})";
+    }
+
+    /// <summary>
+    /// Generates a call to validate a subschema with a different element expression.
+    /// </summary>
+    public string GenerateValidateCallForExpr(string hash, string expr)
+    {
+        return $"validate_{hash}({expr})";
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/IJsKeywordCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/IJsKeywordCodeGenerator.cs
@@ -61,10 +61,24 @@ public sealed class JsCodeGenerationContext
     public required Func<JsonElement, string> GetSubschemaHash { get; init; }
 
     /// <summary>
-    /// Function to resolve a local $ref (e.g., "#/$defs/foo") to the target schema.
-    /// Returns null if the reference cannot be resolved.
+    /// Function to resolve a local $ref (e.g., "#/$defs/foo") to the target schema,
+    /// against the document root. Use ResolveLocalRefInResource when the current
+    /// subschema is inside a nested $id resource.
     /// </summary>
     public required Func<string, JsonElement?> ResolveLocalRef { get; init; }
+
+    /// <summary>
+    /// Function to resolve a local $ref within a specific schema resource.
+    /// Required for correct fragment resolution inside nested $id boundaries.
+    /// </summary>
+    public required Func<string, JsonElement, JsonElement?> ResolveLocalRefInResource { get; init; }
+
+    /// <summary>
+    /// The schema resource root for this subschema: the nearest ancestor with $id
+    /// (or id for Draft 4), or the document root if none. Used to scope local ref
+    /// resolution.
+    /// </summary>
+    public JsonElement? ResourceRoot { get; init; }
 
     /// <summary>
     /// Function to resolve subschema metadata by hash.

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsArrayConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsArrayConstraintsCodeGenerator.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for array constraint keywords: minItems, maxItems, uniqueItems.
+/// </summary>
+public sealed class JsArrayConstraintsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "minItems/maxItems/uniqueItems";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minItems", out _) ||
+               schema.TryGetProperty("maxItems", out _) ||
+               schema.TryGetProperty("uniqueItems", out _);
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minItems", out var minElem) &&
+                     TryGetIntegerValue(minElem, out var min);
+        var hasMax = schema.TryGetProperty("maxItems", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out var max);
+        var hasUnique = schema.TryGetProperty("uniqueItems", out var unElem) &&
+                        unElem.ValueKind == JsonValueKind.True;
+
+        if (!hasMin && !hasMax && !hasUnique) return string.Empty;
+
+        TryGetIntegerValue(minElem, out min);
+        TryGetIntegerValue(maxElem, out max);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        if (hasMin) sb.AppendLine($"  if ({v}.length < {min}) return false;");
+        if (hasMax) sb.AppendLine($"  if ({v}.length > {max}) return false;");
+        if (hasUnique)
+        {
+            sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+            sb.AppendLine($"    for (let _j = _i + 1; _j < {v}.length; _j++) {{");
+            sb.AppendLine($"      if (deepEquals({v}[_i], {v}[_j])) return false;");
+            sb.AppendLine($"    }}");
+            sb.AppendLine($"  }}");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (context.CurrentSchema.ValueKind == JsonValueKind.Object &&
+            context.CurrentSchema.TryGetProperty("uniqueItems", out var u) &&
+            u.ValueKind == JsonValueKind.True)
+        {
+            yield return "deepEquals";
+        }
+    }
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value)
+    {
+        value = 0;
+        if (element.ValueKind != JsonValueKind.Number) return false;
+        if (!element.TryGetDouble(out var d)) return false;
+        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
+        value = (long)d;
+        return true;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsArrayConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsArrayConstraintsCodeGenerator.cs
@@ -64,13 +64,6 @@ public sealed class JsArrayConstraintsCodeGenerator : IJsKeywordCodeGenerator
         }
     }
 
-    private static bool TryGetIntegerValue(JsonElement element, out long value)
-    {
-        value = 0;
-        if (element.ValueKind != JsonValueKind.Number) return false;
-        if (!element.TryGetDouble(out var d)) return false;
-        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
-        value = (long)d;
-        return true;
-    }
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        JsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsContainsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsContainsCodeGenerator.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "contains" keyword with minContains/maxContains.
+/// contains was introduced in Draft 6; minContains/maxContains in Draft 2019-09.
+/// Draft 4 (MVP support) does not have this keyword — emitter no-ops for Draft 4.
+/// </summary>
+public sealed class JsContainsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "contains";
+    public int Priority => 35;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object && schema.TryGetProperty("contains", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft6) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("contains", out var containsElem))
+        {
+            return string.Empty;
+        }
+
+        var hash = context.GetSubschemaHash(containsElem);
+        long min = 1;
+        long max = long.MaxValue;
+        if (context.DetectedDraft >= SchemaDraft.Draft201909)
+        {
+            if (context.CurrentSchema.TryGetProperty("minContains", out var minElem) &&
+                TryGetIntegerValue(minElem, out var mn)) min = mn;
+            if (context.CurrentSchema.TryGetProperty("maxContains", out var maxElem) &&
+                TryGetIntegerValue(maxElem, out var mx)) max = mx;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        sb.AppendLine("  let _count = 0;");
+        sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+        sb.AppendLine($"    if ({context.GenerateValidateCallForExpr(hash, $"{v}[_i]")}) {{");
+        sb.AppendLine("      _count++;");
+        if (max != long.MaxValue)
+        {
+            sb.AppendLine($"      if (_count > {max}) return false;");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine("  }");
+        sb.AppendLine($"  if (_count < {min}) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value)
+    {
+        value = 0;
+        if (element.ValueKind != JsonValueKind.Number) return false;
+        if (!element.TryGetDouble(out var d)) return false;
+        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
+        value = (long)d;
+        return true;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsContainsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsContainsCodeGenerator.cs
@@ -59,13 +59,6 @@ public sealed class JsContainsCodeGenerator : IJsKeywordCodeGenerator
 
     public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
 
-    private static bool TryGetIntegerValue(JsonElement element, out long value)
-    {
-        value = 0;
-        if (element.ValueKind != JsonValueKind.Number) return false;
-        if (!element.TryGetDouble(out var d)) return false;
-        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
-        value = (long)d;
-        return true;
-    }
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        JsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsDependentCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsDependentCodeGenerator.cs
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "dependentRequired" keyword (Draft 2019-09+).
+/// </summary>
+public sealed class JsDependentRequiredCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "dependentRequired";
+    public int Priority => 55;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("dependentRequired", out var d) &&
+        d.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft201909) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("dependentRequired", out var depElem) ||
+            depElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+        return EmitDependentRequired(context.ElementExpr, depElem);
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+
+    internal static string EmitDependentRequired(string v, JsonElement depElem)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var dep in depElem.EnumerateObject())
+        {
+            if (dep.Value.ValueKind != JsonValueKind.Array) continue;
+            var trigger = JsLiteral.String(dep.Name);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {trigger})) {{");
+            foreach (var required in dep.Value.EnumerateArray())
+            {
+                if (required.ValueKind != JsonValueKind.String) continue;
+                sb.AppendLine($"    if (!Object.prototype.hasOwnProperty.call({v}, {JsLiteral.String(required.GetString()!)})) return false;");
+            }
+            sb.AppendLine("  }");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Generates JavaScript code for the "dependentSchemas" keyword (Draft 2019-09+).
+/// </summary>
+public sealed class JsDependentSchemasCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "dependentSchemas";
+    public int Priority => 55;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("dependentSchemas", out var d) &&
+        d.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft201909) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("dependentSchemas", out var depElem) ||
+            depElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+        return EmitDependentSchemas(context, depElem);
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+
+    internal static string EmitDependentSchemas(JsCodeGenerationContext context, JsonElement depElem)
+    {
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var dep in depElem.EnumerateObject())
+        {
+            var trigger = JsLiteral.String(dep.Name);
+            var hash = context.GetSubschemaHash(dep.Value);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {trigger})) {{");
+            sb.AppendLine($"    if (!{context.GenerateValidateCall(hash)}) return false;");
+            sb.AppendLine("  }");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Generates JavaScript code for the "dependencies" keyword (Draft 4-7).
+/// In Draft 4-7, each dependency value can be an array of required property names
+/// or a schema — the combined form later split into dependentRequired/dependentSchemas.
+/// </summary>
+public sealed class JsDependenciesCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "dependencies";
+    public int Priority => 55;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("dependencies", out var d) &&
+        d.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft > SchemaDraft.Draft7) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("dependencies", out var depElem) ||
+            depElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var dep in depElem.EnumerateObject())
+        {
+            var trigger = JsLiteral.String(dep.Name);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {trigger})) {{");
+            if (dep.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var required in dep.Value.EnumerateArray())
+                {
+                    if (required.ValueKind != JsonValueKind.String) continue;
+                    sb.AppendLine($"    if (!Object.prototype.hasOwnProperty.call({v}, {JsLiteral.String(required.GetString()!)})) return false;");
+                }
+            }
+            else
+            {
+                var hash = context.GetSubschemaHash(dep.Value);
+                sb.AppendLine($"    if (!{context.GenerateValidateCall(hash)}) return false;");
+            }
+            sb.AppendLine("  }");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsEnumConstCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsEnumConstCodeGenerator.cs
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "enum" keyword.
+/// Uses the runtime deepEquals helper for structural comparison.
+/// </summary>
+public sealed class JsEnumCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "enum";
+    public int Priority => 80;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("enum", out var e) &&
+               e.ValueKind == JsonValueKind.Array;
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("enum", out var enumElem) ||
+            enumElem.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var checks = new List<string>();
+        foreach (var item in enumElem.EnumerateArray())
+        {
+            checks.Add($"deepEquals({v}, {item.GetRawText()})");
+        }
+        if (checks.Count == 0)
+        {
+            // Empty enum never matches.
+            return "return false;";
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("if (!(");
+        sb.Append(string.Join(" || ", checks));
+        sb.AppendLine(")) return false;");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (context.CurrentSchema.ValueKind == JsonValueKind.Object &&
+            context.CurrentSchema.TryGetProperty("enum", out var e) &&
+            e.ValueKind == JsonValueKind.Array &&
+            e.GetArrayLength() > 0)
+        {
+            yield return "deepEquals";
+        }
+    }
+}
+
+/// <summary>
+/// Generates JavaScript code for the "const" keyword.
+/// </summary>
+public sealed class JsConstCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "const";
+    public int Priority => 80;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("const", out _);
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("const", out var constElem))
+        {
+            return string.Empty;
+        }
+        var v = context.ElementExpr;
+        return $"if (!deepEquals({v}, {constElem.GetRawText()})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        yield return "deepEquals";
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsEnumConstCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsEnumConstCodeGenerator.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 using System.Text;
 using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
 
 namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 
@@ -77,6 +78,9 @@ public sealed class JsConstCodeGenerator : IJsKeywordCodeGenerator
 
     public string GenerateCode(JsCodeGenerationContext context)
     {
+        // const was introduced in Draft 6; for Draft 4 it is an unknown keyword
+        // and must be ignored (annotation-only), not enforced.
+        if (context.DetectedDraft < SchemaDraft.Draft6) return string.Empty;
         if (!context.CurrentSchema.TryGetProperty("const", out var constElem))
         {
             return string.Empty;
@@ -87,6 +91,7 @@ public sealed class JsConstCodeGenerator : IJsKeywordCodeGenerator
 
     public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
     {
+        if (context.DetectedDraft < SchemaDraft.Draft6) yield break;
         yield return "deepEquals";
     }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsEnumConstCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsEnumConstCodeGenerator.cs
@@ -35,7 +35,7 @@ public sealed class JsEnumCodeGenerator : IJsKeywordCodeGenerator
         var checks = new List<string>();
         foreach (var item in enumElem.EnumerateArray())
         {
-            checks.Add($"deepEquals({v}, {item.GetRawText()})");
+            checks.Add($"deepEquals({v}, {JsLiteral.JsonAsExpression(item)})");
         }
         if (checks.Count == 0)
         {
@@ -86,7 +86,7 @@ public sealed class JsConstCodeGenerator : IJsKeywordCodeGenerator
             return string.Empty;
         }
         var v = context.ElementExpr;
-        return $"if (!deepEquals({v}, {constElem.GetRawText()})) return false;";
+        return $"if (!deepEquals({v}, {JsLiteral.JsonAsExpression(constElem)})) return false;";
     }
 
     public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsFormatCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsFormatCodeGenerator.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "format" keyword.
+/// Matches the C# compiled path: eager validation for formats supported by the
+/// detected draft. Unsupported formats for a draft are treated as annotations
+/// (no validation emitted) per spec.
+/// </summary>
+public sealed class JsFormatCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "format";
+    public int Priority => 40;
+
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SupportedFormatsByDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "date-time", "email", "hostname", "ipv4", "ipv6", "uri",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "date-time", "date", "time", "duration",
+            "email", "idn-email",
+            "hostname", "idn-hostname",
+            "ipv4", "ipv6",
+            "uri", "uri-reference", "uri-template",
+            "iri", "iri-reference",
+            "json-pointer", "relative-json-pointer",
+            "regex", "uuid",
+        },
+    };
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        if (!schema.TryGetProperty("format", out var f)) return false;
+        return f.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(f.GetString());
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("format", out var formatElem)) return string.Empty;
+        var format = formatElem.GetString();
+        if (string.IsNullOrEmpty(format)) return string.Empty;
+
+        if (!SupportedFormatsByDraft.TryGetValue(context.DetectedDraft, out var supported) ||
+            !supported.Contains(format))
+        {
+            return string.Empty; // annotation-only for this draft
+        }
+
+        var importName = MapFormatToImport(format);
+        if (importName == null) return string.Empty;
+        var v = context.ElementExpr;
+        return $"if (!{importName}({v})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("format", out var formatElem) ||
+            formatElem.ValueKind != JsonValueKind.String)
+        {
+            yield break;
+        }
+        var format = formatElem.GetString();
+        if (string.IsNullOrEmpty(format)) yield break;
+
+        if (!SupportedFormatsByDraft.TryGetValue(context.DetectedDraft, out var supported) ||
+            !supported.Contains(format))
+        {
+            yield break;
+        }
+        var importName = MapFormatToImport(format);
+        if (importName != null) yield return importName;
+    }
+
+    private static string? MapFormatToImport(string format) => format switch
+    {
+        "date-time" => "isValidDateTime",
+        "date" => "isValidDate",
+        "time" => "isValidTime",
+        "duration" => "isValidDuration",
+        "email" => "isValidEmail",
+        "idn-email" => "isValidIdnEmail",
+        "hostname" => "isValidHostname",
+        "idn-hostname" => "isValidIdnHostname",
+        "ipv4" => "isValidIpv4",
+        "ipv6" => "isValidIpv6",
+        "uri" => "isValidUri",
+        "uri-reference" => "isValidUriReference",
+        "uri-template" => "isValidUriTemplate",
+        "iri" => "isValidIri",
+        "iri-reference" => "isValidIriReference",
+        "json-pointer" => "isValidJsonPointer",
+        "relative-json-pointer" => "isValidRelativeJsonPointer",
+        "regex" => "isValidRegex",
+        "uuid" => "isValidUuid",
+        _ => null,
+    };
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsIfThenElseCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsIfThenElseCodeGenerator.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "if"/"then"/"else" keywords (Draft 7+).
+/// </summary>
+public sealed class JsIfThenElseCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "if/then/else";
+    public int Priority => 25;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("if", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        var schema = context.CurrentSchema;
+        if (!schema.TryGetProperty("if", out var ifElem))
+        {
+            return string.Empty;
+        }
+        var hasThen = schema.TryGetProperty("then", out var thenElem);
+        var hasElse = schema.TryGetProperty("else", out var elseElem);
+        if (!hasThen && !hasElse) return string.Empty;
+
+        var ifHash = context.GetSubschemaHash(ifElem);
+        var sb = new StringBuilder();
+        sb.AppendLine($"if ({context.GenerateValidateCall(ifHash)}) {{");
+        if (hasThen)
+        {
+            var thenHash = context.GetSubschemaHash(thenElem);
+            sb.AppendLine($"  if (!{context.GenerateValidateCall(thenHash)}) return false;");
+        }
+        sb.AppendLine("} else {");
+        if (hasElse)
+        {
+            var elseHash = context.GetSubschemaHash(elseElem);
+            sb.AppendLine($"  if (!{context.GenerateValidateCall(elseHash)}) return false;");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsIfThenElseCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsIfThenElseCodeGenerator.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 using System.Text;
 using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
 
 namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 
@@ -20,6 +21,8 @@ public sealed class JsIfThenElseCodeGenerator : IJsKeywordCodeGenerator
 
     public string GenerateCode(JsCodeGenerationContext context)
     {
+        // if/then/else were introduced in Draft 7; earlier drafts must ignore them.
+        if (context.DetectedDraft < SchemaDraft.Draft7) return string.Empty;
         var schema = context.CurrentSchema;
         if (!schema.TryGetProperty("if", out var ifElem))
         {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
@@ -33,7 +33,15 @@ public sealed class JsItemsCodeGenerator : IJsKeywordCodeGenerator
 
     private static string GenerateDraft202012(JsCodeGenerationContext ctx, JsonElement items)
     {
-        if (items.ValueKind == JsonValueKind.Array) return string.Empty; // invalid in 2020-12
+        if (items.ValueKind == JsonValueKind.Array)
+        {
+            // Draft 2020-12 replaced the tuple form of items with prefixItems.
+            // Silently no-opping would let an invalid schema compile too loosely,
+            // so surface this as a generation failure (matches dynamic validator).
+            throw new InvalidOperationException(
+                "Schema uses array-form \"items\" under Draft 2020-12. " +
+                "Use \"prefixItems\" for tuple validation in 2020-12; \"items\" must be a single schema.");
+        }
         var hash = ctx.GetSubschemaHash(items);
         var v = ctx.ElementExpr;
         var prefixCount = 0;

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
@@ -10,7 +10,10 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 /// <summary>
 /// Generates JavaScript code for the "items" keyword.
 /// Draft 2020-12: items is a single schema applying to indices >= prefixItems count.
-/// Draft 4 + 2019-09 (MVP support): items is either a single schema or an array (tuple).
+/// Draft 4 (MVP's other supported draft): items is either a single schema or an
+/// array (tuple validation). The array-form branch also matches Draft 2019-09
+/// keyword semantics at the code level, but Draft 2019-09 is rejected by
+/// JsCapabilityGate for the JS target.
 /// </summary>
 public sealed class JsItemsCodeGenerator : IJsKeywordCodeGenerator
 {
@@ -135,7 +138,9 @@ public sealed class JsPrefixItemsCodeGenerator : IJsKeywordCodeGenerator
 }
 
 /// <summary>
-/// Generates JavaScript code for the "additionalItems" keyword (Draft 4 + 2019-09).
+/// Generates JavaScript code for the "additionalItems" keyword (Draft 4 in the JS
+/// target; also applies to Draft 2019-09 semantically but that draft is rejected
+/// by JsCapabilityGate, so this generator only fires for Draft 4 schemas here).
 /// Removed in Draft 2020-12. Only meaningful when items is an array (tuple validation).
 /// </summary>
 public sealed class JsAdditionalItemsCodeGenerator : IJsKeywordCodeGenerator

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
@@ -175,6 +175,15 @@ public sealed class JsAdditionalItemsCodeGenerator : IJsKeywordCodeGenerator
         {
             return string.Empty;
         }
+        if (additional.ValueKind != JsonValueKind.Object)
+        {
+            // Invalid schema: additionalItems must be object/boolean per spec.
+            // SubschemaExtractor skips non-schema values, so emitting a
+            // validate_<hash> call would be undefined at runtime.
+            throw new InvalidOperationException(
+                "Schema's \"additionalItems\" value must be an object or boolean; got " +
+                $"{additional.ValueKind}.");
+        }
         var hash = context.GetSubschemaHash(additional);
         var sb = new StringBuilder();
         sb.AppendLine($"if (Array.isArray({v})) {{");

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsItemsCodeGenerator.cs
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "items" keyword.
+/// Draft 2020-12: items is a single schema applying to indices >= prefixItems count.
+/// Draft 4 + 2019-09 (MVP support): items is either a single schema or an array (tuple).
+/// </summary>
+public sealed class JsItemsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "items";
+    public int Priority => 40;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object && schema.TryGetProperty("items", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("items", out var items))
+        {
+            return string.Empty;
+        }
+        return context.DetectedDraft == SchemaDraft.Draft202012
+            ? GenerateDraft202012(context, items)
+            : GenerateLegacy(context, items);
+    }
+
+    private static string GenerateDraft202012(JsCodeGenerationContext ctx, JsonElement items)
+    {
+        if (items.ValueKind == JsonValueKind.Array) return string.Empty; // invalid in 2020-12
+        var hash = ctx.GetSubschemaHash(items);
+        var v = ctx.ElementExpr;
+        var prefixCount = 0;
+        if (ctx.CurrentSchema.TryGetProperty("prefixItems", out var prefixItems) &&
+            prefixItems.ValueKind == JsonValueKind.Array)
+        {
+            prefixCount = prefixItems.GetArrayLength();
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        sb.AppendLine($"  for (let _i = {prefixCount}; _i < {v}.length; _i++) {{");
+        sb.AppendLine($"    if (!{ctx.GenerateValidateCallForExpr(hash, $"{v}[_i]")}) return false;");
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GenerateLegacy(JsCodeGenerationContext ctx, JsonElement items)
+    {
+        var v = ctx.ElementExpr;
+        if (items.ValueKind == JsonValueKind.Array)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            var idx = 0;
+            foreach (var sub in items.EnumerateArray())
+            {
+                var hash = ctx.GetSubschemaHash(sub);
+                sb.AppendLine($"  if ({v}.length > {idx} && !{ctx.GenerateValidateCallForExpr(hash, $"{v}[{idx}]")}) return false;");
+                idx++;
+            }
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        if (items.ValueKind == JsonValueKind.Object ||
+            items.ValueKind == JsonValueKind.True ||
+            items.ValueKind == JsonValueKind.False)
+        {
+            var hash = ctx.GetSubschemaHash(items);
+            var sb = new StringBuilder();
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+            sb.AppendLine($"    if (!{ctx.GenerateValidateCallForExpr(hash, $"{v}[_i]")}) return false;");
+            sb.AppendLine("  }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        return string.Empty;
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates JavaScript code for the "prefixItems" keyword (Draft 2020-12 only).
+/// </summary>
+public sealed class JsPrefixItemsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "prefixItems";
+    public int Priority => 45;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("prefixItems", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft != SchemaDraft.Draft202012) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("prefixItems", out var prefix) ||
+            prefix.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        var idx = 0;
+        foreach (var sub in prefix.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            sb.AppendLine($"  if ({v}.length > {idx} && !{context.GenerateValidateCallForExpr(hash, $"{v}[{idx}]")}) return false;");
+            idx++;
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates JavaScript code for the "additionalItems" keyword (Draft 4 + 2019-09).
+/// Removed in Draft 2020-12. Only meaningful when items is an array (tuple validation).
+/// </summary>
+public sealed class JsAdditionalItemsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "additionalItems";
+    public int Priority => 42;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("additionalItems", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft == SchemaDraft.Draft202012) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("additionalItems", out var additional))
+        {
+            return string.Empty;
+        }
+        if (!context.CurrentSchema.TryGetProperty("items", out var items) ||
+            items.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var tupleLen = items.GetArrayLength();
+        var v = context.ElementExpr;
+
+        if (additional.ValueKind == JsonValueKind.False)
+        {
+            return $"if (Array.isArray({v}) && {v}.length > {tupleLen}) return false;";
+        }
+        if (additional.ValueKind == JsonValueKind.True)
+        {
+            return string.Empty;
+        }
+        var hash = context.GetSubschemaHash(additional);
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        sb.AppendLine($"  for (let _i = {tupleLen}; _i < {v}.length; _i++) {{");
+        sb.AppendLine($"    if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_i]")}) return false;");
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
@@ -12,6 +12,14 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 /// </summary>
 internal static class JsLiteral
 {
+    // U+2028 / U+2029 referenced via hex to keep them out of the C# source itself:
+    // both code points are line terminators in the C# lexer too, so embedding them
+    // inline breaks character-literal parsing.
+    private const char LineSeparator = (char)0x2028;
+    private const char ParagraphSeparator = (char)0x2029;
+    private const string LineSeparatorEscape = "\\u2028";
+    private const string ParagraphSeparatorEscape = "\\u2029";
+
     /// <summary>
     /// Emits a JavaScript double-quoted string literal, including delimiters.
     /// Escapes the characters needed for JS source safety.
@@ -31,8 +39,8 @@ internal static class JsLiteral
                 case '\t': sb.Append("\\t"); break;
                 case '\f': sb.Append("\\f"); break;
                 case '\b': sb.Append("\\b"); break;
-                case '\u2028': sb.Append("\\u2028"); break; // LINE SEPARATOR — legal in ES2019+ strings, escaped for toolchain/legacy safety
-                case '\u2029': sb.Append("\\u2029"); break; // PARAGRAPH SEPARATOR — legal in ES2019+ strings, escaped for toolchain/legacy safety
+                case LineSeparator: sb.Append(LineSeparatorEscape); break;
+                case ParagraphSeparator: sb.Append(ParagraphSeparatorEscape); break;
                 default:
                     if (c < 0x20)
                     {
@@ -52,67 +60,32 @@ internal static class JsLiteral
     /// <summary>
     /// Emits a JSON element as a JavaScript expression literal. Starts from the raw
     /// JSON text (which is always valid JS grammar) and escapes U+2028/U+2029 inside
-    /// string literals — those code points are legal in JSON strings but were illegal
+    /// string literals. Those code points are legal in JSON strings but were illegal
     /// in JS string literals pre-ES2019, and some tooling still chokes on them.
     /// Literal control characters inside strings are impossible (JSON forbids them).
     /// </summary>
     public static string JsonAsExpression(System.Text.Json.JsonElement element)
     {
         var raw = element.GetRawText();
-        if (raw.IndexOf('\u2028') < 0 && raw.IndexOf('\u2029') < 0)
+        if (raw.IndexOf(LineSeparator) < 0 && raw.IndexOf(ParagraphSeparator) < 0)
         {
             return raw;
         }
-        // Both escape sequences are valid in JSON and JS, so replacing the literal
-        // code points with their \uXXXX form preserves semantics in both grammars.
-        return raw.Replace("\u2028", "\\u2028").Replace("\u2029", "\\u2029");
+        return raw
+            .Replace(LineSeparator.ToString(), LineSeparatorEscape)
+            .Replace(ParagraphSeparator.ToString(), ParagraphSeparatorEscape);
     }
 
     /// <summary>
-    /// Emits a JavaScript regex literal like /pattern/ with appropriate escaping of
-    /// characters that would terminate the literal or be interpreted as line breaks.
-    /// Does not rewrite the regex grammar — the pattern is assumed to be ECMAScript.
+    /// Emits a JavaScript RegExp construction expression as <c>new RegExp("pattern")</c>.
+    /// Avoids the <c>/pattern/</c> literal form because certain pattern prefixes
+    /// (most famously a leading asterisk) tokenize as block-comment or other
+    /// invalid syntax and would break module parsing. Invalid ECMAScript regex
+    /// grammar surfaces at RegExp construction time rather than as a JS parse
+    /// error, which is a friendlier failure mode for consumers.
     /// </summary>
     public static string RegexLiteral(string pattern)
     {
-        var sb = new StringBuilder(pattern.Length + 2);
-        sb.Append('/');
-        var escapedNext = false;
-        foreach (var c in pattern)
-        {
-            if (escapedNext)
-            {
-                sb.Append(c);
-                escapedNext = false;
-                continue;
-            }
-            switch (c)
-            {
-                case '\\':
-                    sb.Append('\\');
-                    escapedNext = true;
-                    break;
-                case '/':
-                    sb.Append("\\/");
-                    break;
-                case '\n':
-                    sb.Append("\\n");
-                    break;
-                case '\r':
-                    sb.Append("\\r");
-                    break;
-                case '\u2028':
-                    sb.Append("\\u2028");
-                    break;
-                case '\u2029':
-                    sb.Append("\\u2029");
-                    break;
-                default:
-                    sb.Append(c);
-                    break;
-            }
-        }
-        sb.Append('/');
-        return sb.ToString();
+        return $"new RegExp({String(pattern)})";
     }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
@@ -50,6 +50,25 @@ internal static class JsLiteral
     }
 
     /// <summary>
+    /// Emits a JSON element as a JavaScript expression literal. Starts from the raw
+    /// JSON text (which is always valid JS grammar) and escapes U+2028/U+2029 inside
+    /// string literals — those code points are legal in JSON strings but were illegal
+    /// in JS string literals pre-ES2019, and some tooling still chokes on them.
+    /// Literal control characters inside strings are impossible (JSON forbids them).
+    /// </summary>
+    public static string JsonAsExpression(System.Text.Json.JsonElement element)
+    {
+        var raw = element.GetRawText();
+        if (raw.IndexOf('\u2028') < 0 && raw.IndexOf('\u2029') < 0)
+        {
+            return raw;
+        }
+        // Both escape sequences are valid in JSON and JS, so replacing the literal
+        // code points with their \uXXXX form preserves semantics in both grammars.
+        return raw.Replace("\u2028", "\\u2028").Replace("\u2029", "\\u2029");
+    }
+
+    /// <summary>
     /// Emits a JavaScript regex literal like /pattern/ with appropriate escaping of
     /// characters that would terminate the literal or be interpreted as line breaks.
     /// Does not rewrite the regex grammar — the pattern is assumed to be ECMAScript.

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Globalization;
+using System.Text;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// JavaScript source-literal helpers used by keyword emitters.
+/// Centralises escaping so every emitter produces syntactically safe output.
+/// </summary>
+internal static class JsLiteral
+{
+    /// <summary>
+    /// Emits a JavaScript double-quoted string literal, including delimiters.
+    /// Escapes the characters needed for JS source safety.
+    /// </summary>
+    public static string String(string value)
+    {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\u2028': sb.Append("\\u2028"); break; // LINE SEPARATOR — invalid in JS strings
+                case '\u2029': sb.Append("\\u2029"); break; // PARAGRAPH SEPARATOR — invalid in JS strings
+                default:
+                    if (c < 0x20)
+                    {
+                        sb.Append("\\u").Append(((int)c).ToString("X4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                    break;
+            }
+        }
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emits a JavaScript regex literal like /pattern/ with appropriate escaping of
+    /// characters that would terminate the literal or be interpreted as line breaks.
+    /// Does not rewrite the regex grammar — the pattern is assumed to be ECMAScript.
+    /// </summary>
+    public static string RegexLiteral(string pattern)
+    {
+        var sb = new StringBuilder(pattern.Length + 2);
+        sb.Append('/');
+        var escapedNext = false;
+        foreach (var c in pattern)
+        {
+            if (escapedNext)
+            {
+                sb.Append(c);
+                escapedNext = false;
+                continue;
+            }
+            switch (c)
+            {
+                case '\\':
+                    sb.Append('\\');
+                    escapedNext = true;
+                    break;
+                case '/':
+                    sb.Append("\\/");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\u2028':
+                    sb.Append("\\u2028");
+                    break;
+                case '\u2029':
+                    sb.Append("\\u2029");
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+        sb.Append('/');
+        return sb.ToString();
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
@@ -31,8 +31,8 @@ internal static class JsLiteral
                 case '\t': sb.Append("\\t"); break;
                 case '\f': sb.Append("\\f"); break;
                 case '\b': sb.Append("\\b"); break;
-                case '\u2028': sb.Append("\\u2028"); break; // LINE SEPARATOR — invalid in JS strings
-                case '\u2029': sb.Append("\\u2029"); break; // PARAGRAPH SEPARATOR — invalid in JS strings
+                case '\u2028': sb.Append("\\u2028"); break; // LINE SEPARATOR — legal in ES2019+ strings, escaped for toolchain/legacy safety
+                case '\u2029': sb.Append("\\u2029"); break; // PARAGRAPH SEPARATOR — legal in ES2019+ strings, escaped for toolchain/legacy safety
                 default:
                     if (c < 0x20)
                     {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLogicKeywordsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLogicKeywordsCodeGenerator.cs
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "allOf" keyword.
+/// </summary>
+public sealed class JsAllOfCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "allOf";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("allOf", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("allOf", out var allOf) ||
+            allOf.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var sb = new StringBuilder();
+        foreach (var sub in allOf.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            sb.AppendLine($"if (!{context.GenerateValidateCall(hash)}) return false;");
+        }
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates JavaScript code for the "anyOf" keyword.
+/// </summary>
+public sealed class JsAnyOfCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "anyOf";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("anyOf", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("anyOf", out var anyOf) ||
+            anyOf.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var checks = new List<string>();
+        foreach (var sub in anyOf.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            checks.Add(context.GenerateValidateCall(hash));
+        }
+        if (checks.Count == 0) return string.Empty;
+        return $"if (!({string.Join(" || ", checks)})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates JavaScript code for the "oneOf" keyword.
+/// </summary>
+public sealed class JsOneOfCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "oneOf";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("oneOf", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("oneOf", out var oneOf) ||
+            oneOf.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine("  let _matches = 0;");
+        foreach (var sub in oneOf.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            sb.AppendLine($"  if ({context.GenerateValidateCall(hash)}) _matches++;");
+            sb.AppendLine("  if (_matches > 1) return false;");
+        }
+        sb.AppendLine("  if (_matches !== 1) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates JavaScript code for the "not" keyword.
+/// </summary>
+public sealed class JsNotCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "not";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("not", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("not", out var notElem))
+        {
+            return string.Empty;
+        }
+        var hash = context.GetSubschemaHash(notElem);
+        return $"if ({context.GenerateValidateCall(hash)}) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsNumericConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsNumericConstraintsCodeGenerator.cs
@@ -83,13 +83,17 @@ public sealed class JsNumericConstraintsCodeGenerator : IJsKeywordCodeGenerator
 
         if (hasMul && mulElem.TryGetDouble(out var mul) && mul != 0)
         {
+            // Tolerance: C# compiled path uses double.Epsilon (~4.9e-324 — the
+            // smallest positive denormal). The JS equivalent is Number.MIN_VALUE,
+            // not Number.EPSILON (~2.22e-16). Using EPSILON would be much more
+            // lenient and diverge from C# verdicts on near-multiple edge cases.
             var divisor = Fmt(mul);
             sb.AppendLine($"  {{");
-            sb.AppendLine($"    if (Math.abs({v} % {divisor}) >= Number.EPSILON) {{");
+            sb.AppendLine($"    if (Math.abs({v} % {divisor}) >= Number.MIN_VALUE) {{");
             sb.AppendLine($"      let _q = {v} / {divisor};");
-            sb.AppendLine($"      if (!(!isFinite(_q) && Math.abs({v} % 1) < Number.EPSILON && Math.abs(1 % {divisor}) < Number.EPSILON)) {{");
+            sb.AppendLine($"      if (!(!isFinite(_q) && Math.abs({v} % 1) < Number.MIN_VALUE && Math.abs(1 % {divisor}) < Number.MIN_VALUE)) {{");
             sb.AppendLine($"        _q = Math.round((_q + 0.000001) * 100) / 100;");
-            sb.AppendLine($"        if (!(Math.abs(_q - Math.round(_q)) < Number.EPSILON)) return false;");
+            sb.AppendLine($"        if (!(Math.abs(_q - Math.round(_q)) < Number.MIN_VALUE)) return false;");
             sb.AppendLine($"      }}");
             sb.AppendLine($"    }}");
             sb.AppendLine($"  }}");

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsNumericConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsNumericConstraintsCodeGenerator.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for numeric constraint keywords:
+/// minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf.
+/// Handles Draft 4's boolean exclusiveMinimum/exclusiveMaximum form by pairing
+/// with the sibling minimum/maximum value.
+/// multipleOf mirrors the C# compiled path's IEEE-754 quotient-snapping logic.
+/// </summary>
+public sealed class JsNumericConstraintsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "minimum/maximum/exclusiveMinimum/exclusiveMaximum/multipleOf";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minimum", out _) ||
+               schema.TryGetProperty("maximum", out _) ||
+               schema.TryGetProperty("exclusiveMinimum", out _) ||
+               schema.TryGetProperty("exclusiveMaximum", out _) ||
+               schema.TryGetProperty("multipleOf", out _);
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minimum", out var minElem);
+        var hasMax = schema.TryGetProperty("maximum", out var maxElem);
+        var hasExMin = schema.TryGetProperty("exclusiveMinimum", out var exMinElem);
+        var hasExMax = schema.TryGetProperty("exclusiveMaximum", out var exMaxElem);
+        var hasMul = schema.TryGetProperty("multipleOf", out var mulElem);
+
+        if (!hasMin && !hasMax && !hasExMin && !hasExMax && !hasMul) return string.Empty;
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"number\") {{");
+
+        if (hasMin && minElem.TryGetDouble(out var min))
+        {
+            sb.AppendLine($"  if ({v} < {Fmt(min)}) return false;");
+        }
+        if (hasMax && maxElem.TryGetDouble(out var max))
+        {
+            sb.AppendLine($"  if ({v} > {Fmt(max)}) return false;");
+        }
+
+        if (hasExMin)
+        {
+            if (exMinElem.ValueKind == JsonValueKind.Number && exMinElem.TryGetDouble(out var exMin))
+            {
+                sb.AppendLine($"  if ({v} <= {Fmt(exMin)}) return false;");
+            }
+            else if (exMinElem.ValueKind == JsonValueKind.True && hasMin && minElem.TryGetDouble(out var minVal))
+            {
+                // Draft 4: exclusiveMinimum: true alongside minimum.
+                sb.AppendLine($"  if ({v} <= {Fmt(minVal)}) return false;");
+            }
+        }
+
+        if (hasExMax)
+        {
+            if (exMaxElem.ValueKind == JsonValueKind.Number && exMaxElem.TryGetDouble(out var exMax))
+            {
+                sb.AppendLine($"  if ({v} >= {Fmt(exMax)}) return false;");
+            }
+            else if (exMaxElem.ValueKind == JsonValueKind.True && hasMax && maxElem.TryGetDouble(out var maxVal))
+            {
+                sb.AppendLine($"  if ({v} >= {Fmt(maxVal)}) return false;");
+            }
+        }
+
+        if (hasMul && mulElem.TryGetDouble(out var mul) && mul != 0)
+        {
+            var divisor = Fmt(mul);
+            sb.AppendLine($"  {{");
+            sb.AppendLine($"    if (Math.abs({v} % {divisor}) >= Number.EPSILON) {{");
+            sb.AppendLine($"      let _q = {v} / {divisor};");
+            sb.AppendLine($"      if (!(!isFinite(_q) && Math.abs({v} % 1) < Number.EPSILON && Math.abs(1 % {divisor}) < Number.EPSILON)) {{");
+            sb.AppendLine($"        _q = Math.round((_q + 0.000001) * 100) / 100;");
+            sb.AppendLine($"        if (!(Math.abs(_q - Math.round(_q)) < Number.EPSILON)) return false;");
+            sb.AppendLine($"      }}");
+            sb.AppendLine($"    }}");
+            sb.AppendLine($"  }}");
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+
+    private static string Fmt(double d) => d.ToString("G17", CultureInfo.InvariantCulture);
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsNumericConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsNumericConstraintsCodeGenerator.cs
@@ -42,7 +42,10 @@ public sealed class JsNumericConstraintsCodeGenerator : IJsKeywordCodeGenerator
 
         var v = context.ElementExpr;
         var sb = new StringBuilder();
-        sb.AppendLine($"if (typeof {v} === \"number\") {{");
+        // Number.isFinite guard: NaN/Infinity would bypass every comparison below
+        // (NaN comparisons always return false) and silently accept invalid values.
+        // JSON can't express them, but direct API callers can, so reject defensively.
+        sb.AppendLine($"if (typeof {v} === \"number\" && Number.isFinite({v})) {{");
 
         if (hasMin && minElem.TryGetDouble(out var min))
         {

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsObjectConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsObjectConstraintsCodeGenerator.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for object constraint keywords: minProperties, maxProperties.
+/// </summary>
+public sealed class JsObjectConstraintsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "minProperties/maxProperties";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minProperties", out _) ||
+               schema.TryGetProperty("maxProperties", out _);
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minProperties", out var minElem) &&
+                     TryGetIntegerValue(minElem, out var min);
+        var hasMax = schema.TryGetProperty("maxProperties", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out var max);
+        if (!hasMin && !hasMax) return string.Empty;
+
+        TryGetIntegerValue(minElem, out min);
+        TryGetIntegerValue(maxElem, out max);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.AppendLine($"  const _keys = Object.keys({v});");
+        if (hasMin) sb.AppendLine($"  if (_keys.length < {min}) return false;");
+        if (hasMax) sb.AppendLine($"  if (_keys.length > {max}) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value)
+    {
+        value = 0;
+        if (element.ValueKind != JsonValueKind.Number) return false;
+        if (!element.TryGetDouble(out var d)) return false;
+        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
+        value = (long)d;
+        return true;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsObjectConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsObjectConstraintsCodeGenerator.cs
@@ -45,13 +45,6 @@ public sealed class JsObjectConstraintsCodeGenerator : IJsKeywordCodeGenerator
 
     public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
 
-    private static bool TryGetIntegerValue(JsonElement element, out long value)
-    {
-        value = 0;
-        if (element.ValueKind != JsonValueKind.Number) return false;
-        if (!element.TryGetDouble(out var d)) return false;
-        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
-        value = (long)d;
-        return true;
-    }
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        JsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
@@ -7,7 +7,11 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 
 /// <summary>
 /// Generates JavaScript code for the "pattern" keyword.
-/// Emits a native RegExp literal — ECMAScript regex, matching JSON Schema intent.
+/// Emits a <c>new RegExp("...")</c> constructor expression (via JsLiteral.RegexLiteral)
+/// using the ECMAScript dialect required by JSON Schema. Constructor form is used
+/// instead of a <c>/.../</c> literal so schema-supplied text never participates in
+/// JS tokenisation — patterns starting with <c>*</c> or containing other tokenizer
+/// hazards no longer break module parsing.
 /// Regex timeouts don't exist in JS; pathological patterns are a known limitation
 /// inherited from the spec (documented in KNOWN_LIMITATIONS.md).
 /// </summary>

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "pattern" keyword.
+/// Emits a native RegExp literal — ECMAScript regex, matching JSON Schema intent.
+/// Regex timeouts don't exist in JS; pathological patterns are a known limitation
+/// inherited from the spec (documented in KNOWN_LIMITATIONS.md).
+/// </summary>
+public sealed class JsPatternCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "pattern";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("pattern", out var p) &&
+               p.ValueKind == JsonValueKind.String &&
+               !string.IsNullOrEmpty(p.GetString());
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("pattern", out var patternElement))
+        {
+            return string.Empty;
+        }
+
+        var pattern = patternElement.GetString();
+        if (string.IsNullOrEmpty(pattern))
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var literal = JsLiteral.RegexLiteral(pattern);
+        return $"if (typeof {v} === \"string\" && !{literal}.test({v})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
@@ -20,8 +20,7 @@ public sealed class JsPatternCodeGenerator : IJsKeywordCodeGenerator
     {
         return schema.ValueKind == JsonValueKind.Object &&
                schema.TryGetProperty("pattern", out var p) &&
-               p.ValueKind == JsonValueKind.String &&
-               !string.IsNullOrEmpty(p.GetString());
+               p.ValueKind == JsonValueKind.String;
     }
 
     public string GenerateCode(JsCodeGenerationContext context)
@@ -34,7 +33,11 @@ public sealed class JsPatternCodeGenerator : IJsKeywordCodeGenerator
         var pattern = patternElement.GetString();
         if (string.IsNullOrEmpty(pattern))
         {
-            return string.Empty;
+            // Dynamic validator rejects empty "pattern" as an invalid schema; surface
+            // the same intent here rather than silently emitting no regex check.
+            throw new InvalidOperationException(
+                "Schema has an empty \"pattern\" string, which is invalid — pattern must be " +
+                "a non-empty ECMA-262 regular expression.");
         }
 
         var v = context.ElementExpr;

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertiesCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertiesCodeGenerator.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "properties" keyword.
+/// </summary>
+public sealed class JsPropertiesCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "properties";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("properties", out var props) &&
+               props.ValueKind == JsonValueKind.Object;
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("properties", out var properties) ||
+            properties.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+
+        foreach (var prop in properties.EnumerateObject())
+        {
+            var propHash = context.GetSubschemaHash(prop.Value);
+            var nameLiteral = JsLiteral.String(prop.Name);
+            var call = context.GenerateValidateCallForExpr(propHash, $"{v}[{nameLiteral}]");
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {nameLiteral})) {{");
+            sb.AppendLine($"    if (!{call}) return false;");
+            sb.AppendLine("  }");
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
@@ -126,10 +126,21 @@ public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerato
         {
             sb.AppendLine("    return false;");
         }
-        else
+        else if (addProps.ValueKind == JsonValueKind.Object)
         {
             var hash = context.GetSubschemaHash(addProps);
             sb.AppendLine($"    if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_k]")}) return false;");
+        }
+        else
+        {
+            // Invalid schema: additionalProperties must be object/boolean per
+            // spec. SubschemaExtractor doesn't collect non-schema values, so
+            // emitting a validate_<hash> call would reference an undefined
+            // function at runtime. Fail fast with an actionable message,
+            // matching how the gate treats other invalid-schema shapes.
+            throw new InvalidOperationException(
+                "Schema's \"additionalProperties\" value must be an object or boolean; got " +
+                $"{addProps.ValueKind}.");
         }
         sb.AppendLine("  }");
         sb.AppendLine("}");
@@ -186,6 +197,17 @@ public sealed class JsPropertyNamesCodeGenerator : IJsKeywordCodeGenerator
         if (!context.CurrentSchema.TryGetProperty("propertyNames", out var pn))
         {
             return string.Empty;
+        }
+        if (pn.ValueKind != JsonValueKind.Object &&
+            pn.ValueKind != JsonValueKind.True &&
+            pn.ValueKind != JsonValueKind.False)
+        {
+            // Invalid schema: propertyNames must be a schema (object or boolean).
+            // Non-schema values aren't extracted by SubschemaExtractor, so the
+            // emitted validate_<hash> call would be undefined at runtime.
+            throw new InvalidOperationException(
+                "Schema's \"propertyNames\" value must be an object or boolean; got " +
+                $"{pn.ValueKind}.");
         }
         var hash = context.GetSubschemaHash(pn);
         var v = context.ElementExpr;

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
@@ -22,14 +22,15 @@ public sealed class JsPatternPropertiesCodeGenerator : IJsKeywordCodeGenerator
 
     public string GenerateCode(JsCodeGenerationContext context)
     {
-        if (!context.CurrentSchema.TryGetProperty("patternProperties", out var patterns) ||
-            patterns.ValueKind != JsonValueKind.Object ||
-            patterns.EnumerateObject().FirstOrDefault().Value.ValueKind == JsonValueKind.Undefined)
-        {
-            // If there are no entries, skip.
-        }
         if (!context.CurrentSchema.TryGetProperty("patternProperties", out var patternsElem) ||
             patternsElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        // Empty patternProperties {}: no pattern checks to emit.
+        var patternEnumerator = patternsElem.EnumerateObject();
+        if (!patternEnumerator.MoveNext())
         {
             return string.Empty;
         }
@@ -38,14 +39,16 @@ public sealed class JsPatternPropertiesCodeGenerator : IJsKeywordCodeGenerator
         var sb = new StringBuilder();
         sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
         sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
-        foreach (var pattern in patternsElem.EnumerateObject())
+        do
         {
+            var pattern = patternEnumerator.Current;
             var regex = JsLiteral.RegexLiteral(pattern.Name);
             var hash = context.GetSubschemaHash(pattern.Value);
             sb.AppendLine($"    if ({regex}.test(_k)) {{");
             sb.AppendLine($"      if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_k]")}) return false;");
             sb.AppendLine("    }");
         }
+        while (patternEnumerator.MoveNext());
         sb.AppendLine("  }");
         sb.AppendLine("}");
         return sb.ToString();

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 using System.Text;
 using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
 
 namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 
@@ -153,6 +154,8 @@ public sealed class JsPropertyNamesCodeGenerator : IJsKeywordCodeGenerator
 
     public string GenerateCode(JsCodeGenerationContext context)
     {
+        // propertyNames was introduced in Draft 6; Draft 4 must ignore it.
+        if (context.DetectedDraft < SchemaDraft.Draft6) return string.Empty;
         if (!context.CurrentSchema.TryGetProperty("propertyNames", out var pn))
         {
             return string.Empty;

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "patternProperties" keyword.
+/// </summary>
+public sealed class JsPatternPropertiesCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "patternProperties";
+    public int Priority => 45;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("patternProperties", out var p) &&
+        p.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("patternProperties", out var patterns) ||
+            patterns.ValueKind != JsonValueKind.Object ||
+            patterns.EnumerateObject().FirstOrDefault().Value.ValueKind == JsonValueKind.Undefined)
+        {
+            // If there are no entries, skip.
+        }
+        if (!context.CurrentSchema.TryGetProperty("patternProperties", out var patternsElem) ||
+            patternsElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        foreach (var pattern in patternsElem.EnumerateObject())
+        {
+            var regex = JsLiteral.RegexLiteral(pattern.Name);
+            var hash = context.GetSubschemaHash(pattern.Value);
+            sb.AppendLine($"    if ({regex}.test(_k)) {{");
+            sb.AppendLine($"      if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_k]")}) return false;");
+            sb.AppendLine("    }");
+        }
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates JavaScript code for the "additionalProperties" keyword.
+/// Handles the three forms: false (reject unlisted), schema (validate unlisted), true (no-op).
+/// </summary>
+public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "additionalProperties";
+    public int Priority => 20;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("additionalProperties", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("additionalProperties", out var addProps))
+        {
+            return string.Empty;
+        }
+        if (addProps.ValueKind == JsonValueKind.True)
+        {
+            return string.Empty;
+        }
+
+        var definedNames = CollectDefinedNames(context.CurrentSchema);
+        var patternRegexes = CollectPatternRegexes(context.CurrentSchema);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        if (definedNames.Count > 0)
+        {
+            var conds = definedNames.Select(n => $"_k === {JsLiteral.String(n)}");
+            sb.AppendLine($"    if ({string.Join(" || ", conds)}) continue;");
+        }
+        if (patternRegexes.Count > 0)
+        {
+            var conds = patternRegexes.Select(r => $"{r}.test(_k)");
+            sb.AppendLine($"    if ({string.Join(" || ", conds)}) continue;");
+        }
+        if (addProps.ValueKind == JsonValueKind.False)
+        {
+            sb.AppendLine("    return false;");
+        }
+        else
+        {
+            var hash = context.GetSubschemaHash(addProps);
+            sb.AppendLine($"    if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_k]")}) return false;");
+        }
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+
+    private static List<string> CollectDefinedNames(JsonElement schema)
+    {
+        var names = new List<string>();
+        if (schema.TryGetProperty("properties", out var props) &&
+            props.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var p in props.EnumerateObject())
+            {
+                names.Add(p.Name);
+            }
+        }
+        return names;
+    }
+
+    private static List<string> CollectPatternRegexes(JsonElement schema)
+    {
+        var regexes = new List<string>();
+        if (schema.TryGetProperty("patternProperties", out var patterns) &&
+            patterns.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var p in patterns.EnumerateObject())
+            {
+                regexes.Add(JsLiteral.RegexLiteral(p.Name));
+            }
+        }
+        return regexes;
+    }
+}
+
+/// <summary>
+/// Generates JavaScript code for the "propertyNames" keyword (Draft 6+).
+/// </summary>
+public sealed class JsPropertyNamesCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "propertyNames";
+    public int Priority => 60;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("propertyNames", out _);
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("propertyNames", out var pn))
+        {
+            return string.Empty;
+        }
+        var hash = context.GetSubschemaHash(pn);
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        sb.AppendLine($"    if (!{context.GenerateValidateCallForExpr(hash, "_k")}) return false;");
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
@@ -36,19 +36,31 @@ public sealed class JsPatternPropertiesCodeGenerator : IJsKeywordCodeGenerator
         }
 
         var v = context.ElementExpr;
-        var sb = new StringBuilder();
-        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
-        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        // Hoist each pattern's RegExp outside the key loop. Without this we'd
+        // allocate a new RegExp per property name on every validate call;
+        // hoisting gives one RegExp per validate invocation instead.
+        var hoists = new StringBuilder();
+        var checks = new StringBuilder();
+        var idx = 0;
         do
         {
             var pattern = patternEnumerator.Current;
             var regex = JsLiteral.RegexLiteral(pattern.Name);
+            var regexVar = $"_ppRe{idx}";
             var hash = context.GetSubschemaHash(pattern.Value);
-            sb.AppendLine($"    if ({regex}.test(_k)) {{");
-            sb.AppendLine($"      if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_k]")}) return false;");
-            sb.AppendLine("    }");
+            hoists.AppendLine($"  const {regexVar} = {regex};");
+            checks.AppendLine($"    if ({regexVar}.test(_k)) {{");
+            checks.AppendLine($"      if (!{context.GenerateValidateCallForExpr(hash, $"{v}[_k]")}) return false;");
+            checks.AppendLine("    }");
+            idx++;
         }
         while (patternEnumerator.MoveNext());
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.Append(hoists);
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        sb.Append(checks);
         sb.AppendLine("  }");
         sb.AppendLine("}");
         return sb.ToString();
@@ -85,17 +97,29 @@ public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerato
         var patternRegexes = CollectPatternRegexes(context.CurrentSchema);
 
         var v = context.ElementExpr;
+        // Hoist pattern regexes outside the key loop (same reason as
+        // patternProperties — avoid one RegExp allocation per property).
+        var hoists = new StringBuilder();
+        var regexVars = new List<string>();
+        for (var i = 0; i < patternRegexes.Count; i++)
+        {
+            var rv = $"_apRe{i}";
+            hoists.AppendLine($"  const {rv} = {patternRegexes[i]};");
+            regexVars.Add(rv);
+        }
+
         var sb = new StringBuilder();
         sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.Append(hoists);
         sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
         if (definedNames.Count > 0)
         {
             var conds = definedNames.Select(n => $"_k === {JsLiteral.String(n)}");
             sb.AppendLine($"    if ({string.Join(" || ", conds)}) continue;");
         }
-        if (patternRegexes.Count > 0)
+        if (regexVars.Count > 0)
         {
-            var conds = patternRegexes.Select(r => $"{r}.test(_k)");
+            var conds = regexVars.Select(r => $"{r}.test(_k)");
             sb.AppendLine($"    if ({string.Join(" || ", conds)}) continue;");
         }
         if (addProps.ValueKind == JsonValueKind.False)

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
@@ -38,7 +38,9 @@ public sealed class JsRefCodeGenerator : IJsKeywordCodeGenerator
             : context.ResolveLocalRef(refValue);
         if (!target.HasValue)
         {
-            return $"// WARNING: Could not resolve $ref: {refValue}\nreturn false;";
+            // Don't embed refValue into the emitted source — a ref containing newlines
+            // or "*/" could break out of the comment / inject text into the module.
+            return "// WARNING: Could not resolve local $ref.\nreturn false;";
         }
         var hash = context.GetSubschemaHash(target.Value);
         return $"if (!{context.GenerateValidateCall(hash)}) return false;";

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
@@ -31,7 +31,11 @@ public sealed class JsRefCodeGenerator : IJsKeywordCodeGenerator
         if (string.IsNullOrEmpty(refValue)) return string.Empty;
 
         // Gate rejects non-'#' refs, so we only see local refs here.
-        var target = context.ResolveLocalRef(refValue);
+        // Resolve against the current resource root (the nearest ancestor with $id),
+        // falling back to document-root resolution only when no resource is in scope.
+        var target = context.ResourceRoot.HasValue
+            ? context.ResolveLocalRefInResource(refValue, context.ResourceRoot.Value)
+            : context.ResolveLocalRef(refValue);
         if (!target.HasValue)
         {
             return $"// WARNING: Could not resolve $ref: {refValue}\nreturn false;";

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for local "$ref" references.
+/// External refs are rejected by JsCapabilityGate before emission begins, so this
+/// generator only handles fragment refs (starting with '#') targeting the current
+/// document. Resolved via the shared SubschemaExtractor and dispatched to the
+/// target subschema's validate function.
+/// </summary>
+public sealed class JsRefCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "$ref";
+    public int Priority => 200;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        if (!schema.TryGetProperty("$ref", out var r)) return false;
+        return r.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(r.GetString());
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("$ref", out var refElem)) return string.Empty;
+        var refValue = refElem.GetString();
+        if (string.IsNullOrEmpty(refValue)) return string.Empty;
+
+        // Gate rejects non-'#' refs, so we only see local refs here.
+        var target = context.ResolveLocalRef(refValue);
+        if (!target.HasValue)
+        {
+            return $"// WARNING: Could not resolve $ref: {refValue}\nreturn false;";
+        }
+        var hash = context.GetSubschemaHash(target.Value);
+        return $"if (!{context.GenerateValidateCall(hash)}) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRefCodeGenerator.cs
@@ -38,9 +38,13 @@ public sealed class JsRefCodeGenerator : IJsKeywordCodeGenerator
             : context.ResolveLocalRef(refValue);
         if (!target.HasValue)
         {
-            // Don't embed refValue into the emitted source — a ref containing newlines
-            // or "*/" could break out of the comment / inject text into the module.
-            return "// WARNING: Could not resolve local $ref.\nreturn false;";
+            // An unresolved local ref at this point means the shared extractor
+            // or the gate missed something — fail codegen loudly rather than
+            // silently emitting "return false" that makes every instance fail.
+            // The message deliberately omits refValue so a ref containing
+            // newlines or other source-injection bait can't leak into output.
+            throw new InvalidOperationException(
+                "Could not resolve local $ref during JavaScript code generation.");
         }
         var hash = context.GetSubschemaHash(target.Value);
         return $"if (!{context.GenerateValidateCall(hash)}) return false;";

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRequiredCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsRequiredCodeGenerator.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "required" keyword.
+/// </summary>
+public sealed class JsRequiredCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "required";
+    public int Priority => 95;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("required", out var req) &&
+               req.ValueKind == JsonValueKind.Array;
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("required", out var required) ||
+            required.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+
+        var names = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                names.Add(item.GetString()!);
+            }
+        }
+
+        if (names.Count == 0) return string.Empty;
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var name in names)
+        {
+            var literal = JsLiteral.String(name);
+            sb.AppendLine($"  if (!Object.prototype.hasOwnProperty.call({v}, {literal})) return false;");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsSchemaNumeric.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsSchemaNumeric.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Shared numeric parsing helpers for JS keyword emitters.
+/// Centralises range/integer checks so every bounded-length keyword handles
+/// out-of-range schema values the same way.
+/// </summary>
+internal static class JsSchemaNumeric
+{
+    /// <summary>
+    /// Parses a JSON number as a non-negative integer count suitable for a
+    /// length/bound keyword (minLength, maxItems, minContains, etc.). Returns
+    /// false when the value isn't a number, is negative, is fractional, is
+    /// non-finite, or exceeds long.MaxValue — an explicit range check before
+    /// the double→long cast, since unchecked conversion outside range is
+    /// unspecified in C# and can emit bogus constraints into the JS output.
+    /// </summary>
+    public static bool TryGetNonNegativeIntegerValue(JsonElement element, out long value)
+    {
+        value = 0;
+        if (element.ValueKind != JsonValueKind.Number) return false;
+        if (!element.TryGetDouble(out var d)) return false;
+        if (!double.IsFinite(d)) return false;
+        if (d < 0) return false;
+        if (Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
+        if (d > long.MaxValue) return false;
+        value = (long)d;
+        return true;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsStringConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsStringConstraintsCodeGenerator.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for string constraint keywords: minLength, maxLength.
+/// Grapheme counting is delegated to the runtime's graphemeLength helper to match
+/// C# StringInfo.LengthInTextElements semantics.
+/// </summary>
+public sealed class JsStringConstraintsCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "minLength/maxLength";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minLength", out _) ||
+               schema.TryGetProperty("maxLength", out _);
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minLength", out var minElem) &&
+                     TryGetIntegerValue(minElem, out var min);
+        var hasMax = schema.TryGetProperty("maxLength", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out var max);
+        if (!hasMin && !hasMax) return string.Empty;
+
+        TryGetIntegerValue(minElem, out min);
+        TryGetIntegerValue(maxElem, out max);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"string\") {{");
+        sb.AppendLine($"  const _len = graphemeLength({v});");
+        if (hasMin) sb.AppendLine($"  if (_len < {min}) return false;");
+        if (hasMax) sb.AppendLine($"  if (_len > {max}) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        yield return "graphemeLength";
+    }
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value)
+    {
+        value = 0;
+        if (element.ValueKind != JsonValueKind.Number) return false;
+        if (!element.TryGetDouble(out var d)) return false;
+        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
+        value = (long)d;
+        return true;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsStringConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsStringConstraintsCodeGenerator.cs
@@ -47,7 +47,19 @@ public sealed class JsStringConstraintsCodeGenerator : IJsKeywordCodeGenerator
 
     public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
     {
-        yield return "graphemeLength";
+        // Only yield the import when GenerateCode will actually emit a
+        // graphemeLength call — skip for non-integer minLength/maxLength values
+        // that GenerateCode ignores, so unused imports don't creep into the
+        // emitted module.
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minLength", out var minElem) &&
+                     TryGetIntegerValue(minElem, out _);
+        var hasMax = schema.TryGetProperty("maxLength", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out _);
+        if (hasMin || hasMax)
+        {
+            yield return "graphemeLength";
+        }
     }
 
     private static bool TryGetIntegerValue(JsonElement element, out long value)

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsStringConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsStringConstraintsCodeGenerator.cs
@@ -62,13 +62,6 @@ public sealed class JsStringConstraintsCodeGenerator : IJsKeywordCodeGenerator
         }
     }
 
-    private static bool TryGetIntegerValue(JsonElement element, out long value)
-    {
-        value = 0;
-        if (element.ValueKind != JsonValueKind.Number) return false;
-        if (!element.TryGetDouble(out var d)) return false;
-        if (d < 0 || Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
-        value = (long)d;
-        return true;
-    }
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        JsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsTypeCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsTypeCodeGenerator.cs
@@ -76,10 +76,12 @@ public sealed class JsTypeCodeGenerator : IJsKeywordCodeGenerator
 
     private static string RejectUnlessType(string type, string v)
     {
+        // "number" rejects NaN/Infinity to match JSON numeric semantics —
+        // JSON.parse can't produce them, but direct API callers can.
         return type switch
         {
             "string" => $"if (typeof {v} !== \"string\") return false;",
-            "number" => $"if (typeof {v} !== \"number\") return false;",
+            "number" => $"if (typeof {v} !== \"number\" || !Number.isFinite({v})) return false;",
             "integer" => $"if (!isInteger({v})) return false;",
             "boolean" => $"if (typeof {v} !== \"boolean\") return false;",
             "null" => $"if ({v} !== null) return false;",
@@ -98,7 +100,7 @@ public sealed class JsTypeCodeGenerator : IJsKeywordCodeGenerator
             var cond = item.GetString() switch
             {
                 "string" => $"typeof {v} === \"string\"",
-                "number" => $"typeof {v} === \"number\"",
+                "number" => $"(typeof {v} === \"number\" && Number.isFinite({v}))",
                 "integer" => $"isInteger({v})",
                 "boolean" => $"typeof {v} === \"boolean\"",
                 "null" => $"{v} === null",

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsTypeCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsTypeCodeGenerator.cs
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
+
+/// <summary>
+/// Generates JavaScript code for the "type" keyword.
+/// </summary>
+public sealed class JsTypeCodeGenerator : IJsKeywordCodeGenerator
+{
+    public string Keyword => "type";
+    public int Priority => 100;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("type", out _);
+    }
+
+    public string GenerateCode(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("type", out var typeElement))
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+
+        if (typeElement.ValueKind == JsonValueKind.String)
+        {
+            return RejectUnlessType(typeElement.GetString()!, v);
+        }
+
+        if (typeElement.ValueKind == JsonValueKind.Array)
+        {
+            return GenerateMultiTypeCheck(typeElement, v);
+        }
+
+        return string.Empty;
+    }
+
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("type", out var typeElement))
+        {
+            yield break;
+        }
+
+        if (ReferencesIntegerType(typeElement))
+        {
+            yield return "isInteger";
+        }
+    }
+
+    private static bool ReferencesIntegerType(JsonElement typeElement)
+    {
+        if (typeElement.ValueKind == JsonValueKind.String)
+        {
+            return typeElement.GetString() == "integer";
+        }
+        if (typeElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in typeElement.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String && item.GetString() == "integer")
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static string RejectUnlessType(string type, string v)
+    {
+        return type switch
+        {
+            "string" => $"if (typeof {v} !== \"string\") return false;",
+            "number" => $"if (typeof {v} !== \"number\") return false;",
+            "integer" => $"if (!isInteger({v})) return false;",
+            "boolean" => $"if (typeof {v} !== \"boolean\") return false;",
+            "null" => $"if ({v} !== null) return false;",
+            "array" => $"if (!Array.isArray({v})) return false;",
+            "object" => $"if (typeof {v} !== \"object\" || {v} === null || Array.isArray({v})) return false;",
+            _ => string.Empty,
+        };
+    }
+
+    private static string GenerateMultiTypeCheck(JsonElement typeArray, string v)
+    {
+        var conditions = new List<string>();
+        foreach (var item in typeArray.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String) continue;
+            var cond = item.GetString() switch
+            {
+                "string" => $"typeof {v} === \"string\"",
+                "number" => $"typeof {v} === \"number\"",
+                "integer" => $"isInteger({v})",
+                "boolean" => $"typeof {v} === \"boolean\"",
+                "null" => $"{v} === null",
+                "array" => $"Array.isArray({v})",
+                "object" => $"(typeof {v} === \"object\" && {v} !== null && !Array.isArray({v}))",
+                _ => null,
+            };
+            if (cond != null) conditions.Add(cond);
+        }
+
+        if (conditions.Count == 0) return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.Append("if (!(");
+        sb.Append(string.Join(" || ", conditions));
+        sb.AppendLine(")) return false;");
+        return sb.ToString();
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/JsRuntime.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/JsRuntime.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Reflection;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+
+/// <summary>
+/// Accessor for the embedded jsv-runtime.js module source.
+/// Emitted validators import from this runtime; CLI writes it next to generated files,
+/// tests feed it to the Jint harness. Both paths use the same bytes.
+/// </summary>
+public static class JsRuntime
+{
+    private const string ResourceName =
+        "FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime.jsv-runtime.js";
+
+    /// <summary>
+    /// The default filename validators expect the runtime to be saved as.
+    /// Matches the default JsSchemaCodeGenerator.RuntimeImportSpecifier.
+    /// </summary>
+    public const string FileName = "jsv-runtime.js";
+
+    /// <summary>
+    /// Returns the runtime module source as a UTF-8 string.
+    /// </summary>
+    public static string GetSource()
+    {
+        var assembly = typeof(JsRuntime).GetTypeInfo().Assembly;
+        using var stream = assembly.GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded runtime resource not found: {ResourceName}. " +
+                "Build configuration issue — confirm Runtime/jsv-runtime.js is listed as EmbeddedResource.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+
+// jsv-runtime.js
+//
+// Shared runtime for JavaScript validators emitted by jsv-codegen.
+// This file IS the ABI. Emitted modules import named exports from here.
+//
+// ABI VERSION: mvp-0
+//
+// FROZEN (stable across MVP; breaking changes require ABI version bump):
+//   Helpers:   deepEquals, escapeJsonPointer, graphemeLength, isInteger
+//   Formats:   isValidDateTime, isValidDate, isValidTime, isValidDuration,
+//              isValidEmail, isValidIdnEmail, isValidHostname, isValidIdnHostname,
+//              isValidIpv4, isValidIpv6, isValidUri, isValidUriReference,
+//              isValidUriTemplate, isValidIri, isValidIriReference,
+//              isValidJsonPointer, isValidRelativeJsonPointer, isValidRegex,
+//              isValidUuid
+//   Validator module shape (what emitted modules export):
+//              default export: { validate, schemaUri }
+//              named exports:  validate(data): boolean, schemaUri: string | null
+//
+// PROVISIONAL (reserved names for deferred features; shape subject to change
+// when the owning phase lands — do not depend on these in MVP consumers):
+//   EvaluatedState        — unevaluatedProperties / unevaluatedItems tracking
+//   CompiledValidatorScope — $dynamicRef / $recursiveRef scope stack
+//   Registry              — external $ref resolution
+//
+// Format implementations land in Phase 4. Until then the exports throw a
+// clear not-implemented error so emitters referencing them surface the gap
+// loudly rather than silently returning a wrong verdict.
+
+// ---- Helpers (frozen) -----------------------------------------------------
+
+/**
+ * RFC 6901 JSON Pointer segment escape: '~' -> '~0', '/' -> '~1'.
+ * @param {string} segment
+ * @returns {string}
+ */
+export function escapeJsonPointer(segment) {
+    return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+// Lazy Intl.Segmenter probe. If unavailable (non-ICU builds), fall back to
+// code-point counting — matches surrogate pairs but not combining marks.
+// The gap is documented in KNOWN_LIMITATIONS.md and is acceptable for MVP.
+let _segmenter = null;
+let _segmenterProbed = false;
+function _getSegmenter() {
+    if (_segmenterProbed) return _segmenter;
+    _segmenterProbed = true;
+    try {
+        if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+            _segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+        }
+    } catch {
+        _segmenter = null;
+    }
+    return _segmenter;
+}
+
+/**
+ * Counts grapheme clusters in a string. Mirrors C# StringInfo.LengthInTextElements.
+ * @param {string} str
+ * @returns {number}
+ */
+export function graphemeLength(str) {
+    const seg = _getSegmenter();
+    if (seg !== null) {
+        let count = 0;
+        // eslint-disable-next-line no-unused-vars
+        for (const _ of seg.segment(str)) count++;
+        return count;
+    }
+    return Array.from(str).length;
+}
+
+/**
+ * Returns true if v is a JSON integer for validation purposes.
+ * Accepts BigInt and finite Number values with no fractional part.
+ * Matches the IEEE-754 semantics used by the C# compiled path.
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+export function isInteger(v) {
+    if (typeof v === "bigint") return true;
+    if (typeof v !== "number") return false;
+    if (!Number.isFinite(v)) return false;
+    return Math.floor(v) === v;
+}
+
+/**
+ * Deep structural equality for parsed JSON values. Numeric equality is ===
+ * (IEEE-754), matching the C# compiled path.
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {boolean}
+ */
+export function deepEquals(a, b) {
+    if (a === b) return true;
+    if (typeof a !== typeof b) return false;
+    if (a === null || b === null) return a === b;
+    if (Array.isArray(a)) {
+        if (!Array.isArray(b)) return false;
+        if (a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) {
+            if (!deepEquals(a[i], b[i])) return false;
+        }
+        return true;
+    }
+    if (typeof a === "object") {
+        if (Array.isArray(b) || typeof b !== "object") return false;
+        const ak = Object.keys(a);
+        const bk = Object.keys(b);
+        if (ak.length !== bk.length) return false;
+        for (const k of ak) {
+            if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+            if (!deepEquals(a[k], b[k])) return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+// ---- Format validators (frozen signatures) --------------------------------
+//
+// Each validator returns true for non-string inputs (format applies only to
+// strings per the spec). For strings, it returns true iff the value matches
+// the format. Implementations are pragmatic regex-based checks intended to
+// match common test-suite verdicts; idn-* and iri-* variants fall back to
+// their ASCII counterparts for MVP and are documented in KNOWN_LIMITATIONS.
+
+function _nonString(v) { return typeof v !== "string"; }
+
+const _reDateFullDate = /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+const _reTimePart = /^(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})$/i;
+const _reDuration = /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
+const _reEmail = /^[^\s@"]+@[^\s@"]+\.[^\s@"]+$/;
+const _reHostnameLabel = /^(?=.{1,63}$)[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+const _reIpv4Octet = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+const _reIpv6 =
+    /^(([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|([0-9A-Fa-f]{1,4}:){1,7}:|([0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|([0-9A-Fa-f]{1,4}:){1,5}(:[0-9A-Fa-f]{1,4}){1,2}|([0-9A-Fa-f]{1,4}:){1,4}(:[0-9A-Fa-f]{1,4}){1,3}|([0-9A-Fa-f]{1,4}:){1,3}(:[0-9A-Fa-f]{1,4}){1,4}|([0-9A-Fa-f]{1,4}:){1,2}(:[0-9A-Fa-f]{1,4}){1,5}|[0-9A-Fa-f]{1,4}:((:[0-9A-Fa-f]{1,4}){1,6})|:((:[0-9A-Fa-f]{1,4}){1,7}|:))$/;
+const _reUuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const _reJsonPointer = /^(\/([^~/]|~0|~1)*)*$/;
+const _reRelativeJsonPointer = /^(0|[1-9]\d*)(#|(\/([^~/]|~0|~1)*)*)$/;
+const _reUriTemplate = /^([^\x00-\x20"'<>%\\^`{|}]|%[0-9A-Fa-f]{2}|\{[+#./;?&=,!@|]?((\w|\.|%[0-9A-Fa-f]{2})+(\*|:\d+)?)(,(\w|\.|%[0-9A-Fa-f]{2})+(\*|:\d+)?)*\})*$/;
+
+/** @type {(v: unknown) => boolean} */
+export function isValidDate(v) {
+    if (_nonString(v)) return true;
+    const m = _reDateFullDate.exec(v);
+    if (!m) return false;
+    const year = +m[1], month = +m[2], day = +m[3];
+    const daysInMonth = [31, (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0 ? 29 : 28,
+        31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    return day <= daysInMonth[month - 1];
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidTime(v) {
+    if (_nonString(v)) return true;
+    return _reTimePart.test(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidDateTime(v) {
+    if (_nonString(v)) return true;
+    const tIdx = v.search(/[Tt]/);
+    if (tIdx < 0) return false;
+    return isValidDate(v.slice(0, tIdx)) && isValidTime(v.slice(tIdx + 1));
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidDuration(v) {
+    if (_nonString(v)) return true;
+    return _reDuration.test(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidEmail(v) {
+    if (_nonString(v)) return true;
+    return _reEmail.test(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export const isValidIdnEmail = isValidEmail;
+
+/** @type {(v: unknown) => boolean} */
+export function isValidHostname(v) {
+    if (_nonString(v)) return true;
+    if (v.length > 253) return false;
+    return v.split(".").every((label) => _reHostnameLabel.test(label));
+}
+
+/** @type {(v: unknown) => boolean} */
+export const isValidIdnHostname = isValidHostname;
+
+/** @type {(v: unknown) => boolean} */
+export function isValidIpv4(v) {
+    if (_nonString(v)) return true;
+    const parts = v.split(".");
+    if (parts.length !== 4) return false;
+    return parts.every((p) => _reIpv4Octet.test(p));
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidIpv6(v) {
+    if (_nonString(v)) return true;
+    return _reIpv6.test(v);
+}
+
+function _tryUrl(v, base) {
+    try {
+        // eslint-disable-next-line no-new
+        new URL(v, base);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidUri(v) {
+    if (_nonString(v)) return true;
+    // Absolute URIs only — must parse standalone and contain a scheme.
+    if (!/^[A-Za-z][A-Za-z0-9+\-.]*:/.test(v)) return false;
+    return _tryUrl(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidUriReference(v) {
+    if (_nonString(v)) return true;
+    return _tryUrl(v, "http://example.com/");
+}
+
+/** @type {(v: unknown) => boolean} */
+export const isValidIri = isValidUri;
+
+/** @type {(v: unknown) => boolean} */
+export const isValidIriReference = isValidUriReference;
+
+/** @type {(v: unknown) => boolean} */
+export function isValidUriTemplate(v) {
+    if (_nonString(v)) return true;
+    return _reUriTemplate.test(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidJsonPointer(v) {
+    if (_nonString(v)) return true;
+    return _reJsonPointer.test(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidRelativeJsonPointer(v) {
+    if (_nonString(v)) return true;
+    return _reRelativeJsonPointer.test(v);
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidRegex(v) {
+    if (_nonString(v)) return true;
+    try {
+        // eslint-disable-next-line no-new
+        new RegExp(v);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** @type {(v: unknown) => boolean} */
+export function isValidUuid(v) {
+    if (_nonString(v)) return true;
+    return _reUuid.test(v);
+}
+
+// ---- Provisional deferred-feature shapes (reference-only, do not depend on) --
+//
+// @typedef {object} EvaluatedState
+// @property {(loc: string, propertyName: string) => void} markPropertyEvaluated
+// @property {(loc: string, propertyName: string) => boolean} isPropertyEvaluated
+// @property {(loc: string, index: number) => void} markItemEvaluated
+// @property {(loc: string, index: number) => boolean} isItemEvaluated
+// @property {() => void} reset
+// @property {() => EvaluatedState} clone
+// @property {(other: EvaluatedState) => void} mergeFrom
+//
+// @typedef {object} CompiledScopeEntry
+// @property {Record<string, Function> | null} dynamicAnchors
+// @property {boolean} hasRecursiveAnchor
+// @property {Function | null} rootValidator
+//
+// @typedef {object} CompiledValidatorScope
+// @property {(entry: CompiledScopeEntry) => CompiledValidatorScope} push
+//
+// @typedef {object} Registry
+// @property {(hash: string, validator: unknown) => void} registerByHash
+// @property {(uri: string, validator: unknown) => void} registerForUri
+// @property {(uri: string) => unknown | null} tryGetValidator

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
@@ -134,6 +134,8 @@ export function deepEquals(a, b) {
 function _nonString(v) { return typeof v !== "string"; }
 
 const _reDateFullDate = /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+// Time shape: HH:MM:SS[.fraction](Z|±HH:MM). Field ranges checked separately —
+// a shape-only regex lets "25:00:00Z" through. Range check in isValidTime.
 const _reTimePart = /^(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})$/i;
 const _reDuration = /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
 const _reEmail = /^[^\s@"]+@[^\s@"]+\.[^\s@"]+$/;
@@ -160,7 +162,19 @@ export function isValidDate(v) {
 /** @type {(v: unknown) => boolean} */
 export function isValidTime(v) {
     if (_nonString(v)) return true;
-    return _reTimePart.test(v);
+    const m = _reTimePart.exec(v);
+    if (!m) return false;
+    const hour = +m[1], minute = +m[2], second = +m[3];
+    // RFC 3339: hour 00-23, minute 00-59, second 00-60 (leap second allowed).
+    if (hour > 23 || minute > 59 || second > 60) return false;
+    // Offsets: ±HH:MM with HH in 00-23 and MM in 00-59.
+    const offset = m[5];
+    if (offset && offset.toUpperCase() !== "Z") {
+        const offHour = +offset.slice(1, 3);
+        const offMin = +offset.slice(4, 6);
+        if (offHour > 23 || offMin > 59) return false;
+    }
+    return true;
 }
 
 /** @type {(v: unknown) => boolean} */

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
@@ -27,9 +27,8 @@
 //   CompiledValidatorScope — $dynamicRef / $recursiveRef scope stack
 //   Registry              — external $ref resolution
 //
-// Format implementations land in Phase 4. Until then the exports throw a
-// clear not-implemented error so emitters referencing them surface the gap
-// loudly rather than silently returning a wrong verdict.
+// All format exports below are implemented in this runtime and are part of
+// the frozen MVP ABI that emitted validators consume.
 
 // ---- Helpers (frozen) -----------------------------------------------------
 

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
@@ -77,13 +77,15 @@ export function graphemeLength(str) {
 
 /**
  * Returns true if v is a JSON integer for validation purposes.
- * Accepts BigInt and finite Number values with no fractional part.
- * Matches the IEEE-754 semantics used by the C# compiled path.
+ * Accepts finite Number values with no fractional part. Rejects BigInt to
+ * stay consistent with the IEEE-754 semantics used by the C# compiled path
+ * and by every numeric-constraint emitter (minimum/maximum/multipleOf guard
+ * on `typeof === "number"`); allowing BigInt here would let `type: integer`
+ * accept values that silently skip numeric constraints.
  * @param {unknown} v
  * @returns {boolean}
  */
 export function isInteger(v) {
-    if (typeof v === "bigint") return true;
     if (typeof v !== "number") return false;
     if (!Number.isFinite(v)) return false;
     return Math.floor(v) === v;

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsCapabilityGateTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsCapabilityGateTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+public class JsCapabilityGateTests
+{
+    private static string? Check(string json, SchemaDraft draft = SchemaDraft.Draft202012)
+    {
+        var root = JsonDocument.Parse(json).RootElement;
+        return JsCapabilityGate.CheckSupported(root, draft);
+    }
+
+    [Fact]
+    public void Accepts_Self_Contained_Schema()
+    {
+        var rejection = Check("""{ "type": "string", "minLength": 1 }""");
+        Assert.Null(rejection);
+    }
+
+    [Fact]
+    public void Accepts_Local_Ref()
+    {
+        var rejection = Check("""
+            {
+              "$defs": { "s": { "type": "string" } },
+              "$ref": "#/$defs/s"
+            }
+            """);
+        Assert.Null(rejection);
+    }
+
+    [Fact]
+    public void Rejects_Unevaluated_Properties()
+    {
+        var rejection = Check("""{ "type": "object", "unevaluatedProperties": false }""");
+        Assert.NotNull(rejection);
+        Assert.Contains("unevaluatedProperties", rejection);
+    }
+
+    [Fact]
+    public void Rejects_Unevaluated_Items()
+    {
+        var rejection = Check("""{ "type": "array", "unevaluatedItems": false }""");
+        Assert.NotNull(rejection);
+        Assert.Contains("unevaluatedItems", rejection);
+    }
+
+    [Fact]
+    public void Rejects_Dynamic_Ref()
+    {
+        var rejection = Check("""{ "$dynamicRef": "#meta" }""");
+        Assert.NotNull(rejection);
+        Assert.Contains("$dynamicRef", rejection);
+    }
+
+    [Fact]
+    public void Rejects_Dynamic_Anchor()
+    {
+        var rejection = Check("""{ "$dynamicAnchor": "meta" }""");
+        Assert.NotNull(rejection);
+        Assert.Contains("$dynamicAnchor", rejection);
+    }
+
+    [Fact]
+    public void Rejects_Recursive_Ref()
+    {
+        var rejection = Check("""{ "$recursiveRef": "#" }""", SchemaDraft.Draft202012);
+        Assert.NotNull(rejection);
+        Assert.Contains("$recursiveRef", rejection);
+    }
+
+    [Fact]
+    public void Rejects_External_Ref()
+    {
+        var rejection = Check("""{ "$ref": "https://example.com/other.json" }""");
+        Assert.NotNull(rejection);
+        Assert.Contains("external $ref", rejection);
+    }
+
+    [Fact]
+    public void Rejects_External_Ref_Nested()
+    {
+        var rejection = Check("""
+            {
+              "type": "object",
+              "properties": {
+                "inner": { "$ref": "./sibling.json" }
+              }
+            }
+            """);
+        Assert.NotNull(rejection);
+        Assert.Contains("external $ref", rejection);
+    }
+
+    [Fact]
+    public void Rejects_Unsupported_Draft()
+    {
+        var rejection = Check("""{ "type": "string" }""", SchemaDraft.Draft7);
+        Assert.NotNull(rejection);
+        Assert.Contains("Draft 4 and Draft 2020-12", rejection);
+    }
+
+    [Fact]
+    public void Accepts_Draft_4()
+    {
+        var rejection = Check("""{ "type": "string" }""", SchemaDraft.Draft4);
+        Assert.Null(rejection);
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsFormatTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsFormatTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// Eager-format tests. These verify the compiled path's "supported formats are
+/// validated" behavior, matching the C# compiled path. Suite's annotation-only
+/// expectation is explicitly out of scope (excluded from the suite runner).
+/// </summary>
+public class JsFormatTests
+{
+    private readonly JsValidatorHarness _harness = new();
+
+    private void Expect(string schema, (string data, bool expected)[] cases)
+    {
+        var result = _harness.Evaluate(schema, cases.Select(c => c.data));
+        Assert.True(result.Success, result.Error);
+        for (var i = 0; i < cases.Length; i++)
+        {
+            Assert.True(
+                result.Verdicts[i] == cases[i].expected,
+                $"Data {cases[i].data}: expected {cases[i].expected}, got {result.Verdicts[i]}.\n" +
+                $"Emitted:\n{result.GeneratedSource}");
+        }
+    }
+
+    [Fact]
+    public void Date_RejectsInvalidDate()
+    {
+        Expect(
+            """{ "format": "date" }""",
+            [
+                ("\"2023-01-15\"", true),
+                ("\"2023-13-01\"", false),
+                ("\"not-a-date\"", false),
+                ("42", true),
+            ]);
+    }
+
+    [Fact]
+    public void DateTime_Rfc3339()
+    {
+        Expect(
+            """{ "format": "date-time" }""",
+            [
+                ("\"2023-01-15T12:00:00Z\"", true),
+                ("\"2023-01-15T12:00:00+02:00\"", true),
+                ("\"2023-01-15 12:00:00Z\"", false),
+                ("\"garbage\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Email_BasicShapes()
+    {
+        Expect(
+            """{ "format": "email" }""",
+            [
+                ("\"a@b.co\"", true),
+                ("\"user.name+tag@example.com\"", true),
+                ("\"no-at-sign\"", false),
+                ("\"trailing@\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Uuid_Rfc4122()
+    {
+        Expect(
+            """{ "format": "uuid" }""",
+            [
+                ("\"550e8400-e29b-41d4-a716-446655440000\"", true),
+                ("\"not-a-uuid\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Ipv4_RejectsOutOfRange()
+    {
+        Expect(
+            """{ "format": "ipv4" }""",
+            [
+                ("\"192.168.1.1\"", true),
+                ("\"256.0.0.0\"", false),
+                ("\"1.2.3\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Regex_RejectsInvalidPattern()
+    {
+        Expect(
+            """{ "format": "regex" }""",
+            [
+                ("\"^[a-z]+$\"", true),
+                ("\"[unclosed\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Unsupported_Format_IsAnnotationOnly_PerDraft()
+    {
+        // "duration" exists in 2020-12 but not in Draft 4. When schema targets
+        // Draft 4, duration is annotation-only — our emitter skips validation.
+        Expect(
+            """{ "$schema": "http://json-schema.org/draft-04/schema#", "format": "duration" }""",
+            [
+                ("\"bogus\"", true),       // annotation-only, no rejection
+                ("\"P1Y\"", true),
+            ]);
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -363,4 +363,42 @@ public class JsReviewFixesTests
         Assert.False(result.Success);
         Assert.Contains("$dynamicRef", result.Error);
     }
+
+    // Copilot review: enum/const values with U+2028/U+2029 must be escaped when
+    // inlined into the emitted JS expression (legal in ES2019+ string literals
+    // but defensive escaping protects older tooling).
+    [Fact]
+    public void Enum_EscapesLineSeparator()
+    {
+        Expect(
+            "{ \"enum\": [\"a\u2028b\"] }",
+            [
+                ("\"a\u2028b\"", true),
+                ("\"ab\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Const_EscapesParagraphSeparator()
+    {
+        Expect(
+            "{ \"const\": \"x\u2029y\" }",
+            [
+                ("\"x\u2029y\"", true),
+                ("\"xy\"", false),
+            ]);
+    }
+
+    // Copilot review: empty patternProperties must not emit an object-keys loop.
+    [Fact]
+    public void PatternProperties_EmptyObject_EmitsNothing()
+    {
+        var result = _harness.Evaluate(
+            """{ "patternProperties": {} }""",
+            ["{\"anything\": 1}", "\"string\"", "42"]);
+        Assert.True(result.Success, result.Error);
+        Assert.All(result.Verdicts, v => Assert.True(v));
+        // The dead object-keys loop should not appear.
+        Assert.DoesNotContain("for (const _k of Object.keys", result.GeneratedSource);
+    }
 }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
 using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using Jint;
 using Xunit;
 
 namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
@@ -400,5 +401,91 @@ public class JsReviewFixesTests
         Assert.All(result.Verdicts, v => Assert.True(v));
         // The dead object-keys loop should not appear.
         Assert.DoesNotContain("for (const _k of Object.keys", result.GeneratedSource);
+    }
+
+    // Copilot review: items as an array is invalid in Draft 2020-12 (replaced
+    // by prefixItems). Codegen must fail loudly rather than silently compile.
+    [Fact]
+    public void Items_AsArray_InDraft202012_FailsCodegen()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "items": [ { "type": "integer" }, { "type": "string" } ]
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("array-form \"items\"", result.Error);
+    }
+
+    [Fact]
+    public void Items_AsArray_InDraft4_StillValid()
+    {
+        // Draft 4 accepts the tuple form of items — regression to ensure the
+        // 2020-12-only guard doesn't misfire on older drafts.
+        Expect(
+            """
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "items": [ { "type": "integer" }, { "type": "string" } ]
+            }
+            """,
+            [
+                ("[1, \"a\"]", true),
+                ("[\"x\", \"a\"]", false),
+                ("[1, 2]", false),
+                ("[]", true),
+            ]);
+    }
+
+    // Copilot review: empty pattern string is an invalid schema per the
+    // dynamic validator's stance; codegen should reject it.
+    [Fact]
+    public void Pattern_Empty_FailsCodegen()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""{ "pattern": "" }""").RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("empty \"pattern\"", result.Error);
+    }
+
+    // Copilot review: isInteger must not accept BigInt, since numeric-constraint
+    // emitters only handle `typeof v === "number"`. Accepting BigInt in the type
+    // check would let values silently skip minimum/maximum/multipleOf.
+    [Fact]
+    public void Integer_RejectsBigInt_SoNumericConstraintsApplyConsistently()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            { "type": "integer", "minimum": 1 }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, result.Error);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-bigint-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime.JsRuntime.FileName),
+                FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime.JsRuntime.GetSource());
+            File.WriteAllText(Path.Combine(tempDir, "validator.js"), result.GeneratedCode!);
+
+            var engine = new Jint.Engine(opts => opts.EnableModules(tempDir));
+            var module = engine.Modules.Import("./validator.js");
+            var validate = module.Get("validate");
+            var verdict = engine.Invoke(validate, engine.Evaluate("5n"));
+            Assert.True(verdict.IsBoolean());
+            // BigInt 5n would pass minimum=1 if isInteger returned true, but with
+            // the fix it's rejected at the type check.
+            Assert.False(verdict.AsBoolean());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// Regression tests for defects found in review of the initial JS target commit.
+/// Each test names the original bug it locks against.
+/// </summary>
+public class JsReviewFixesTests
+{
+    private readonly JsValidatorHarness _harness = new();
+
+    private void Expect(string schema, (string data, bool expected)[] cases)
+    {
+        var result = _harness.Evaluate(schema, cases.Select(c => c.data));
+        Assert.True(result.Success, result.Error);
+        for (var i = 0; i < cases.Length; i++)
+        {
+            Assert.True(
+                result.Verdicts[i] == cases[i].expected,
+                $"Data {cases[i].data}: expected {cases[i].expected}, got {result.Verdicts[i]}.\n" +
+                $"Emitted:\n{result.GeneratedSource}");
+        }
+    }
+
+    // [P1] Local refs inside a nested $id resource must resolve within that
+    // resource, not against the document root.
+    [Fact]
+    public void LocalRef_ResolvesWithinNestedIdResource()
+    {
+        Expect(
+            """
+            {
+              "$defs": {
+                "sub": {
+                  "$id": "https://example.com/sub",
+                  "$defs": { "x": { "type": "integer" } },
+                  "$ref": "#/$defs/x"
+                }
+              },
+              "$ref": "#/$defs/sub"
+            }
+            """,
+            [
+                ("42", true),
+                ("\"not an integer\"", false),
+                ("1.5", false),
+            ]);
+    }
+
+    // [P2] Gate must not treat keyword names inside annotation/data (default,
+    // examples, enum, const) as if they were schema keywords.
+    [Fact]
+    public void Gate_DoesNotDescendIntoDefault()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "default": { "unevaluatedProperties": false }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_DoesNotDescendIntoEnum()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "enum": [ { "$ref": "https://external.example/x" }, { "unevaluatedItems": false } ]
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_DoesNotDescendIntoConst()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            { "const": { "$dynamicRef": "#meta" } }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected schema: {result.Error}");
+    }
+
+    // [P2] Relative $id must not crash — fall back to sourcePath for filename.
+    [Fact]
+    public void RelativeId_DoesNotCrash_FallsBackToSourcePath()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            { "$id": "person", "type": "object" }
+            """).RootElement;
+        var result = gen.Generate(schema, sourcePath: "/tmp/myschema.json");
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("myschema.js", result.FileName);
+    }
+
+    [Fact]
+    public void RelativeId_WithoutSourcePath_UsesDefault()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            { "$id": "schemas/person.json", "type": "object" }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("validator.js", result.FileName);
+    }
+
+    // [P2] const was added in Draft 6 — Draft 4 must ignore it.
+    [Fact]
+    public void Const_IsIgnored_InDraft4()
+    {
+        Expect(
+            """{ "$schema": "http://json-schema.org/draft-04/schema#", "const": 1 }""",
+            [
+                ("1", true),
+                ("2", true),
+                ("\"anything\"", true),
+            ]);
+    }
+
+    [Fact]
+    public void Const_IsEnforced_InDraft202012()
+    {
+        Expect(
+            """{ "$schema": "https://json-schema.org/draft/2020-12/schema", "const": 1 }""",
+            [
+                ("1", true),
+                ("2", false),
+            ]);
+    }
+
+    // [P2] propertyNames is Draft 6+ — Draft 4 must ignore it.
+    [Fact]
+    public void PropertyNames_IsIgnored_InDraft4()
+    {
+        Expect(
+            """
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "propertyNames": { "enum": ["x"] }
+            }
+            """,
+            [
+                ("{\"y\": 1}", true),
+                ("{\"x\": 1}", true),
+            ]);
+    }
+
+    [Fact]
+    public void PropertyNames_IsEnforced_InDraft202012()
+    {
+        Expect(
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "propertyNames": { "enum": ["x"] }
+            }
+            """,
+            [
+                ("{\"x\": 1}", true),
+                ("{\"y\": 1}", false),
+            ]);
+    }
+
+    // [P2] if/then/else are Draft 7+ — Draft 4 must ignore them.
+    [Fact]
+    public void IfThenElse_IsIgnored_InDraft4()
+    {
+        Expect(
+            """
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "if": {}, "then": false
+            }
+            """,
+            [
+                ("42", true),
+                ("\"anything\"", true),
+            ]);
+    }
+
+    [Fact]
+    public void IfThenElse_IsEnforced_InDraft202012()
+    {
+        Expect(
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "if": { "type": "string" }, "then": { "minLength": 2 }
+            }
+            """,
+            [
+                ("\"ab\"", true),
+                ("\"a\"", false),
+                ("42", true),
+            ]);
+    }
+
+    // [P2] Time format must range-check hour/minute/second, not just shape.
+    [Fact]
+    public void Time_RejectsOutOfRangeComponents()
+    {
+        Expect(
+            """{ "format": "time" }""",
+            [
+                ("\"12:34:56Z\"", true),
+                ("\"23:59:60Z\"", true),   // leap second
+                ("\"25:00:00Z\"", false),
+                ("\"23:61:00Z\"", false),
+                ("\"23:59:61Z\"", false),
+                ("\"12:34:56+14:00\"", true),
+                ("\"12:34:56+25:00\"", false),
+                ("\"12:34:56+10:60\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void DateTime_RejectsOutOfRangeTimeComponents()
+    {
+        Expect(
+            """{ "format": "date-time" }""",
+            [
+                ("\"2023-01-15T12:00:00Z\"", true),
+                ("\"2023-01-15T25:00:00Z\"", false),
+                ("\"2023-01-15T23:61:00Z\"", false),
+            ]);
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -623,6 +623,73 @@ public class JsReviewFixesTests
         Assert.Contains("multiple nested $id resources", result.Error);
     }
 
+    // Copilot round 5: gate should mirror the emitter's $ref-siblings-masked
+    // behavior for Draft 4-7 — any sibling keyword is ignored at emission, so
+    // the gate shouldn't reject a schema because those ignored siblings contain
+    // deferred features.
+    [Fact]
+    public void Gate_Draft4_IgnoresMaskedSiblingsAlongsideRef()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        // In Draft 4, $ref masks all siblings — including `not` here, which
+        // would otherwise be traversed and trip on unevaluatedProperties.
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "definitions": { "x": { "type": "integer" } },
+              "$ref": "#/definitions/x",
+              "not": { "unevaluatedProperties": false }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate should ignore masked siblings: {result.Error}");
+    }
+
+    // Copilot round 5: regex literal form is brittle for patterns beginning
+    // with '*' because /*.../ parses as a block-comment token. The new
+    // RegexLiteral form uses new RegExp(...) which bypasses the issue.
+    [Fact]
+    public void Pattern_StartingWithAsterisk_StillCompiles()
+    {
+        // A bare "*" is not a valid ECMAScript regex, but the generator must
+        // produce SYNTACTICALLY VALID JS source regardless. If it emitted
+        // /*/ the module wouldn't even parse; with new RegExp("*") the module
+        // parses and the invalid pattern would only fail at RegExp construction.
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            { "patternProperties": { "^a": { "type": "integer" } } }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("new RegExp(", result.GeneratedCode);
+        Assert.DoesNotContain("/^a/", result.GeneratedCode);
+    }
+
+    // Copilot round 5: patternProperties must hoist RegExp allocation outside
+    // the per-property loop. Without hoisting, each property name allocates a
+    // new RegExp on every validate call.
+    [Fact]
+    public void PatternProperties_HoistsRegexOutsideLoop()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "patternProperties": {
+                "^a": { "type": "integer" },
+                "^b": { "type": "string" }
+              }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, result.Error);
+        var src = result.GeneratedCode!;
+        // Both regexes declared as consts before the for-loop.
+        var hoistIndex = src.IndexOf("const _ppRe", StringComparison.Ordinal);
+        var forIndex = src.IndexOf("for (const _k of Object.keys", StringComparison.Ordinal);
+        Assert.True(hoistIndex > 0 && forIndex > hoistIndex,
+            "Hoisted RegExp constants must appear before the Object.keys loop.");
+    }
+
     // Non-ambiguous case: two resources with different $ref text — not collapsed,
     // and each resolves against its own resource. Regression guard that the
     // ambiguity detector doesn't misfire on schemas that are actually fine.

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -623,6 +623,34 @@ public class JsReviewFixesTests
         Assert.Contains("multiple nested $id resources", result.Error);
     }
 
+    // Copilot round 8: reachability must follow local $ref so a ref target under
+    // a non-applicator container still ends up in the emitted module. Uses the
+    // same "legacy definitions in 2020-12" shape as the round-6 test — the map
+    // fix alone covers the known keyword; the follow-ref fix is a belt-and-
+    // suspenders guarantee that the same pattern works even if the extractor
+    // places the target under a container we don't explicitly walk.
+    [Fact]
+    public void LocalRef_MarksTargetReachable_EvenThroughLegacyContainer()
+    {
+        // If my applicator set missed "definitions" (it does now, but this test
+        // exists to lock the follow-ref behavior regardless), the ref would still
+        // have to resolve and the target's validate_<hash> would still have to
+        // be emitted.
+        Expect(
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "definitions": { "inner": { "type": "integer", "minimum": 0 } },
+              "allOf": [ { "$ref": "#/definitions/inner" } ]
+            }
+            """,
+            [
+                ("5", true),
+                ("-1", false),
+                ("\"no\"", false),
+            ]);
+    }
+
     // Copilot round 7: schema numeric values that exceed long.MaxValue must not
     // silently cast to garbage longs. Out-of-range minLength/maxLength etc. are
     // treated as "no valid integer" and the constraint is skipped.

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -623,6 +623,55 @@ public class JsReviewFixesTests
         Assert.Contains("multiple nested $id resources", result.Error);
     }
 
+    // Copilot round 11: invalid-schema-shape values for applicator keywords
+    // must fail codegen cleanly. Before the fix, a non-object/non-boolean
+    // value for additionalProperties / propertyNames / additionalItems passed
+    // through to hash-based dispatch, but SubschemaExtractor doesn't collect
+    // non-schema values, so the emitted module referenced an undefined
+    // validate_<hash> at runtime.
+    [Fact]
+    public void AdditionalProperties_NonSchemaValue_FailsCodegen()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            { "additionalProperties": 42 }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("additionalProperties", result.Error);
+    }
+
+    [Fact]
+    public void PropertyNames_NonSchemaValue_FailsCodegen()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "propertyNames": "not-a-schema"
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("propertyNames", result.Error);
+    }
+
+    [Fact]
+    public void AdditionalItems_NonSchemaValue_FailsCodegen()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "items": [ { "type": "string" } ],
+              "additionalItems": 99
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("additionalItems", result.Error);
+    }
+
     // Copilot round 10: empty-string $ref must not silently mask sibling
     // keywords in Draft 4-7. Pre-fix: refMasksSiblings triggered on any $ref
     // key (even ""), JsRefCodeGenerator emitted nothing, and the whole

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -557,4 +557,101 @@ public class JsReviewFixesTests
         var result = gen.Generate(schema);
         Assert.True(result.Success, $"Gate wrongly rejected schema: {result.Error}");
     }
+
+    // Codex review: contentSchema metadata must not produce emitter failures
+    // even when it contains keyword shapes that would be invalid as real
+    // subschemas (e.g., items-as-array in Draft 2020-12). The reachability
+    // walk skips annotation keywords, so no validator function is emitted for
+    // the contentSchema contents.
+    [Fact]
+    public void ContentSchema_NotEmitted_EvenIfItContainsInvalidShapes()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+              "contentSchema": { "items": [ { "type": "integer" } ] }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"contentSchema metadata should not cause codegen failure: {result.Error}");
+        Assert.DoesNotContain("validate_", result.GeneratedCode!.Replace($"validate_{SchemaHasher_ComputeRoot(schema)}", ""));
+    }
+
+    // Helper: hash of root schema (extractor keeps root under its own hash).
+    private static string SchemaHasher_ComputeRoot(JsonElement root) =>
+        FormFinch.JsonSchemaValidation.Common.SchemaHasher.ComputeHash(root);
+
+    // Codex review: when two nested $id resources each contain a text-identical
+    // $ref-only subschema, the shared analyzer collapses them to one hash and
+    // retains only the first resource root. Resolving the ref in the second
+    // context would then target the first resource's definition. The reachability
+    // pass detects this and rejects pre-emission.
+    [Fact]
+    public void AmbiguousResourceRef_IsRejected()
+    {
+        // Both A and B nest an identical {"$ref":"#/$defs/T"} subschema. Each
+        // resource defines its own T differently. The shared extractor collapses
+        // the two ref objects to a single SubschemaInfo keyed on the first
+        // resource, so the emitted validator would resolve "#/$defs/T" against
+        // the wrong resource at one of the two call sites. Detector must reject.
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$defs": {
+                "A": {
+                  "$id": "https://example.com/a",
+                  "$defs": { "T": { "type": "integer" } },
+                  "allOf": [ { "$ref": "#/$defs/T" } ]
+                },
+                "B": {
+                  "$id": "https://example.com/b",
+                  "$defs": { "T": { "type": "string" } },
+                  "allOf": [ { "$ref": "#/$defs/T" } ]
+                }
+              },
+              "allOf": [
+                { "$ref": "#/$defs/A" },
+                { "$ref": "#/$defs/B" }
+              ]
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("multiple nested $id resources", result.Error);
+    }
+
+    // Non-ambiguous case: two resources with different $ref text — not collapsed,
+    // and each resolves against its own resource. Regression guard that the
+    // ambiguity detector doesn't misfire on schemas that are actually fine.
+    [Fact]
+    public void DistinctRefsAcrossResources_AreAllowed()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$defs": {
+                "A": {
+                  "$id": "https://example.com/a",
+                  "$defs": { "Ta": { "type": "integer" } },
+                  "$ref": "#/$defs/Ta"
+                },
+                "B": {
+                  "$id": "https://example.com/b",
+                  "$defs": { "Tb": { "type": "string" } },
+                  "$ref": "#/$defs/Tb"
+                }
+              },
+              "allOf": [
+                { "$ref": "#/$defs/A" },
+                { "$ref": "#/$defs/B" }
+              ]
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, result.Error);
+    }
 }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -714,15 +714,13 @@ public class JsReviewFixesTests
     }
 
     // Copilot round 5: regex literal form is brittle for patterns beginning
-    // with '*' because /*.../ parses as a block-comment token. The new
-    // RegexLiteral form uses new RegExp(...) which bypasses the issue.
+    // with '*' because /*.../ parses as a block-comment token. Generator now
+    // uses new RegExp("...") construction which sidesteps the hazard entirely.
+    // The emitted-source check covers ALL patterns, not just the leading-*
+    // case — any schema-supplied pattern is now kept out of JS tokenisation.
     [Fact]
-    public void Pattern_StartingWithAsterisk_StillCompiles()
+    public void PatternEmission_UsesConstructorFormNotLiteralSlash()
     {
-        // A bare "*" is not a valid ECMAScript regex, but the generator must
-        // produce SYNTACTICALLY VALID JS source regardless. If it emitted
-        // /*/ the module wouldn't even parse; with new RegExp("*") the module
-        // parses and the invalid pattern would only fail at RegExp construction.
         var gen = new JsSchemaCodeGenerator();
         var schema = JsonDocument.Parse("""
             { "patternProperties": { "^a": { "type": "integer" } } }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -455,37 +455,89 @@ public class JsReviewFixesTests
     // Copilot review: isInteger must not accept BigInt, since numeric-constraint
     // emitters only handle `typeof v === "number"`. Accepting BigInt in the type
     // check would let values silently skip minimum/maximum/multipleOf.
+    // Copilot round 3: NaN/Infinity must not silently pass numeric constraints
+    // or type: number. JSON.parse can't produce them, but direct API callers can.
     [Fact]
-    public void Integer_RejectsBigInt_SoNumericConstraintsApplyConsistently()
+    public void Type_Number_RejectsNaN_ViaDirectApi()
     {
+        AssertVerdictForJsExpr("""{ "type": "number" }""", "NaN", false);
+        AssertVerdictForJsExpr("""{ "type": "number" }""", "Infinity", false);
+        AssertVerdictForJsExpr("""{ "type": "number" }""", "-Infinity", false);
+        AssertVerdictForJsExpr("""{ "type": "number" }""", "42", true);
+    }
+
+    [Fact]
+    public void TypeNumber_Plus_Minimum_RejectsNaN()
+    {
+        // With type: number enforcing finiteness, NaN fails type before reaching
+        // numeric constraints. Confirms the guard keeps NaN from slipping through.
+        AssertVerdictForJsExpr("""{ "type": "number", "minimum": 0 }""", "NaN", false);
+        AssertVerdictForJsExpr("""{ "type": "number", "minimum": 0 }""", "Infinity", false);
+        AssertVerdictForJsExpr("""{ "type": "number", "minimum": 0 }""", "1", true);
+        AssertVerdictForJsExpr("""{ "type": "number", "minimum": 0 }""", "-1", false);
+    }
+
+    [Fact]
+    public void BareMinimum_SkipsNaN_AsUnknownType()
+    {
+        // Without type: number the schema doesn't restrict type, and JSON Schema
+        // numeric constraints only apply to JSON numbers — NaN isn't one. Validator
+        // returns true because no applicable constraint was violated.
+        AssertVerdictForJsExpr("""{ "minimum": 0 }""", "NaN", true);
+        AssertVerdictForJsExpr("""{ "minimum": 0 }""", "1", true);
+        AssertVerdictForJsExpr("""{ "minimum": 0 }""", "-1", false);
+    }
+
+    [Fact]
+    public void StringConstraints_DoNotEmitUnusedRuntimeImport()
+    {
+        // When minLength/maxLength are present but non-integer, GenerateCode
+        // ignores them and must NOT import graphemeLength.
         var gen = new JsSchemaCodeGenerator();
         var schema = JsonDocument.Parse("""
-            { "type": "integer", "minimum": 1 }
+            { "minLength": "not-an-integer" }
             """).RootElement;
         var result = gen.Generate(schema);
         Assert.True(result.Success, result.Error);
+        Assert.DoesNotContain("graphemeLength", result.GeneratedCode);
+    }
 
-        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-bigint-" + Guid.NewGuid().ToString("N"));
+    private static void AssertVerdictForJsExpr(string schemaJson, string dataJsExpr, bool expected)
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse(schemaJson).RootElement;
+        var genResult = gen.Generate(schema);
+        Assert.True(genResult.Success, genResult.Error);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-direct-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
         try
         {
             File.WriteAllText(
                 Path.Combine(tempDir, FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime.JsRuntime.FileName),
                 FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime.JsRuntime.GetSource());
-            File.WriteAllText(Path.Combine(tempDir, "validator.js"), result.GeneratedCode!);
-
-            var engine = new Jint.Engine(opts => opts.EnableModules(tempDir));
+            File.WriteAllText(Path.Combine(tempDir, "validator.js"), genResult.GeneratedCode!);
+            var engine = new Engine(opts => opts.EnableModules(tempDir));
             var module = engine.Modules.Import("./validator.js");
             var validate = module.Get("validate");
-            var verdict = engine.Invoke(validate, engine.Evaluate("5n"));
-            Assert.True(verdict.IsBoolean());
-            // BigInt 5n would pass minimum=1 if isInteger returned true, but with
-            // the fix it's rejected at the type check.
-            Assert.False(verdict.AsBoolean());
+            var verdict = engine.Invoke(validate, engine.Evaluate(dataJsExpr));
+            Assert.True(verdict.IsBoolean(),
+                $"Non-boolean verdict for {dataJsExpr}. Source:\n{genResult.GeneratedCode}");
+            Assert.True(verdict.AsBoolean() == expected,
+                $"Data {dataJsExpr}: expected {expected}, got {verdict.AsBoolean()}.\n" +
+                $"Source:\n{genResult.GeneratedCode}");
         }
         finally
         {
             try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
         }
+    }
+
+    [Fact]
+    public void Integer_RejectsBigInt_SoNumericConstraintsApplyConsistently()
+    {
+        // BigInt would pass minimum=1 if isInteger returned true for it, but with
+        // the fix it's rejected at the type check before numeric constraints run.
+        AssertVerdictForJsExpr("""{ "type": "integer", "minimum": 1 }""", "5n", false);
     }
 }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -239,4 +239,128 @@ public class JsReviewFixesTests
                 ("\"2023-01-15T23:61:00Z\"", false),
             ]);
     }
+
+    // [P2] Gate is draft-aware. Post-Draft-4 keywords like unevaluatedProperties
+    // or $dynamicRef are unknown keywords in Draft 4 and must be ignored, not
+    // rejected. Schema-valued keywords that don't exist in Draft 4 (propertyNames,
+    // if/then/else, contains, dependentSchemas, $defs) must not be traversed.
+    [Fact]
+    public void Gate_Draft4_AcceptsUnevaluatedProperties_AsUnknownKeyword()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "unevaluatedProperties": false
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected Draft 4 schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_Draft4_AcceptsDynamicRef_AsUnknownKeyword()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "$dynamicRef": "#meta"
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected Draft 4 schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_Draft4_DoesNotTraverseIntoPropertyNames()
+    {
+        // propertyNames is unknown in Draft 4. Even if its value contains a
+        // keyword that WOULD be deferred in 2020-12, Draft 4 must ignore
+        // the whole structure.
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "propertyNames": { "unevaluatedProperties": false }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected Draft 4 schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_Draft4_DoesNotTraverseIntoIfThenElse()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "if": { "$dynamicRef": "#x" },
+              "then": { "unevaluatedItems": false }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected Draft 4 schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_Draft4_DoesNotTraverseIntoContains()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "contains": { "$recursiveRef": "#x" }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected Draft 4 schema: {result.Error}");
+    }
+
+    [Fact]
+    public void Gate_Draft4_DoesNotTraverseIntoDefs()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "$defs": { "a": { "unevaluatedProperties": false } }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected Draft 4 schema: {result.Error}");
+    }
+
+    // Draft 2020-12 behavior is unchanged — must still reject real deferred
+    // features when the keyword exists in the detected draft.
+    [Fact]
+    public void Gate_Draft202012_StillRejectsUnevaluatedProperties()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "unevaluatedProperties": false
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("unevaluatedProperties", result.Error);
+    }
+
+    [Fact]
+    public void Gate_Draft202012_StillRejectsDynamicRef()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$dynamicRef": "#meta"
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.False(result.Success);
+        Assert.Contains("$dynamicRef", result.Error);
+    }
 }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -623,6 +623,28 @@ public class JsReviewFixesTests
         Assert.Contains("multiple nested $id resources", result.Error);
     }
 
+    // Copilot round 6: legacy "definitions" used under Draft 2020-12. The
+    // shared extractor walks it, so $ref targets under #/definitions must be
+    // emitted as validators. If they aren't, the generated JS calls a
+    // missing validate_<hash> at runtime.
+    [Fact]
+    public void Draft202012_LegacyDefinitions_WithRef_IsValidatedCorrectly()
+    {
+        Expect(
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "definitions": { "nonnegInt": { "type": "integer", "minimum": 0 } },
+              "$ref": "#/definitions/nonnegInt"
+            }
+            """,
+            [
+                ("5", true),
+                ("-1", false),
+                ("\"x\"", false),
+            ]);
+    }
+
     // Copilot round 5: gate should mirror the emitter's $ref-siblings-masked
     // behavior for Draft 4-7 — any sibling keyword is ignored at emission, so
     // the gate shouldn't reject a schema because those ignored siblings contain

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -623,6 +623,29 @@ public class JsReviewFixesTests
         Assert.Contains("multiple nested $id resources", result.Error);
     }
 
+    // Copilot round 10: empty-string $ref must not silently mask sibling
+    // keywords in Draft 4-7. Pre-fix: refMasksSiblings triggered on any $ref
+    // key (even ""), JsRefCodeGenerator emitted nothing, and the whole
+    // validator compiled to always-true. Now the mask only applies when $ref
+    // is a usable non-empty string, so siblings like type/required still run.
+    [Fact]
+    public void EmptyRef_DoesNotMaskSiblings_InDraft4()
+    {
+        Expect(
+            """
+            {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "$ref": "",
+              "type": "integer"
+            }
+            """,
+            [
+                ("5", true),
+                ("\"not-int\"", false),
+                ("{}", false),
+            ]);
+    }
+
     // Copilot round 8: reachability must follow local $ref so a ref target under
     // a non-applicator container still ends up in the emitted module. Uses the
     // same "legacy definitions in 2020-12" shape as the round-6 test — the map

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -540,4 +540,21 @@ public class JsReviewFixesTests
         // the fix it's rejected at the type check before numeric constraints run.
         AssertVerdictForJsExpr("""{ "type": "integer", "minimum": 1 }""", "5n", false);
     }
+
+    // Copilot round 4: contentSchema is annotation-only in this codebase.
+    // Gate must not traverse into it and reject on nested deferred keywords.
+    [Fact]
+    public void Gate_DoesNotTraverseIntoContentSchema()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+              "contentSchema": { "unevaluatedProperties": false }
+            }
+            """).RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, $"Gate wrongly rejected schema: {result.Error}");
+    }
 }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -623,6 +623,24 @@ public class JsReviewFixesTests
         Assert.Contains("multiple nested $id resources", result.Error);
     }
 
+    // Copilot round 7: schema numeric values that exceed long.MaxValue must not
+    // silently cast to garbage longs. Out-of-range minLength/maxLength etc. are
+    // treated as "no valid integer" and the constraint is skipped.
+    [Fact]
+    public void MinLength_WithOutOfRangeValue_IsIgnored_NoGarbageEmitted()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        // 1e20 fits in a double but overflows long. Before the fix this cast
+        // produced an unspecified long and the emitted JS contained a bogus
+        // comparison. After the fix, the constraint is treated as unparseable
+        // and skipped entirely, so no length check appears in the output.
+        var schema = JsonDocument.Parse("""{ "minLength": 1e20 }""").RootElement;
+        var result = gen.Generate(schema);
+        Assert.True(result.Success, result.Error);
+        Assert.DoesNotContain("_len <", result.GeneratedCode);
+        Assert.DoesNotContain("graphemeLength", result.GeneratedCode);
+    }
+
     // Copilot round 6: legacy "definitions" used under Draft 2020-12. The
     // shared extractor walks it, so $ref targets under #/definitions must be
     // emitted as validators. If they aren't, the generated JS calls a

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsRuntimeTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsRuntimeTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+public class JsRuntimeTests
+{
+    [Fact]
+    public void GetSource_ReturnsNonEmpty()
+    {
+        var source = JsRuntime.GetSource();
+        Assert.NotNull(source);
+        Assert.NotEmpty(source);
+    }
+
+    [Theory]
+    [InlineData("export function escapeJsonPointer")]
+    [InlineData("export function graphemeLength")]
+    [InlineData("export function isInteger")]
+    [InlineData("export function deepEquals")]
+    public void GetSource_ExposesFrozenHelpers(string expectedFragment)
+    {
+        var source = JsRuntime.GetSource();
+        Assert.Contains(expectedFragment, source);
+    }
+
+    [Theory]
+    [InlineData("isValidDateTime")]
+    [InlineData("isValidDate")]
+    [InlineData("isValidTime")]
+    [InlineData("isValidDuration")]
+    [InlineData("isValidEmail")]
+    [InlineData("isValidIdnEmail")]
+    [InlineData("isValidHostname")]
+    [InlineData("isValidIdnHostname")]
+    [InlineData("isValidIpv4")]
+    [InlineData("isValidIpv6")]
+    [InlineData("isValidUri")]
+    [InlineData("isValidUriReference")]
+    [InlineData("isValidUriTemplate")]
+    [InlineData("isValidIri")]
+    [InlineData("isValidIriReference")]
+    [InlineData("isValidJsonPointer")]
+    [InlineData("isValidRelativeJsonPointer")]
+    [InlineData("isValidRegex")]
+    [InlineData("isValidUuid")]
+    public void GetSource_ExposesAllFrozenFormatNames(string formatExport)
+    {
+        var source = JsRuntime.GetSource();
+        // Format exports can be `export function name` or `export const name = ...` (for aliases).
+        var asFunction = source.Contains($"export function {formatExport}");
+        var asConst = source.Contains($"export const {formatExport}");
+        Assert.True(asFunction || asConst, $"Runtime does not export '{formatExport}' as function or const.");
+    }
+
+    [Fact]
+    public void GetSource_StampsAbiVersion()
+    {
+        var source = JsRuntime.GetSource();
+        Assert.Contains("ABI VERSION: mvp-0", source);
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsSchemaCodeGeneratorTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsSchemaCodeGeneratorTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+public class JsSchemaCodeGeneratorTests
+{
+    private readonly JsSchemaCodeGenerator _generator = new();
+
+    [Fact]
+    public void Generate_BooleanTrue_EmitsTrueModule()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("true").RootElement);
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("return true;", result.GeneratedCode);
+        Assert.Contains("export function validate(data)", result.GeneratedCode);
+        Assert.Contains("export default", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_BooleanFalse_EmitsFalseModule()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("false").RootElement);
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("return false;", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_SkeletonModule_ExportsValidate()
+    {
+        // Phase 1: no keyword emitters registered yet, so the body reduces to the default
+        // "return true;" skeleton. This confirms the module shell is well-formed.
+        var result = _generator.Generate(JsonDocument.Parse("""{ "type": "string" }""").RootElement);
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("export function validate(data)", result.GeneratedCode);
+        Assert.Contains("export const schemaUri", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_RejectsUnsupportedFeature_ViaGate()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""
+            { "type": "object", "unevaluatedProperties": false }
+            """).RootElement);
+        Assert.False(result.Success);
+        Assert.Contains("unevaluatedProperties", result.Error);
+    }
+
+    [Fact]
+    public void Generate_RejectsExternalRef_ViaGate()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""
+            { "$ref": "https://example.com/other.json" }
+            """).RootElement);
+        Assert.False(result.Success);
+        Assert.Contains("external $ref", result.Error);
+    }
+
+    [Fact]
+    public void Generate_SetsSchemaUri_FromId()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""
+            { "$id": "https://example.com/s.json", "type": "string" }
+            """).RootElement);
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("\"https://example.com/s.json\"", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_NoSchemaUri_EmitsNull()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""{ "type": "string" }""").RootElement);
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("export const schemaUri = null;", result.GeneratedCode);
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsTestHelpers.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsTestHelpers.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// Shared helpers for JS-target tests. Keeps escape/quoting rules in one place
+/// so harness and suite runner can't drift.
+/// </summary>
+internal static class JsTestHelpers
+{
+    // U+2028 / U+2029 kept out of source via hex casts; both are line
+    // terminators in the C# lexer and would break character-literal parsing.
+    private const char LineSeparator = (char)0x2028;
+    private const char ParagraphSeparator = (char)0x2029;
+
+    /// <summary>
+    /// Wraps <paramref name="input"/> as a JS string literal whose decoded
+    /// value is the same text, suitable for feeding to <c>JSON.parse(...)</c>
+    /// inside Jint. Two-level escaping: U+2028/U+2029 first so the JSON layer
+    /// preserves them as escape sequences (Jint's JSON.parse rejects literal
+    /// line terminators inside JSON strings), then backslashes/quotes/newlines
+    /// so the JS string literal itself is well-formed.
+    /// </summary>
+    public static string ToJsStringLiteral(string input)
+    {
+        return "\"" + input
+            .Replace(LineSeparator.ToString(), "\\u2028")
+            .Replace(ParagraphSeparator.ToString(), "\\u2029")
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r") + "\"";
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
@@ -215,6 +215,8 @@ public class JsTestSuiteRunner
     private static string ToJsStringLiteral(string input)
     {
         return "\"" + input
+            .Replace("\u2028", "\\u2028")
+            .Replace("\u2029", "\\u2029")
             .Replace("\\", "\\\\")
             .Replace("\"", "\\\"")
             .Replace("\n", "\\n")

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
@@ -127,7 +127,13 @@ public class JsTestSuiteRunner
         SchemaDraft draft)
     {
         var suitePath = FindTestSuitePath();
-        if (suitePath == null) yield break;
+        if (suitePath == null)
+        {
+            // Surface missing submodule as a single failing case rather than
+            // silently running zero cases (which would mask CI misconfiguration).
+            yield return [TestCase.MissingSuite(draft)];
+            yield break;
+        }
 
         foreach (var file in files)
         {
@@ -153,6 +159,15 @@ public class JsTestSuiteRunner
 
     private void RunCase(TestCase tc)
     {
+        if (tc.IsMissingSuiteSentinel)
+        {
+            Assert.Fail(
+                "JSON-Schema-Test-Suite submodule is not available on this machine. " +
+                "Run 'git submodule update --init' (or ensure submodules/JSON-Schema-Test-Suite/tests/ " +
+                "exists) before running the JS suite runner — otherwise the Theory silently yields " +
+                "zero cases and masks broad-coverage regressions.");
+        }
+
         foreach (var (contains, why) in CaseSkips)
         {
             if (tc.GroupDescription.Contains(contains, StringComparison.OrdinalIgnoreCase) ||
@@ -223,6 +238,14 @@ public class JsTestSuiteRunner
         string DataJson,
         bool Expected)
     {
+        public bool IsMissingSuiteSentinel { get; init; }
+
+        public static TestCase MissingSuite(SchemaDraft draft) => new(
+            draft, "(missing submodule)", "JSON-Schema-Test-Suite submodule is not checked out",
+            "run 'git submodule update --init' before running tests",
+            "{}", "null", true)
+        { IsMissingSuiteSentinel = true };
+
         public override string ToString() =>
             $"[{Draft}/{File}] {GroupDescription} -> {TestDescription}";
     }

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
@@ -168,8 +168,9 @@ public class JsTestSuiteRunner
         var genResult = generator.Generate(schemaElement);
         if (!genResult.Success)
         {
-            // Gate rejection = legitimate skip for MVP.
-            if (genResult.Error!.Contains("JS target MVP") || genResult.Error.Contains("external $ref"))
+            // Gate rejection = legitimate skip for MVP. Use the stable prefix
+            // constant instead of substring-matching free-form wording.
+            if (genResult.Error!.StartsWith(JsCapabilityGate.RejectionPrefix, StringComparison.Ordinal))
             {
                 _output.WriteLine($"SKIP (gate): {tc} — {genResult.Error}");
                 return;
@@ -187,7 +188,7 @@ public class JsTestSuiteRunner
             var module = engine.Modules.Import("./validator.js");
             var validate = module.Get("validate");
 
-            var parsed = engine.Evaluate($"JSON.parse({ToJsStringLiteral(tc.DataJson)})");
+            var parsed = engine.Evaluate($"JSON.parse({JsTestHelpers.ToJsStringLiteral(tc.DataJson)})");
             var verdictRaw = engine.Invoke(validate, parsed);
             Assert.True(verdictRaw.IsBoolean(), $"Non-boolean verdict for {tc}");
             var actual = verdictRaw.AsBoolean();
@@ -212,16 +213,6 @@ public class JsTestSuiteRunner
         return null;
     }
 
-    private static string ToJsStringLiteral(string input)
-    {
-        return "\"" + input
-            .Replace("\u2028", "\\u2028")
-            .Replace("\u2029", "\\u2029")
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"")
-            .Replace("\n", "\\n")
-            .Replace("\r", "\\r") + "\"";
-    }
 
     public sealed record TestCase(
         SchemaDraft Draft,

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using Jint;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// Runs the MVP-relevant subset of the official JSON Schema Test Suite against
+/// the JS emitter + Jint runtime. Supplements the explicit-verdict tests by
+/// confirming the emitter tracks spec behavior on a wide range of real schemas.
+///
+/// Schemas that trip the JS capability gate (deferred features like external
+/// $ref or unevaluated*) are counted as legitimate skips, not failures — the
+/// gate is doing its job.
+/// </summary>
+public class JsTestSuiteRunner
+{
+    private readonly ITestOutputHelper _output;
+    public JsTestSuiteRunner(ITestOutputHelper output) => _output = output;
+
+    // MVP keyword coverage: one file per keyword family. Drives enough breadth
+    // to catch emitter regressions without turning this into a whole-suite run.
+    private static readonly string[] Draft202012Files =
+    [
+        "type.json",
+        "required.json",
+        "properties.json",
+        "enum.json",
+        "const.json",
+        "minLength.json",
+        "maxLength.json",
+        "pattern.json",
+        "minimum.json",
+        "maximum.json",
+        "exclusiveMinimum.json",
+        "exclusiveMaximum.json",
+        "multipleOf.json",
+        "minItems.json",
+        "maxItems.json",
+        "uniqueItems.json",
+        "minProperties.json",
+        "maxProperties.json",
+        "minContains.json",
+        "maxContains.json",
+        "items.json",
+        "prefixItems.json",
+        "contains.json",
+        "patternProperties.json",
+        "additionalProperties.json",
+        "propertyNames.json",
+        "allOf.json",
+        "anyOf.json",
+        "oneOf.json",
+        "not.json",
+        "if-then-else.json",
+        "dependentRequired.json",
+        "dependentSchemas.json",
+        "boolean_schema.json",
+        "ref.json",
+        "defs.json",
+        // format.json is deliberately excluded: the suite expects annotation-only
+        // behavior by default (2020-12 spec), while our compiled path eager-validates
+        // supported formats — same stance as the C# compiled tests. Explicit format
+        // coverage lives in JsFormatTests.
+    ];
+
+    private static readonly string[] Draft4Files =
+    [
+        "type.json",
+        "required.json",
+        "properties.json",
+        "enum.json",
+        "minLength.json",
+        "maxLength.json",
+        "pattern.json",
+        "minimum.json",
+        "maximum.json",
+        "multipleOf.json",
+        "minItems.json",
+        "maxItems.json",
+        "uniqueItems.json",
+        "minProperties.json",
+        "maxProperties.json",
+        "items.json",
+        "patternProperties.json",
+        "additionalProperties.json",
+        "allOf.json",
+        "anyOf.json",
+        "oneOf.json",
+        "not.json",
+        "dependencies.json",
+    ];
+
+    // Test-description substrings whose cases we intentionally bypass — each
+    // reason is called out so future-me knows what a bypass covers. Anything
+    // listed here is material worth reviewing when expanding scope.
+    private static readonly (string Contains, string Why)[] CaseSkips =
+    [
+        ("remote ref", "Gate rejects external refs — deferred feature."),
+        ("base URI change", "Gate rejects cross-document refs — deferred feature."),
+    ];
+
+    [Theory]
+    [MemberData(nameof(Draft202012Cases))]
+    public void Draft202012(TestCase tc) => RunCase(tc);
+
+    [Theory]
+    [MemberData(nameof(Draft4Cases))]
+    public void Draft4(TestCase tc) => RunCase(tc);
+
+    public static IEnumerable<object[]> Draft202012Cases() =>
+        EnumerateCases("draft2020-12", Draft202012Files, SchemaDraft.Draft202012);
+
+    public static IEnumerable<object[]> Draft4Cases() =>
+        EnumerateCases("draft4", Draft4Files, SchemaDraft.Draft4);
+
+    private static IEnumerable<object[]> EnumerateCases(
+        string draftFolder,
+        string[] files,
+        SchemaDraft draft)
+    {
+        var suitePath = FindTestSuitePath();
+        if (suitePath == null) yield break;
+
+        foreach (var file in files)
+        {
+            var full = Path.Combine(suitePath, "tests", draftFolder, file);
+            if (!File.Exists(full)) continue;
+
+            var json = File.ReadAllText(full);
+            using var doc = JsonDocument.Parse(json);
+            foreach (var group in doc.RootElement.EnumerateArray())
+            {
+                var groupDesc = group.GetProperty("description").GetString() ?? "";
+                var schema = group.GetProperty("schema").GetRawText();
+                foreach (var test in group.GetProperty("tests").EnumerateArray())
+                {
+                    var testDesc = test.GetProperty("description").GetString() ?? "";
+                    var data = test.GetProperty("data").GetRawText();
+                    var valid = test.GetProperty("valid").GetBoolean();
+                    yield return [new TestCase(draft, file, groupDesc, testDesc, schema, data, valid)];
+                }
+            }
+        }
+    }
+
+    private void RunCase(TestCase tc)
+    {
+        foreach (var (contains, why) in CaseSkips)
+        {
+            if (tc.GroupDescription.Contains(contains, StringComparison.OrdinalIgnoreCase) ||
+                tc.TestDescription.Contains(contains, StringComparison.OrdinalIgnoreCase))
+            {
+                _output.WriteLine($"SKIP: {tc} — {why}");
+                return;
+            }
+        }
+
+        var generator = new JsSchemaCodeGenerator { DefaultDraft = tc.Draft };
+        var schemaElement = JsonDocument.Parse(tc.SchemaJson).RootElement;
+        var genResult = generator.Generate(schemaElement);
+        if (!genResult.Success)
+        {
+            // Gate rejection = legitimate skip for MVP.
+            if (genResult.Error!.Contains("JS target MVP") || genResult.Error.Contains("external $ref"))
+            {
+                _output.WriteLine($"SKIP (gate): {tc} — {genResult.Error}");
+                return;
+            }
+            Assert.Fail($"Codegen failed for {tc}: {genResult.Error}");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-suite-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, JsRuntime.FileName), JsRuntime.GetSource());
+            File.WriteAllText(Path.Combine(tempDir, "validator.js"), genResult.GeneratedCode!);
+            var engine = new Engine(opts => opts.EnableModules(tempDir));
+            var module = engine.Modules.Import("./validator.js");
+            var validate = module.Get("validate");
+
+            var parsed = engine.Evaluate($"JSON.parse({ToJsStringLiteral(tc.DataJson)})");
+            var verdictRaw = engine.Invoke(validate, parsed);
+            Assert.True(verdictRaw.IsBoolean(), $"Non-boolean verdict for {tc}");
+            var actual = verdictRaw.AsBoolean();
+            Assert.True(actual == tc.Expected,
+                $"{tc}\nExpected: {tc.Expected}, Got: {actual}\nSchema: {tc.SchemaJson}\nData: {tc.DataJson}\nSource:\n{genResult.GeneratedCode}");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static string? FindTestSuitePath()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "submodules", "JSON-Schema-Test-Suite");
+            if (Directory.Exists(Path.Combine(candidate, "tests"))) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+
+    private static string ToJsStringLiteral(string input)
+    {
+        return "\"" + input
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r") + "\"";
+    }
+
+    public sealed record TestCase(
+        SchemaDraft Draft,
+        string File,
+        string GroupDescription,
+        string TestDescription,
+        string SchemaJson,
+        string DataJson,
+        bool Expected)
+    {
+        public override string ToString() =>
+            $"[{Draft}/{File}] {GroupDescription} -> {TestDescription}";
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
@@ -24,7 +24,10 @@ public sealed class JsValidatorHarness
     /// </summary>
     public HarnessResult Evaluate(string schemaJson, IEnumerable<string> dataJsonValues)
     {
-        var schemaElement = JsonDocument.Parse(schemaJson).RootElement;
+        // JsonElement is backed by JsonDocument's pooled buffers; dispose the
+        // document once we've lifted the schema into generator-owned form via Clone.
+        using var schemaDoc = JsonDocument.Parse(schemaJson);
+        var schemaElement = schemaDoc.RootElement.Clone();
         var genResult = _generator.Generate(schemaElement);
         if (!genResult.Success)
         {

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
@@ -78,7 +78,14 @@ public sealed class JsValidatorHarness
 
     private static string ToJsStringLiteral(string input)
     {
+        // Two-level escaping: the result is a JS string literal whose decoded value
+        // is JSON text for JSON.parse. U+2028/U+2029 must reach JSON.parse as the
+        // JSON escape sequence \u2028 / \u2029 (Jint's JSON.parse rejects literal
+        // line terminators). So: replace U+2028 with "\u2028" first, then double
+        // all backslashes so the JS string decodes to a literal backslash for JSON.
         return "\"" + input
+            .Replace("\u2028", "\\u2028")
+            .Replace("\u2029", "\\u2029")
             .Replace("\\", "\\\\")
             .Replace("\"", "\\\"")
             .Replace("\n", "\\n")

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using Jint;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// Tests drive generated JS through Jint to prove emitted output is executable
+/// and produces the expected verdicts. The harness writes the validator and
+/// runtime to a temp directory so Jint's default module loader can resolve
+/// the emitter's canonical "./jsv-runtime.js" import — the same resolution
+/// path a real ESM consumer uses.
+/// </summary>
+public sealed class JsValidatorHarness
+{
+    private readonly JsSchemaCodeGenerator _generator = new();
+
+    /// <summary>
+    /// Generates JS for the schema and executes it against each data value.
+    /// </summary>
+    public HarnessResult Evaluate(string schemaJson, IEnumerable<string> dataJsonValues)
+    {
+        var schemaElement = JsonDocument.Parse(schemaJson).RootElement;
+        var genResult = _generator.Generate(schemaElement);
+        if (!genResult.Success)
+        {
+            return new HarnessResult(false, genResult.Error, null, []);
+        }
+
+        var validatorSource = genResult.GeneratedCode!;
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-harness-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, JsRuntime.FileName), JsRuntime.GetSource());
+            File.WriteAllText(Path.Combine(tempDir, "validator.js"), validatorSource);
+
+            var engine = new Engine(opts => opts.EnableModules(tempDir));
+            var module = engine.Modules.Import("./validator.js");
+            var validate = module.Get("validate");
+
+            var verdicts = new List<bool>();
+            foreach (var dataJson in dataJsonValues)
+            {
+                var parsed = engine.Evaluate($"JSON.parse({ToJsStringLiteral(dataJson)})");
+                var verdictRaw = engine.Invoke(validate, parsed);
+                if (!verdictRaw.IsBoolean())
+                {
+                    return new HarnessResult(false,
+                        $"validate() did not return a boolean (got {verdictRaw.Type}).",
+                        validatorSource, verdicts);
+                }
+                verdicts.Add(verdictRaw.AsBoolean());
+            }
+            return new HarnessResult(true, null, validatorSource, verdicts);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Probes whether Intl.Segmenter is available in the Jint build.
+    /// </summary>
+    public static bool IntlSegmenterAvailable()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(
+            "typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'");
+        return result.AsBoolean();
+    }
+
+    private static string ToJsStringLiteral(string input)
+    {
+        return "\"" + input
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r") + "\"";
+    }
+
+    public sealed record HarnessResult(
+        bool Success,
+        string? Error,
+        string? GeneratedSource,
+        IReadOnlyList<bool> Verdicts);
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsValidatorHarness.cs
@@ -47,7 +47,7 @@ public sealed class JsValidatorHarness
             var verdicts = new List<bool>();
             foreach (var dataJson in dataJsonValues)
             {
-                var parsed = engine.Evaluate($"JSON.parse({ToJsStringLiteral(dataJson)})");
+                var parsed = engine.Evaluate($"JSON.parse({JsTestHelpers.ToJsStringLiteral(dataJson)})");
                 var verdictRaw = engine.Invoke(validate, parsed);
                 if (!verdictRaw.IsBoolean())
                 {
@@ -74,22 +74,6 @@ public sealed class JsValidatorHarness
         var result = engine.Evaluate(
             "typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'");
         return result.AsBoolean();
-    }
-
-    private static string ToJsStringLiteral(string input)
-    {
-        // Two-level escaping: the result is a JS string literal whose decoded value
-        // is JSON text for JSON.parse. U+2028/U+2029 must reach JSON.parse as the
-        // JSON escape sequence \u2028 / \u2029 (Jint's JSON.parse rejects literal
-        // line terminators). So: replace U+2028 with "\u2028" first, then double
-        // all backslashes so the JS string decodes to a literal backslash for JSON.
-        return "\"" + input
-            .Replace("\u2028", "\\u2028")
-            .Replace("\u2029", "\\u2029")
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"")
-            .Replace("\n", "\\n")
-            .Replace("\r", "\\r") + "\"";
     }
 
     public sealed record HarnessResult(

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsVerticalSliceTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsVerticalSliceTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// End-to-end execution tests for the vertical slice:
+/// type, required, properties, pattern, minLength/maxLength.
+/// Generates JS, executes via Jint against the shared runtime, and checks
+/// verdicts to prove the emitter + runtime wiring is correct before we
+/// expand keyword coverage.
+/// </summary>
+public class JsVerticalSliceTests
+{
+    private readonly JsValidatorHarness _harness = new();
+
+    private void Expect(string schema, (string data, bool expected)[] cases)
+    {
+        var result = _harness.Evaluate(schema, cases.Select(c => c.data));
+        Assert.True(result.Success, result.Error);
+        for (var i = 0; i < cases.Length; i++)
+        {
+            Assert.True(
+                result.Verdicts[i] == cases[i].expected,
+                $"Data {cases[i].data}: expected {cases[i].expected}, got {result.Verdicts[i]}.\n" +
+                $"Emitted source:\n{result.GeneratedSource}");
+        }
+    }
+
+    [Fact]
+    public void Type_String_RejectsNonStrings()
+    {
+        Expect(
+            """{ "type": "string" }""",
+            [
+                ("\"hello\"", true),
+                ("42", false),
+                ("null", false),
+                ("true", false),
+                ("[]", false),
+                ("{}", false),
+            ]);
+    }
+
+    [Fact]
+    public void Type_Integer_AcceptsIntegerValuedNumbers()
+    {
+        Expect(
+            """{ "type": "integer" }""",
+            [
+                ("5", true),
+                ("-17", true),
+                ("0", true),
+                ("5.0", true),
+                ("5.5", false),
+                ("\"5\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void Type_Object_RejectsArraysAndNull()
+    {
+        Expect(
+            """{ "type": "object" }""",
+            [
+                ("{}", true),
+                ("{\"k\":1}", true),
+                ("[]", false),
+                ("null", false),
+                ("42", false),
+            ]);
+    }
+
+    [Fact]
+    public void Type_Array_OfStrings_Or_Numbers()
+    {
+        Expect(
+            """{ "type": ["string", "number"] }""",
+            [
+                ("\"x\"", true),
+                ("42", true),
+                ("true", false),
+                ("null", false),
+            ]);
+    }
+
+    [Fact]
+    public void Required_OnlyAppliesToObjects()
+    {
+        Expect(
+            """{ "required": ["name", "age"] }""",
+            [
+                ("{\"name\":\"a\",\"age\":1}", true),
+                ("{\"name\":\"a\"}", false),
+                ("{}", false),
+                ("42", true),             // required is a no-op for non-objects
+                ("[\"name\",\"age\"]", true),
+            ]);
+    }
+
+    [Fact]
+    public void Properties_RecursivelyValidatesEachKnownKey()
+    {
+        Expect(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "age": { "type": "integer" }
+              }
+            }
+            """,
+            [
+                ("{\"name\":\"a\",\"age\":1}", true),
+                ("{\"name\":123}", false),
+                ("{\"age\":1.5}", false),
+                ("{\"age\":1}", true),
+                ("{}", true),             // no required constraint
+            ]);
+    }
+
+    [Fact]
+    public void Pattern_IsECMAScriptRegex_OnStrings()
+    {
+        Expect(
+            """{ "pattern": "^[a-z]+$" }""",
+            [
+                ("\"hello\"", true),
+                ("\"Hello\"", false),
+                ("\"\"", false),
+                ("42", true),             // non-strings bypass the pattern check
+            ]);
+    }
+
+    [Fact]
+    public void MinLength_And_MaxLength_CountGraphemes()
+    {
+        Expect(
+            """{ "minLength": 2, "maxLength": 4 }""",
+            [
+                ("\"ab\"", true),
+                ("\"abcd\"", true),
+                ("\"a\"", false),
+                ("\"abcde\"", false),
+                // Emoji flag is a single grapheme cluster (2 code points).
+                // Grapheme counter (when Intl.Segmenter available) says length 1,
+                // so "🇳🇱" fails minLength 2. Fallback path counts code points = 2 (passes).
+                // The harness asserts the Intl.Segmenter-aware verdict since Jint 4.8 ships it.
+                ("\"\\uD83C\\uDDF3\\uD83C\\uDDF1\"", false),
+            ]);
+    }
+
+    [Fact]
+    public void RequiresProperties_Compose_TopLevel()
+    {
+        Expect(
+            """
+            {
+              "type": "object",
+              "required": ["id"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 }
+              }
+            }
+            """,
+            [
+                ("{\"id\":\"abc\"}", true),
+                ("{\"id\":\"\"}", false),     // minLength 1 fails
+                ("{\"id\":1}", false),         // type string fails
+                ("{}", false),                 // required id fails
+                ("\"raw\"", false),            // type: object — string rejected at the type check
+            ]);
+    }
+
+    [Fact]
+    public void Probe_IntlSegmenter_IsAvailable_InJint()
+    {
+        // If Jint ever ships without Intl.Segmenter, this test fires first and
+        // signals that the runtime's code-point fallback needs to be validated
+        // against the test suite before broad keyword work proceeds.
+        Assert.True(JsValidatorHarness.IntlSegmenterAvailable(),
+            "Intl.Segmenter not present in this Jint build; runtime grapheme counter " +
+            "will fall back to code-point counting — revisit before expanding coverage.");
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaValidation.CodeGenerator.Tests.csproj
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaValidation.CodeGenerator.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Jint" Version="4.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -21,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration\JsonSchemaValidation.CodeGeneration.csproj" />
+    <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration.JavaScript\JsonSchemaValidation.CodeGeneration.JavaScript.csproj" />
     <ProjectReference Include="..\JsonSchemaValidation\JsonSchemaValidation.csproj" />
   </ItemGroup>
 </Project>

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -4,6 +4,8 @@
 using System.Text;
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
 using FormFinch.JsonSchemaValidation.Common;
 
 namespace FormFinch.JsonSchemaValidation.CodeGenerator;
@@ -24,6 +26,7 @@ internal static class Program
         return command switch
         {
             "generate" => HandleGenerate(remainingArgs),
+            "generate-js" => HandleGenerateJs(remainingArgs),
             "generate-metaschemas" => HandleGenerateMetaschemas(remainingArgs),
             "compile-test-schemas" => HandleCompileTestSchemas(remainingArgs),
             "analyze" => HandleAnalyze(remainingArgs),
@@ -40,7 +43,8 @@ internal static class Program
             Usage: jsv-codegen <command> [options]
 
             Commands:
-              generate              Generate compiled validator from schema file
+              generate              Generate compiled C# validator from schema file
+              generate-js           Generate compiled JavaScript (ESM) validator from schema file
               generate-metaschemas  Generate compiled validators for all metaschemas
               compile-test-schemas  Generate compiled validators for JSON-Schema-Test-Suite schemas
               analyze               Analyze schema for compilation compatibility
@@ -50,6 +54,18 @@ internal static class Program
               -o, --output <path>     Output directory for generated code (required)
               -n, --namespace <name>  Namespace for generated classes (default: JsonSchemaValidation.Generated)
               -c, --class <name>      Class name (defaults to derived from schema $id)
+
+            generate-js options:
+              -s, --schema <path>    Input schema file (required)
+              -o, --output <path>    Output directory (required). Emits <schema>.js and jsv-runtime.js.
+              --no-runtime           Skip writing jsv-runtime.js (useful when runtime is already present).
+
+            generate-js MVP scope:
+              - Drafts: 2020-12 and 4 (other drafts rejected pre-emission).
+              - Self-contained schemas with local $ref only. External $ref rejected.
+              - Deferred features rejected: unevaluatedProperties/Items,
+                $dynamicRef/$dynamicAnchor, $recursiveRef/$recursiveAnchor.
+              - Format: eager validation for draft-supported formats; others are annotation-only.
 
             generate-metaschemas options:
               -o, --output <path>     Output directory for generated code (required)
@@ -66,6 +82,7 @@ internal static class Program
 
             Examples:
               jsv-codegen generate -s schema.json -o ./Generated/
+              jsv-codegen generate-js -s schema.json -o ./src/validators/
               jsv-codegen generate-metaschemas -o ./Generated/ -l ../JsonSchemaValidation
               jsv-codegen compile-test-schemas -t ./submodules/JSON-Schema-Test-Suite -o ./Generated/
               jsv-codegen analyze -s schema.json
@@ -151,6 +168,78 @@ internal static class Program
 
         Console.Error.WriteLine($"Generation failed: {result.Error}");
         return 1;
+    }
+
+    private static int HandleGenerateJs(string[] args)
+    {
+        string? schemaPath = null;
+        string? outputPath = null;
+        var writeRuntime = true;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            var nextArg = i + 1 < args.Length ? args[i + 1] : null;
+            switch (arg)
+            {
+                case "-s":
+                case "--schema":
+                    schemaPath = nextArg;
+                    i++;
+                    break;
+                case "-o":
+                case "--output":
+                    outputPath = nextArg;
+                    i++;
+                    break;
+                case "--no-runtime":
+                    writeRuntime = false;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(schemaPath))
+        {
+            Console.Error.WriteLine("Error: Schema path is required (-s, --schema)");
+            return 1;
+        }
+        if (string.IsNullOrEmpty(outputPath))
+        {
+            Console.Error.WriteLine("Error: Output path is required (-o, --output)");
+            return 1;
+        }
+        if (!File.Exists(schemaPath))
+        {
+            Console.Error.WriteLine($"Error: Schema file not found: {schemaPath}");
+            return 1;
+        }
+        if (!Directory.Exists(outputPath))
+        {
+            Directory.CreateDirectory(outputPath);
+        }
+
+        Console.WriteLine($"Generating JS validator for: {schemaPath}");
+        Console.WriteLine($"Output directory: {outputPath}");
+
+        var generator = new JsSchemaCodeGenerator();
+        var result = generator.Generate(schemaPath);
+        if (!result.Success)
+        {
+            Console.Error.WriteLine($"Generation failed: {result.Error}");
+            return 1;
+        }
+
+        var validatorPath = Path.Combine(outputPath, result.FileName!);
+        File.WriteAllText(validatorPath, result.GeneratedCode!);
+        Console.WriteLine($"Generated: {validatorPath}");
+
+        if (writeRuntime)
+        {
+            var runtimePath = Path.Combine(outputPath, JsRuntime.FileName);
+            File.WriteAllText(runtimePath, JsRuntime.GetSource());
+            Console.WriteLine($"Generated: {runtimePath}");
+        }
+        return 0;
     }
 
     private static int HandleGenerateMetaschemas(string[] args)

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -63,8 +63,10 @@ internal static class Program
             generate-js MVP scope:
               - Drafts: 2020-12 and 4 (other drafts rejected pre-emission).
               - Self-contained schemas with local $ref only. External $ref rejected.
-              - Deferred features rejected: unevaluatedProperties/Items,
-                $dynamicRef/$dynamicAnchor, $recursiveRef/$recursiveAnchor.
+              - Deferred features (unevaluatedProperties/Items, $dynamicRef/$dynamicAnchor,
+                $recursiveRef/$recursiveAnchor) are rejected under drafts that define them —
+                that is, Draft 2020-12. Under Draft 4 these names are not JSON Schema
+                keywords and are ignored as unknown annotations per spec.
               - Format: eager validation for draft-supported formats; others are annotation-only.
 
             generate-metaschemas options:

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -253,13 +253,16 @@ internal static class Program
     }
 
     /// <summary>
-    /// Returns true if the argument is present and doesn't look like another flag
-    /// (i.e. doesn't start with '-'), so option parsers can distinguish a missing
-    /// value from an actual value.
+    /// Returns true if the argument is present (i.e., an option's value wasn't
+    /// elided from the end of argv). No leading-'-' check — that would reject
+    /// legitimate values like <c>-schema.json</c> and diverges from the existing
+    /// generate/generate-metaschemas/compile-test-schemas parsers. "--schema -o out"
+    /// will bind schemaPath="-o" and fail later with "schema file not found: -o",
+    /// which is adequate.
     /// </summary>
     private static bool IsOptionValue(string? arg)
     {
-        return !string.IsNullOrEmpty(arg) && !arg.StartsWith('-');
+        return !string.IsNullOrEmpty(arg);
     }
 
     private static int HandleGenerateMetaschemas(string[] args)

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -184,11 +184,21 @@ internal static class Program
             {
                 case "-s":
                 case "--schema":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
                     schemaPath = nextArg;
                     i++;
                     break;
                 case "-o":
                 case "--output":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
                     outputPath = nextArg;
                     i++;
                     break;
@@ -240,6 +250,16 @@ internal static class Program
             Console.WriteLine($"Generated: {runtimePath}");
         }
         return 0;
+    }
+
+    /// <summary>
+    /// Returns true if the argument is present and doesn't look like another flag
+    /// (i.e. doesn't start with '-'), so option parsers can distinguish a missing
+    /// value from an actual value.
+    /// </summary>
+    private static bool IsOptionValue(string? arg)
+    {
+        return !string.IsNullOrEmpty(arg) && !arg.StartsWith('-');
     }
 
     private static int HandleGenerateMetaschemas(string[] args)

--- a/JsonSchemaValidationSolution.slnx
+++ b/JsonSchemaValidationSolution.slnx
@@ -8,5 +8,6 @@
   <Project Path="JsonSchemaValidation.CodeGenerator/JsonSchemaValidation.CodeGenerator.csproj" />
   <Project Path="JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaValidation.CodeGenerator.Tests.csproj" />
   <Project Path="JsonSchemaValidation.CodeGeneration/JsonSchemaValidation.CodeGeneration.csproj" />
+  <Project Path="JsonSchemaValidation.CodeGeneration.JavaScript/JsonSchemaValidation.CodeGeneration.JavaScript.csproj" />
   <Project Path="JsonSchemaValidation.Compiler/JsonSchemaValidation.Compiler.csproj" />
 </Solution>

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -33,3 +33,33 @@ Compiled validators cannot process `$ref` targets according to their declared `$
 ### Float Normalization
 
 `System.Text.Json` normalizes `1.0` to `1`. The library cannot distinguish between integer and float representations of the same number. This affects the `zeroTerminatedFloats` optional test (Drafts 3 and 4). Not fixable without custom JSON parsing.
+
+## JavaScript Code-Gen Target (`jsv-codegen generate-js`)
+
+The JS target emits compiled validators for consumption by JavaScript/TypeScript projects (ESM modules, importable from Node or bundlers). MVP scope is deliberately narrower than the C# target; items below are either active MVP constraints or documented behavioral gaps.
+
+### MVP Scope
+
+- **Drafts:** 2020-12 and 4 only. Other drafts (3, 6, 7, 2019-09) are rejected pre-emission. Tracked as follow-up work.
+- **Self-contained schemas with local `$ref` only.** External `$ref` is rejected pre-emission. The registry/fragment subschema machinery that exists for C# has not been ported.
+- **Deferred features rejected:** `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef`, `$dynamicAnchor`, `$recursiveRef`, `$recursiveAnchor`. The capability gate surfaces a structured error naming the unsupported keyword.
+
+### Numeric Precision
+
+JavaScript numbers are IEEE-754 doubles. Integer detection and `multipleOf` comparisons use the same precision as the C# compiled path (`double`/`TryGetDouble`). There is no BigInt fast path — large integers beyond 2^53 lose precision on both sides, matching behavior rather than adding divergence.
+
+### String Length Counting
+
+`minLength`/`maxLength` count grapheme clusters via `Intl.Segmenter` when available (matches C# `StringInfo.LengthInTextElements`). On environments without `Intl.Segmenter` (non-ICU builds), the runtime falls back to code-point counting (`Array.from(str).length`), which handles surrogate pairs but not combining marks or ZWJ sequences.
+
+### Regex Execution
+
+Patterns emit native JavaScript `RegExp` literals (ECMAScript flavor, matching the JSON Schema spec). JavaScript has no regex timeout — pathological patterns that would trip C#'s `matchTimeoutMilliseconds` safeguard can hang in JS. Treat validator input as untrusted at your own discretion.
+
+### Format Validation
+
+Supported formats are eager-validated (same stance as the C# compiled path). This intentionally diverges from the 2020-12 suite's "annotation-only by default" expectation; suite cases asserting annotation-only behavior are excluded from our test runner. For `idn-email`, `idn-hostname`, `iri`, and `iri-reference`, the runtime aliases to the ASCII counterpart — IDN-specific validation is deferred.
+
+### Shared Runtime Module
+
+Emitted validators import from a sibling `jsv-runtime.js`. The CLI writes both files by default; pass `--no-runtime` to suppress the runtime write if your build already provides one. The runtime ABI is versioned (`ABI VERSION: mvp-0`); bumping the version signals a breaking change to emitted validator expectations.

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -54,7 +54,7 @@ JavaScript numbers are IEEE-754 doubles. Integer detection and `multipleOf` comp
 
 ### Regex Execution
 
-Patterns emit native JavaScript `RegExp` literals (ECMAScript flavor, matching the JSON Schema spec). JavaScript has no regex timeout — pathological patterns that would trip C#'s `matchTimeoutMilliseconds` safeguard can hang in JS. Treat validator input as untrusted at your own discretion.
+Patterns emit JavaScript `new RegExp("...")` constructor expressions (ECMAScript flavor, matching the JSON Schema spec). Constructor form is used instead of the `/pattern/` literal form so schema-supplied text never participates in JS tokenisation — patterns starting with `*` or containing other tokenizer hazards can no longer break module parsing. Invalid ECMAScript regex grammar surfaces at `RegExp` construction time rather than as a module parse error. JavaScript has no regex timeout — pathological patterns that would trip C#'s `matchTimeoutMilliseconds` safeguard can hang in JS. Treat validator input as untrusted at your own discretion.
 
 ### Format Validation
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -42,7 +42,7 @@ The JS target emits compiled validators for consumption by JavaScript/TypeScript
 
 - **Drafts:** 2020-12 and 4 only. Other drafts (3, 6, 7, 2019-09) are rejected pre-emission. Tracked as follow-up work.
 - **Self-contained schemas with local `$ref` only.** External `$ref` is rejected pre-emission. The registry/fragment subschema machinery that exists for C# has not been ported.
-- **Deferred features rejected:** `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef`, `$dynamicAnchor`, `$recursiveRef`, `$recursiveAnchor`. The capability gate surfaces a structured error naming the unsupported keyword.
+- **Deferred features rejected in drafts that define them:** `unevaluatedProperties`, `unevaluatedItems`, `$dynamicRef`, `$dynamicAnchor`, `$recursiveRef`, `$recursiveAnchor`. The capability gate is draft-aware — under Draft 4 these names are not JSON Schema keywords, so the gate treats them as unknown annotations and ignores them (per spec). Under Draft 2020-12 they are real keywords, and the gate rejects pre-emission with a structured error naming the unsupported feature.
 
 ### Numeric Precision
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ This library is dual-licensed:
 
 See [COMMERCIAL.md](https://github.com/formfinch/JsonSchemaValidation/blob/main/COMMERCIAL.md) for details.
 
+## JavaScript Code-Gen (Preview)
+
+`jsv-codegen` can emit compiled JavaScript validators for use in browsers, Node, or bundlers — the same source-of-truth schema validates on both server (.NET) and client (JS).
+
+```bash
+jsv-codegen generate-js -s schema.json -o ./src/validators/
+```
+
+This writes `<schema>.js` (an ESM module exporting `validate(data): boolean`) and a sibling `jsv-runtime.js` (shared helpers and format validators). Import and use:
+
+```js
+import validator from "./src/validators/person.js";
+if (!validator.validate(data)) { /* reject */ }
+```
+
+MVP scope: Drafts 2020-12 and 4, self-contained schemas with local `$ref` only. See [Known Limitations](https://github.com/formfinch/JsonSchemaValidation/blob/main/KNOWN_LIMITATIONS.md#javascript-code-gen-target-jsv-codegen-generate-js) for the full list of deferred features and behavioral notes.
+
 ## Documentation
 
 - [Known Limitations](https://github.com/formfinch/JsonSchemaValidation/blob/main/KNOWN_LIMITATIONS.md) — architectural trade-offs, platform constraints, and compiled validator gaps


### PR DESCRIPTION
## Summary

Adds a JavaScript/ESM validator target parallel to the existing C# target in `JsonSchemaValidation.CodeGeneration`. Same schema validates on both server (.NET) and client (JS) via a single source of truth.

Closes #25.

## Scope (MVP)

- **Drafts:** 2020-12 and Draft 4. Others are rejected pre-emission with an actionable error (tracked as follow-up work).
- **Self-contained schemas with local \`\$ref\` only.** External \`\$ref\` is rejected pre-emission.
- **Deferred features rejected:** \`unevaluatedProperties\`/\`unevaluatedItems\`, \`\$dynamicRef\`/\`\$dynamicAnchor\`, \`\$recursiveRef\`/\`\$recursiveAnchor\`. The \`JsCapabilityGate\` is draft-aware: Draft 4 accepts these as unknown annotations per spec.
- **Format:** eager validation for draft-supported formats (matches the C# compiled path). \`idn-*\`/\`iri*\` alias to ASCII counterparts for MVP.

## Architecture

- New project \`JsonSchemaValidation.CodeGeneration.JavaScript\` (net8.0 + net10.0) shares the language-agnostic schema analyzer (\`SubschemaExtractor\`, \`SchemaHasher\`, \`SchemaDraftDetector\`) with the C# target via ProjectRef.
- 27 \`IJsKeywordCodeGenerator\` implementations emit ESM JS; \`JsSchemaCodeGenerator\` orchestrates them.
- Emitted validators import from a shared \`jsv-runtime.js\` (deepEquals, escapeJsonPointer, graphemeLength via \`Intl.Segmenter\`, isInteger, 19 format validators). ABI versioned (\`mvp-0\`).
- CLI: \`jsv-codegen generate-js -s schema.json -o out/ [--no-runtime]\`.

## Test plan

- [x] Unit/shape/gate tests (64) — emitter shape, capability gate coverage, runtime ABI surface
- [x] Vertical-slice execution tests (10) — end-to-end codegen → Jint → runtime → verdict for \`type\`/\`properties\`/\`required\`/\`pattern\`/\`minLength\`/\`maxLength\`
- [x] Format tests (7) — eager validation of date/date-time/email/uuid/ipv4/regex; annotation-only for unsupported-per-draft formats
- [x] Review-fix regression tests (22) — lock all seven defects found in initial review + draft-aware gate behavior
- [x] JSON Schema Test Suite subset (1327 cases: 2020-12 + Draft 4) — driven end-to-end through generator + runtime via Jint
- [x] **Total: 1430 passing on net8.0 and net10.0** (7s runtime)
- [ ] Manual smoke-test of \`generate-js\` CLI including gate rejection path

## Out of scope (tracked as follow-ups)

- \`unevaluatedProperties\`/\`unevaluatedItems\` emission
- \`\$dynamicRef\`/\`\$dynamicAnchor\` + dynamic scope runtime
- External \`\$ref\` + registry/fragment handling
- Drafts 3/6/7/2019-09

## Commits

1. \`feat: Add JavaScript code-gen target (issue #25)\` — initial implementation
2. \`fix: Address review findings on JS code-gen target (issue #25)\` — seven defects from first review
3. \`fix: Make JS capability gate draft-aware (issue #25)\` — Draft 4 unknown-keyword handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)