### PR TITLE
perf: Cache JS validator regexes and add Node.js competitor benchmarks

### DIFF
--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/NodeJsCompetitorBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/NodeJsCompetitorBenchmarks.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using FormFinch.JsonSchemaValidation.Benchmarks.Config;
+using FormFinch.JsonSchemaValidation.Benchmarks.Infrastructure;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+
+namespace FormFinch.JsonSchemaValidation.Benchmarks.Benchmarks.Competitors;
+
+/// <summary>
+/// Draft 2020-12 JavaScript benchmark comparison between the generated FormFinch
+/// validator and Ajv, both executed through the shared Node.js host.
+/// Batch mode amortizes IPC so the measurement is dominated by validator work.
+/// </summary>
+[Config(typeof(ThroughputConfig))]
+public class NodeJsCompetitorBenchmarks
+{
+    private const int BatchSize = 1000;
+
+    private NodeBenchmarkHost _ajvHost = null!;
+    private NodeBenchmarkHost _formFinchJsHost = null!;
+    private string _generatedModuleDirectory = null!;
+
+    [Params(SchemaComplexity.Simple, SchemaComplexity.Medium, SchemaComplexity.Complex, SchemaComplexity.Production)]
+    public SchemaComplexity Complexity { get; set; }
+
+    [Params(true, false)]
+    public bool IsValidInstance { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var schemaJson = BenchmarkData.GetSchema(Complexity);
+        var instanceJson = IsValidInstance
+            ? BenchmarkData.GetValidInstance(Complexity)
+            : BenchmarkData.GetInvalidInstance(Complexity);
+
+        _generatedModuleDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "ff-js-bench-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_generatedModuleDirectory);
+
+        File.WriteAllText(Path.Combine(_generatedModuleDirectory, JsRuntime.FileName), JsRuntime.GetSource());
+        File.WriteAllText(Path.Combine(_generatedModuleDirectory, "validator.js"), GenerateValidatorSource(schemaJson));
+
+        _ajvHost = new NodeBenchmarkHost();
+        _ajvHost.PrepareAjv(schemaJson);
+        _ajvHost.PrepareData(instanceJson);
+
+        _formFinchJsHost = new NodeBenchmarkHost();
+        _formFinchJsHost.PrepareGeneratedValidator(Path.Combine(_generatedModuleDirectory, "validator.js"));
+        _formFinchJsHost.PrepareData(instanceJson);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _ajvHost?.Dispose();
+        _formFinchJsHost?.Dispose();
+
+        if (!string.IsNullOrEmpty(_generatedModuleDirectory))
+        {
+            try
+            {
+                Directory.Delete(_generatedModuleDirectory, recursive: true);
+            }
+            catch
+            {
+                // Best effort cleanup.
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = BatchSize, Description = "Ajv 2020-12")]
+    public int Ajv202012()
+    {
+        return _ajvHost.ValidatePreparedBatch(BatchSize);
+    }
+
+    [Benchmark(OperationsPerInvoke = BatchSize, Description = "FormFinch JS codegen")]
+    public int FormFinchJsCodegen()
+    {
+        return _formFinchJsHost.ValidatePreparedBatch(BatchSize);
+    }
+
+    private static string GenerateValidatorSource(string schemaJson)
+    {
+        using var schemaDoc = JsonDocument.Parse(schemaJson);
+        var generator = new JsSchemaCodeGenerator
+        {
+            DefaultDraft = SchemaDraft.Draft202012
+        };
+
+        var result = generator.Generate(schemaDoc.RootElement.Clone(), sourcePath: "benchmark-schema.json");
+        if (!result.Success || string.IsNullOrEmpty(result.GeneratedCode))
+        {
+            throw new InvalidOperationException(
+                $"Failed to generate JS benchmark validator: {result.Error ?? "Unknown error"}");
+        }
+
+        return result.GeneratedCode;
+    }
+}

--- a/JsonSchemaValidation.Benchmarks/Infrastructure/NodeBenchmarkHost.cs
+++ b/JsonSchemaValidation.Benchmarks/Infrastructure/NodeBenchmarkHost.cs
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Persistent Node.js host for JS validator benchmarks.
+/// Uses the shared benchmark adapter so Ajv and generated validators are measured
+/// through the same transport.
+/// </summary>
+public sealed class NodeBenchmarkHost : IDisposable
+{
+    private readonly Process _process;
+    private readonly StreamWriter _stdin;
+    private readonly StreamReader _stdout;
+    private bool _disposed;
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    public NodeBenchmarkHost()
+    {
+        var adapterPath = LocateAdapterHostPath();
+        var workingDirectory = Path.GetDirectoryName(adapterPath)
+            ?? throw new InvalidOperationException($"Could not determine adapter host directory for {adapterPath}.");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "node",
+            Arguments = $"\"{adapterPath}\"",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardInputEncoding = Utf8NoBom,
+            StandardOutputEncoding = Utf8NoBom,
+            StandardErrorEncoding = Utf8NoBom
+        };
+
+        _process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start Node.js benchmark host. Ensure Node.js is installed and on PATH.");
+        _stdin = _process.StandardInput;
+        _stdout = _process.StandardOutput;
+
+        var ready = _stdout.ReadLine();
+        if (!string.Equals(ready, "ready", StringComparison.Ordinal))
+        {
+            var stderr = _process.StandardError.ReadToEnd();
+            throw new InvalidOperationException(
+                $"Node.js benchmark host failed to initialize. Ready line: '{ready ?? "<null>"}'. STDERR: {stderr}");
+        }
+    }
+
+    public void PrepareAjv(string schemaJson)
+    {
+        Send(new
+        {
+            cmd = "prepare",
+            library = "ajv",
+            schema = schemaJson
+        });
+    }
+
+    public void PrepareGeneratedValidator(string modulePath)
+    {
+        Send(new
+        {
+            cmd = "prepare",
+            library = "formfinch-js",
+            modulePath
+        });
+    }
+
+    public void PrepareData(string dataJson)
+    {
+        Send(new
+        {
+            cmd = "prepare-data",
+            data = dataJson
+        });
+    }
+
+    public int ValidatePreparedBatch(int iterations)
+    {
+        using var response = Send(new
+        {
+            cmd = "benchmark-prepared",
+            iterations
+        });
+
+        if (!response.RootElement.TryGetProperty("ValidCount", out var validCount) ||
+            !validCount.TryGetInt32(out var count))
+        {
+            throw new InvalidOperationException($"Node benchmark host did not return a ValidCount for batch size {iterations}.");
+        }
+
+        return count;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            if (!_process.HasExited)
+            {
+                try
+                {
+                    Send(new { cmd = "exit" }).Dispose();
+                }
+                catch
+                {
+                    // Best effort shutdown.
+                }
+
+                if (!_process.WaitForExit(2000))
+                {
+                    _process.Kill(entireProcessTree: true);
+                }
+            }
+        }
+        finally
+        {
+            _stdin.Dispose();
+            _stdout.Dispose();
+            _process.Dispose();
+        }
+    }
+
+    private JsonDocument Send(object command)
+    {
+        ThrowIfDisposed();
+
+        var json = JsonSerializer.Serialize(command);
+        _stdin.WriteLine(json);
+        _stdin.Flush();
+
+        var responseLine = _stdout.ReadLine();
+        if (string.IsNullOrWhiteSpace(responseLine))
+        {
+            var stderr = _process.HasExited ? _process.StandardError.ReadToEnd() : string.Empty;
+            throw new InvalidOperationException(
+                $"Node benchmark host returned no response. Process exited: {_process.HasExited}. STDERR: {stderr}");
+        }
+
+        var response = JsonDocument.Parse(responseLine);
+        if (!response.RootElement.TryGetProperty("Success", out var successElement) ||
+            !successElement.GetBoolean())
+        {
+            var error = response.RootElement.TryGetProperty("Error", out var errorElement)
+                ? errorElement.GetString()
+                : "Unknown node benchmark host error.";
+            response.Dispose();
+            throw new InvalidOperationException(error);
+        }
+
+        return response;
+    }
+
+    private static string LocateAdapterHostPath()
+    {
+        var current = AppContext.BaseDirectory;
+        for (var i = 0; i < 12 && current != null; i++)
+        {
+            var candidate = Path.Combine(current, "benchmarks", "node", "adapter-host.js");
+            if (File.Exists(candidate))
+            {
+                var nodeModules = Path.Combine(current, "benchmarks", "node", "node_modules");
+                if (!Directory.Exists(nodeModules))
+                {
+                    throw new InvalidOperationException(
+                        $"Node benchmark dependencies are missing at '{nodeModules}'. Run 'npm install' in benchmarks/node first.");
+                }
+
+                return candidate;
+            }
+
+            current = Path.GetDirectoryName(current);
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate benchmarks/node/adapter-host.js from the benchmark output directory.");
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+}

--- a/JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj
+++ b/JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\JsonSchemaValidation\JsonSchemaValidation.csproj" />
     <ProjectReference Include="..\JsonSchemaValidation.Compiler\JsonSchemaValidation.Compiler.csproj" />
+    <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration.JavaScript\JsonSchemaValidation.CodeGeneration.JavaScript.csproj" />
   </ItemGroup>
 
   <!-- BenchmarkDotNet -->

--- a/JsonSchemaValidation.Benchmarks/docs/METHODOLOGY.md
+++ b/JsonSchemaValidation.Benchmarks/docs/METHODOLOGY.md
@@ -42,6 +42,12 @@ Compare FormFinch against other .NET JSON Schema validators:
 - JsonSchema.Net
 - LateApexEarlySpeed.Json.Schema
 
+### 6. JavaScript Competitor Benchmarks
+
+Compare Draft 2020-12 JavaScript validators through a shared Node.js host:
+- Ajv 2020-12
+- FormFinch generated JS validator
+
 ## Test Data
 
 All benchmark data is embedded in the assembly and verified via SHA-256 checksums at startup. This ensures:
@@ -83,16 +89,30 @@ All benchmark data is embedded in the assembly and verified via SHA-256 checksum
 
 ## Running Benchmarks
 
-```bash
+```powershell
+# Preferred on Windows: build once, then run the benchmark assembly directly.
+# This avoids file-lock failures from dotnet run when an earlier benchmark process
+# is still alive.
+
 # Run all benchmarks
-dotnet run -c Release --project JsonSchemaValidation.Benchmarks
+.\JsonSchemaValidation.Benchmarks\run-benchmarks.ps1
 
 # Run specific benchmark class
-dotnet run -c Release --project JsonSchemaValidation.Benchmarks -- --filter *Simple*
+.\JsonSchemaValidation.Benchmarks\run-benchmarks.ps1 --filter *Simple*
 
 # Dry run (verification only)
-dotnet run -c Release --project JsonSchemaValidation.Benchmarks -- --filter *Simple* --job dry
+.\JsonSchemaValidation.Benchmarks\run-benchmarks.ps1 --filter *Simple* --job dry
 ```
+
+```bash
+# Cross-platform equivalent
+dotnet build JsonSchemaValidation.Benchmarks/JsonSchemaValidation.Benchmarks.csproj -c Release -f net10.0
+./JsonSchemaValidation.Benchmarks/bin/Release/net10.0/JsonSchemaValidation.Benchmarks --filter '*Simple*' --job dry
+```
+
+If you use `dotnet run`, BenchmarkDotNet still works, but rerunning while an earlier
+`JsonSchemaValidation.Benchmarks` process is alive can fail on Windows because MSBuild
+cannot overwrite locked output assemblies.
 
 ## Interpreting Results
 
@@ -109,3 +129,4 @@ BenchmarkDotNet provides several statistics:
 1. **FormFinch Dynamic vs Compiled**: Dynamic uses the interpreter; Compiled generates native code at runtime
 2. **Memory**: Lower allocations typically indicate better performance for high-throughput scenarios
 3. **.NET Only**: Benchmarks compare .NET JSON Schema validators only
+4. **Node-hosted JS comparisons**: Ajv and FormFinch JS codegen are measured through the same persistent Node.js adapter. Batch operations are used so transport overhead is amortized across many validations.

--- a/JsonSchemaValidation.Benchmarks/run-benchmarks.ps1
+++ b/JsonSchemaValidation.Benchmarks/run-benchmarks.ps1
@@ -1,0 +1,29 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$BenchmarkArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$projectDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectFile = Join-Path $projectDir "JsonSchemaValidation.Benchmarks.csproj"
+$outputDir = Join-Path $projectDir "bin\\Release\\net10.0"
+$benchmarkExe = Join-Path $outputDir "JsonSchemaValidation.Benchmarks.exe"
+
+$running = Get-Process -Name "JsonSchemaValidation.Benchmarks" -ErrorAction SilentlyContinue |
+    Where-Object { $_.Path -eq $benchmarkExe }
+
+if ($running)
+{
+    $ids = ($running | Select-Object -ExpandProperty Id) -join ", "
+    throw "A benchmark process is already running from '$benchmarkExe' (PID: $ids). Stop it or wait for it to finish before starting another run."
+}
+
+dotnet build $projectFile -c Release -f net10.0 | Out-Host
+
+if (-not (Test-Path $benchmarkExe))
+{
+    throw "Expected benchmark executable was not created: $benchmarkExe"
+}
+
+& $benchmarkExe @BenchmarkArgs

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsLiteral.cs
@@ -76,16 +76,4 @@ internal static class JsLiteral
             .Replace(ParagraphSeparator.ToString(), ParagraphSeparatorEscape);
     }
 
-    /// <summary>
-    /// Emits a JavaScript RegExp construction expression as <c>new RegExp("pattern")</c>.
-    /// Avoids the <c>/pattern/</c> literal form because certain pattern prefixes
-    /// (most famously a leading asterisk) tokenize as block-comment or other
-    /// invalid syntax and would break module parsing. Invalid ECMAScript regex
-    /// grammar surfaces at RegExp construction time rather than as a JS parse
-    /// error, which is a friendlier failure mode for consumers.
-    /// </summary>
-    public static string RegexLiteral(string pattern)
-    {
-        return $"new RegExp({String(pattern)}, \"u\")";
-    }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPatternCodeGenerator.cs
@@ -7,11 +7,9 @@ namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 
 /// <summary>
 /// Generates JavaScript code for the "pattern" keyword.
-/// Emits a <c>new RegExp("...")</c> constructor expression (via JsLiteral.RegexLiteral)
-/// using the ECMAScript dialect required by JSON Schema. Constructor form is used
-/// instead of a <c>/.../</c> literal so schema-supplied text never participates in
-/// JS tokenisation — patterns starting with <c>*</c> or containing other tokenizer
-/// hazards no longer break module parsing.
+/// Uses the runtime's cached-regex helper so schema patterns are compiled once
+/// and then reused across validations. Constructor form remains hidden behind
+/// the helper so schema-supplied text never participates in JS tokenisation.
 /// Regex timeouts don't exist in JS; pathological patterns are a known limitation
 /// inherited from the spec (documented in KNOWN_LIMITATIONS.md).
 /// </summary>
@@ -50,9 +48,27 @@ public sealed class JsPatternCodeGenerator : IJsKeywordCodeGenerator
         }
 
         var v = context.ElementExpr;
-        var literal = JsLiteral.RegexLiteral(pattern);
-        return $"if (typeof {v} === \"string\" && !{literal}.test({v})) return false;";
+        var patternLiteral = JsLiteral.String(pattern);
+        return $$"""
+            if (typeof {{v}} === "string") {
+              const _patternRe = getCachedRegex({{patternLiteral}});
+              if (!_patternRe.test({{v}})) return false;
+            }
+            """;
     }
 
-    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            yield break;
+        }
+
+        if (context.CurrentSchema.TryGetProperty("pattern", out var patternElement) &&
+            patternElement.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrEmpty(patternElement.GetString()))
+        {
+            yield return "getCachedRegex";
+        }
+    }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Keywords/JsPropertyApplicatorsCodeGenerator.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using System.Linq;
 
 namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Keywords;
 
@@ -45,10 +46,9 @@ public sealed class JsPatternPropertiesCodeGenerator : IJsKeywordCodeGenerator
         do
         {
             var pattern = patternEnumerator.Current;
-            var regex = JsLiteral.RegexLiteral(pattern.Name);
             var regexVar = $"_ppRe{idx}";
             var hash = context.GetSubschemaHash(pattern.Value);
-            hoists.AppendLine($"  const {regexVar} = {regex};");
+            hoists.AppendLine($"  const {regexVar} = getCachedRegex({JsLiteral.String(pattern.Name)});");
             checks.AppendLine($"    if ({regexVar}.test(_k)) {{");
             checks.AppendLine($"      if (!{context.GenerateValidateCallForProperty(hash, $"{v}[_k]", "_k")}) return false;");
             if (context.RequiresPropertyAnnotations)
@@ -70,7 +70,15 @@ public sealed class JsPatternPropertiesCodeGenerator : IJsKeywordCodeGenerator
         return sb.ToString();
     }
 
-    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (context.CurrentSchema.TryGetProperty("patternProperties", out var patternsElem) &&
+            patternsElem.ValueKind == JsonValueKind.Object &&
+            patternsElem.EnumerateObject().Any())
+        {
+            yield return "getCachedRegex";
+        }
+    }
 }
 
 /// <summary>
@@ -101,7 +109,7 @@ public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerato
         }
 
         var definedNames = CollectDefinedNames(context.CurrentSchema);
-        var patternRegexes = CollectPatternRegexes(context.CurrentSchema);
+        var patternRegexes = CollectPatternPatterns(context.CurrentSchema);
 
         var v = context.ElementExpr;
         // Hoist pattern regexes outside the key loop (same reason as
@@ -111,7 +119,7 @@ public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerato
         for (var i = 0; i < patternRegexes.Count; i++)
         {
             var rv = $"_apRe{i}";
-            hoists.AppendLine($"  const {rv} = {patternRegexes[i]};");
+            hoists.AppendLine($"  const {rv} = getCachedRegex({JsLiteral.String(patternRegexes[i])});");
             regexVars.Add(rv);
         }
 
@@ -162,7 +170,13 @@ public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerato
         return sb.ToString();
     }
 
-    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context) => [];
+    public IEnumerable<string> GetRuntimeImports(JsCodeGenerationContext context)
+    {
+        if (CollectPatternPatterns(context.CurrentSchema).Count > 0)
+        {
+            yield return "getCachedRegex";
+        }
+    }
 
     private static List<string> CollectDefinedNames(JsonElement schema)
     {
@@ -178,18 +192,18 @@ public sealed class JsAdditionalPropertiesCodeGenerator : IJsKeywordCodeGenerato
         return names;
     }
 
-    private static List<string> CollectPatternRegexes(JsonElement schema)
+    private static List<string> CollectPatternPatterns(JsonElement schema)
     {
-        var regexes = new List<string>();
-        if (schema.TryGetProperty("patternProperties", out var patterns) &&
-            patterns.ValueKind == JsonValueKind.Object)
+        var patternNames = new List<string>();
+        if (schema.TryGetProperty("patternProperties", out var patternsElement) &&
+            patternsElement.ValueKind == JsonValueKind.Object)
         {
-            foreach (var p in patterns.EnumerateObject())
+            foreach (var p in patternsElement.EnumerateObject())
             {
-                regexes.Add(JsLiteral.RegexLiteral(p.Name));
+                patternNames.Add(p.Name);
             }
         }
-        return regexes;
+        return patternNames;
     }
 }
 

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Runtime/jsv-runtime.js
@@ -10,7 +10,7 @@
 // ABI VERSION: mvp-0
 //
 // FROZEN (stable across MVP; breaking changes require ABI version bump):
-//   Helpers:   deepEquals, escapeJsonPointer, graphemeLength, isInteger
+//   Helpers:   deepEquals, escapeJsonPointer, getCachedRegex, graphemeLength, isInteger
 //   Formats:   isValidDateTime, isValidDate, isValidTime, isValidDuration,
 //              isValidEmail, isValidIdnEmail, isValidHostname, isValidIdnHostname,
 //              isValidIpv4, isValidIpv6, isValidUri, isValidUriReference,
@@ -60,6 +60,11 @@ export function escapeJsonPointer(segment) {
 // The gap is documented in KNOWN_LIMITATIONS.md and is acceptable for MVP.
 let _segmenter = null;
 let _segmenterProbed = false;
+/** @type {Map<string, RegExp>} */
+// Process-global within a loaded runtime module. This grows with distinct
+// schema patterns and intentionally does not evict to keep hot-path lookups
+// trivial for generated validators and benchmark runs.
+const _regexCache = new Map();
 function _getSegmenter() {
     if (_segmenterProbed) return _segmenter;
     _segmenterProbed = true;
@@ -74,11 +79,37 @@ function _getSegmenter() {
 }
 
 /**
+ * Returns a cached ECMAScript-unicode RegExp instance for a schema pattern.
+ * Generated validators call through this helper so regex compilation happens
+ * once per module load instead of once per validation.
+ * @param {string} pattern
+ * @returns {RegExp}
+ */
+export function getCachedRegex(pattern) {
+    let regex = _regexCache.get(pattern);
+    if (regex === undefined) {
+        regex = new RegExp(pattern, "u");
+        _regexCache.set(pattern, regex);
+    }
+    return regex;
+}
+
+/**
  * Counts grapheme clusters in a string. Mirrors C# StringInfo.LengthInTextElements.
  * @param {string} str
  * @returns {number}
  */
 export function graphemeLength(str) {
+    if (str.length === 0) return 0;
+    let asciiOnly = true;
+    for (let i = 0; i < str.length; i++) {
+        if (str.charCodeAt(i) > 0x7F) {
+            asciiOnly = false;
+            break;
+        }
+    }
+    if (asciiOnly) return str.length;
+
     const seg = _getSegmenter();
     if (seg !== null) {
         let count = 0;

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsReviewFixesTests.cs
@@ -1064,7 +1064,7 @@ public class JsReviewFixesTests
             """).RootElement;
         var result = gen.Generate(schema);
         Assert.True(result.Success, result.Error);
-        Assert.Contains("new RegExp(", result.GeneratedCode);
+        Assert.Contains("getCachedRegex(", result.GeneratedCode);
         Assert.DoesNotContain("/^a/", result.GeneratedCode);
     }
 
@@ -1091,6 +1091,19 @@ public class JsReviewFixesTests
         var forIndex = src.IndexOf("for (const _k of Object.keys", StringComparison.Ordinal);
         Assert.True(hoistIndex > 0 && forIndex > hoistIndex,
             "Hoisted RegExp constants must appear before the Object.keys loop.");
+    }
+
+    [Fact]
+    public void Pattern_UsesCachedRegexHelper()
+    {
+        var gen = new JsSchemaCodeGenerator();
+        var schema = JsonDocument.Parse("""{ "pattern": "^[a-z]+$" }""").RootElement;
+
+        var result = gen.Generate(schema);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("getCachedRegex(", result.GeneratedCode);
+        Assert.DoesNotContain("new RegExp(", result.GeneratedCode);
     }
 
     // Non-ambiguous case: two resources with different $ref text — not collapsed,

--- a/benchmarks/node/adapter-host.js
+++ b/benchmarks/node/adapter-host.js
@@ -3,6 +3,7 @@ import addFormats from 'ajv-formats';
 import * as Hyperjump from '@hyperjump/json-schema/draft-2020-12';
 import { Validator as CfworkerValidator } from '@cfworker/json-schema';
 import { createInterface } from 'readline';
+import { pathToFileURL } from 'url';
 
 let currentLibrary = null;
 let schemaCounter = 0;
@@ -11,6 +12,8 @@ let schemaCounter = 0;
 let ajvValidator = null;
 let hyperjumpSchemaUri = null;
 let cfworkerValidator = null;
+let generatedValidator = null;
+let preparedData = undefined;
 
 function createAjv() {
     const instance = new Ajv2020({
@@ -31,6 +34,40 @@ function respond(obj) {
     console.log(JSON.stringify(obj));
 }
 
+async function validatePrepared(data) {
+    if (currentLibrary === 'ajv') {
+        if (!ajvValidator) {
+            throw new Error('No schema prepared');
+        }
+        return !!ajvValidator(data);
+    }
+
+    if (currentLibrary === 'hyperjump') {
+        if (!hyperjumpSchemaUri) {
+            throw new Error('No schema prepared');
+        }
+        const output = await Hyperjump.validate(hyperjumpSchemaUri, data);
+        return !!output.valid;
+    }
+
+    if (currentLibrary === 'cfworker') {
+        if (!cfworkerValidator) {
+            throw new Error('No schema prepared');
+        }
+        const result = cfworkerValidator.validate(data);
+        return !!result.valid;
+    }
+
+    if (currentLibrary === 'formfinch-js') {
+        if (!generatedValidator) {
+            throw new Error('No generated validator prepared');
+        }
+        return !!generatedValidator(data);
+    }
+
+    throw new Error('No library selected');
+}
+
 async function handleCommand(command) {
     try {
         const cmd = command.Cmd || command.cmd;
@@ -39,14 +76,16 @@ async function handleCommand(command) {
         switch (cmd) {
             case 'prepare':
                 currentLibrary = library.toLowerCase();
-                const schemaText = command.Schema || command.schema;
-                const schema = JSON.parse(schemaText);
 
                 if (currentLibrary === 'ajv') {
+                    const schemaText = command.Schema || command.schema;
+                    const schema = JSON.parse(schemaText);
                     const ajv = createAjv();
                     ajvValidator = ajv.compile(schema);
                     respond({ Success: true });
                 } else if (currentLibrary === 'hyperjump') {
+                    const schemaText = command.Schema || command.schema;
+                    const schema = JSON.parse(schemaText);
                     schemaCounter++;
                     hyperjumpSchemaUri = `https://benchmark.local/schema-${schemaCounter}`;
 
@@ -74,40 +113,48 @@ async function handleCommand(command) {
                     Hyperjump.registerSchema(schemaToRegister, hyperjumpSchemaUri);
                     respond({ Success: true });
                 } else if (currentLibrary === 'cfworker') {
+                    const schemaText = command.Schema || command.schema;
+                    const schema = JSON.parse(schemaText);
                     cfworkerValidator = new CfworkerValidator(schema, '2020-12', false);
+                    respond({ Success: true });
+                } else if (currentLibrary === 'formfinch-js') {
+                    const modulePath = command.ModulePath || command.modulePath;
+                    if (!modulePath) {
+                        respond({ Success: false, Error: 'modulePath is required for formfinch-js' });
+                        return;
+                    }
+
+                    const moduleUrl = `${pathToFileURL(modulePath).href}?v=${++schemaCounter}`;
+                    const module = await import(moduleUrl);
+                    const validate = module.validate ?? module.default?.validate;
+                    if (typeof validate !== 'function') {
+                        respond({ Success: false, Error: 'Generated module does not export validate()' });
+                        return;
+                    }
+
+                    generatedValidator = validate;
                     respond({ Success: true });
                 } else {
                     respond({ Success: false, Error: `Unknown library: ${library}` });
                 }
                 break;
 
+            case 'prepare-data':
+                preparedData = JSON.parse(command.Data || command.data);
+                respond({ Success: true });
+                break;
+
             case 'validate':
                 const data = JSON.parse(command.Data || command.data);
+                respond({ Success: true, Valid: await validatePrepared(data) });
+                break;
 
-                if (currentLibrary === 'ajv') {
-                    if (!ajvValidator) {
-                        respond({ Success: false, Error: 'No schema prepared' });
-                        return;
-                    }
-                    const valid = ajvValidator(data);
-                    respond({ Success: true, Valid: valid });
-                } else if (currentLibrary === 'hyperjump') {
-                    if (!hyperjumpSchemaUri) {
-                        respond({ Success: false, Error: 'No schema prepared' });
-                        return;
-                    }
-                    const output = await Hyperjump.validate(hyperjumpSchemaUri, data);
-                    respond({ Success: true, Valid: output.valid });
-                } else if (currentLibrary === 'cfworker') {
-                    if (!cfworkerValidator) {
-                        respond({ Success: false, Error: 'No schema prepared' });
-                        return;
-                    }
-                    const result = cfworkerValidator.validate(data);
-                    respond({ Success: true, Valid: result.valid });
-                } else {
-                    respond({ Success: false, Error: 'No library selected' });
+            case 'validate-prepared':
+                if (preparedData === undefined) {
+                    respond({ Success: false, Error: 'No prepared data' });
+                    return;
                 }
+                respond({ Success: true, Valid: await validatePrepared(preparedData) });
                 break;
 
             case 'benchmark':
@@ -115,45 +162,31 @@ async function handleCommand(command) {
                 const iterations = command.Iterations || command.iterations || 1000;
                 const timings = [];
 
-                if (currentLibrary === 'ajv') {
-                    if (!ajvValidator) {
-                        respond({ Success: false, Error: 'No schema prepared' });
-                        return;
-                    }
-                    for (let i = 0; i < iterations; i++) {
-                        const start = process.hrtime.bigint();
-                        ajvValidator(benchData);
-                        const end = process.hrtime.bigint();
-                        timings.push(Number(end - start) / 1000);
-                    }
-                } else if (currentLibrary === 'hyperjump') {
-                    if (!hyperjumpSchemaUri) {
-                        respond({ Success: false, Error: 'No schema prepared' });
-                        return;
-                    }
-                    for (let i = 0; i < iterations; i++) {
-                        const start = process.hrtime.bigint();
-                        await Hyperjump.validate(hyperjumpSchemaUri, benchData);
-                        const end = process.hrtime.bigint();
-                        timings.push(Number(end - start) / 1000);
-                    }
-                } else if (currentLibrary === 'cfworker') {
-                    if (!cfworkerValidator) {
-                        respond({ Success: false, Error: 'No schema prepared' });
-                        return;
-                    }
-                    for (let i = 0; i < iterations; i++) {
-                        const start = process.hrtime.bigint();
-                        cfworkerValidator.validate(benchData);
-                        const end = process.hrtime.bigint();
-                        timings.push(Number(end - start) / 1000);
-                    }
-                } else {
-                    respond({ Success: false, Error: 'No library selected' });
-                    return;
+                for (let i = 0; i < iterations; i++) {
+                    const start = process.hrtime.bigint();
+                    await validatePrepared(benchData);
+                    const end = process.hrtime.bigint();
+                    timings.push(Number(end - start) / 1000);
                 }
 
                 respond({ Success: true, Timings: timings });
+                break;
+
+            case 'benchmark-prepared':
+                if (preparedData === undefined) {
+                    respond({ Success: false, Error: 'No prepared data' });
+                    return;
+                }
+
+                const preparedIterations = command.Iterations || command.iterations || 1000;
+                let validCount = 0;
+                for (let i = 0; i < preparedIterations; i++) {
+                    if (await validatePrepared(preparedData)) {
+                        validCount++;
+                    }
+                }
+
+                respond({ Success: true, ValidCount: validCount });
                 break;
 
             case 'benchmark-full':


### PR DESCRIPTION
## Summary
- Cache compiled `RegExp` instances in the JS runtime via `getCachedRegex`, and emit calls to it from `pattern`, `patternProperties`, and `additionalProperties` codegen so schema patterns compile once per module load instead of per validation.
- Add ASCII fast path to `graphemeLength` in `jsv-runtime.js`.
- Add `NodeJsCompetitorBenchmarks` + `NodeBenchmarkHost` to measure Ajv 2020-12 against the generated FormFinch JS validator through the shared `adapter-host.js` (new `prepare-data` / `benchmark-prepared` commands).
- Add `run-benchmarks.ps1` Windows wrapper that builds once and runs the benchmark exe directly to avoid MSBuild file-lock failures, and document the flow in METHODOLOGY.md.

## Test plan
- [ ] `dotnet test JsonSchemaValidation.CodeGenerator.Tests` (covers new `Pattern_UsesCachedRegexHelper` and updated hoist assertions).
- [ ] `npm install` under `benchmarks/node`, then `./JsonSchemaValidation.Benchmarks/run-benchmarks.ps1 --filter *NodeJsCompetitor* --job dry` to verify the Node host wiring.
- [ ] Spot-check a generated validator module and confirm it imports `getCachedRegex` and contains no raw `new RegExp(` in `result.GeneratedCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)