### PR TITLE
Add TypeScript-first JavaScript codegen path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,15 @@ dotnet test JsonSchemaValidationTests/JsonSchemaValidationTests.csproj --filter 
 dotnet test JsonSchemaValidationTests.Stress/JsonSchemaValidationTests.Stress.csproj
 ```
 
+The optional TypeScript-first JS pipeline uses the TypeScript compiler when emitting JS from TS:
+
+```bash
+# Requires TypeScript on PATH as `tsc`, or pass --tsc <path>
+jsv-codegen generate-js -s schema.json -o ./out --pipeline typescript --ecmascript-target ES2020
+```
+
+Keep the default direct JS generator available when working on this path; it is the parity and benchmark baseline.
+
 ### Code Coverage
 
 ```bash

--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/NodeJsCompetitorBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/NodeJsCompetitorBenchmarks.cs
@@ -9,6 +9,7 @@ using FormFinch.JsonSchemaValidation.Benchmarks.Infrastructure;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
 using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
 using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
 
 namespace FormFinch.JsonSchemaValidation.Benchmarks.Benchmarks.Competitors;
 
@@ -24,6 +25,7 @@ public class NodeJsCompetitorBenchmarks
 
     private NodeBenchmarkHost _ajvHost = null!;
     private NodeBenchmarkHost _formFinchJsHost = null!;
+    private NodeBenchmarkHost _formFinchTsDerivedJsHost = null!;
     private string _generatedModuleDirectory = null!;
 
     [Params(SchemaComplexity.Simple, SchemaComplexity.Medium, SchemaComplexity.Complex, SchemaComplexity.Production)]
@@ -45,16 +47,26 @@ public class NodeJsCompetitorBenchmarks
             "ff-js-bench-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_generatedModuleDirectory);
 
-        File.WriteAllText(Path.Combine(_generatedModuleDirectory, JsRuntime.FileName), JsRuntime.GetSource());
-        File.WriteAllText(Path.Combine(_generatedModuleDirectory, "validator.js"), GenerateValidatorSource(schemaJson));
+        var directDirectory = Path.Combine(_generatedModuleDirectory, "direct");
+        Directory.CreateDirectory(directDirectory);
+        File.WriteAllText(Path.Combine(directDirectory, JsRuntime.FileName), JsRuntime.GetSource());
+        File.WriteAllText(Path.Combine(directDirectory, "validator.js"), GenerateValidatorSource(schemaJson));
+
+        var typeScriptDerivedDirectory = Path.Combine(_generatedModuleDirectory, "typescript");
+        Directory.CreateDirectory(typeScriptDerivedDirectory);
+        var typeScriptDerivedModulePath = GenerateTypeScriptDerivedJavaScript(schemaJson, typeScriptDerivedDirectory);
 
         _ajvHost = new NodeBenchmarkHost();
         _ajvHost.PrepareAjv(schemaJson);
         _ajvHost.PrepareData(instanceJson);
 
         _formFinchJsHost = new NodeBenchmarkHost();
-        _formFinchJsHost.PrepareGeneratedValidator(Path.Combine(_generatedModuleDirectory, "validator.js"));
+        _formFinchJsHost.PrepareGeneratedValidator(Path.Combine(directDirectory, "validator.js"));
         _formFinchJsHost.PrepareData(instanceJson);
+
+        _formFinchTsDerivedJsHost = new NodeBenchmarkHost();
+        _formFinchTsDerivedJsHost.PrepareGeneratedValidator(typeScriptDerivedModulePath);
+        _formFinchTsDerivedJsHost.PrepareData(instanceJson);
     }
 
     [GlobalCleanup]
@@ -62,6 +74,7 @@ public class NodeJsCompetitorBenchmarks
     {
         _ajvHost?.Dispose();
         _formFinchJsHost?.Dispose();
+        _formFinchTsDerivedJsHost?.Dispose();
 
         if (!string.IsNullOrEmpty(_generatedModuleDirectory))
         {
@@ -88,6 +101,12 @@ public class NodeJsCompetitorBenchmarks
         return _formFinchJsHost.ValidatePreparedBatch(BatchSize);
     }
 
+    [Benchmark(OperationsPerInvoke = BatchSize, Description = "FormFinch TS-derived JS codegen")]
+    public int FormFinchTypeScriptDerivedJsCodegen()
+    {
+        return _formFinchTsDerivedJsHost.ValidatePreparedBatch(BatchSize);
+    }
+
     private static string GenerateValidatorSource(string schemaJson)
     {
         using var schemaDoc = JsonDocument.Parse(schemaJson);
@@ -104,5 +123,47 @@ public class NodeJsCompetitorBenchmarks
         }
 
         return result.GeneratedCode;
+    }
+
+    private static string GenerateTypeScriptDerivedJavaScript(string schemaJson, string outputDirectory)
+    {
+        using var schemaDoc = JsonDocument.Parse(schemaJson);
+        var generator = new TsSchemaCodeGenerator
+        {
+            DefaultDraft = SchemaDraft.Draft202012
+        };
+
+        var result = generator.Generate(schemaDoc.RootElement.Clone(), sourcePath: "validator.json");
+        if (!result.Success || string.IsNullOrEmpty(result.GeneratedCode))
+        {
+            throw new InvalidOperationException(
+                $"Failed to generate TS benchmark validator: {result.Error ?? "Unknown error"}");
+        }
+
+        var sourceDirectory = Path.Combine(outputDirectory, "ts-src");
+        Directory.CreateDirectory(sourceDirectory);
+        var validatorPath = Path.Combine(sourceDirectory, result.FileName!);
+        var runtimePath = Path.Combine(sourceDirectory, TsRuntime.FileName);
+        File.WriteAllText(validatorPath, result.GeneratedCode);
+        File.WriteAllText(runtimePath, TsRuntime.GetSource());
+
+        var compilationResult = TypeScriptCompiler.Compile(
+            [validatorPath, runtimePath],
+            outputDirectory,
+            ecmaScriptTarget: "ES2020");
+        if (!compilationResult.Success)
+        {
+            throw new InvalidOperationException(
+                $"Failed to compile TS benchmark validator: {compilationResult.Error}\n{compilationResult.StandardError}\n{compilationResult.StandardOutput}");
+        }
+
+        var modulePath = Path.Combine(outputDirectory, Path.ChangeExtension(result.FileName!, ".js"));
+        if (!File.Exists(modulePath))
+        {
+            throw new InvalidOperationException(
+                $"TS benchmark validator compiled successfully, but the expected module was not produced: {modulePath}");
+        }
+
+        return modulePath;
     }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/ITsKeywordCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/ITsKeywordCodeGenerator.cs
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Interface for keyword-specific TypeScript code generators.
+/// Parallel to IKeywordCodeGenerator but emits ESM JavaScript instead of C#.
+/// </summary>
+public interface ITsKeywordCodeGenerator
+{
+    /// <summary>
+    /// The JSON Schema keyword this generator handles.
+    /// </summary>
+    string Keyword { get; }
+
+    /// <summary>
+    /// Priority for code generation. Higher values run first.
+    /// Type checks should run first (100), then constraints (50), then applicators (0).
+    /// </summary>
+    int Priority { get; }
+
+    /// <summary>
+    /// Returns true if this generator can handle the keyword in the given schema.
+    /// </summary>
+    bool CanGenerate(JsonElement schema);
+
+    /// <summary>
+    /// Generates validation code for the keyword.
+    /// </summary>
+    string GenerateCode(TsCodeGenerationContext context);
+
+    /// <summary>
+    /// Returns any helper imports required from the runtime module.
+    /// Consumed by the orchestrator to build a single deduplicated import statement.
+    /// </summary>
+    IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context);
+}
+
+/// <summary>
+/// Context provided to JavaScript keyword code generators.
+/// </summary>
+public sealed class TsCodeGenerationContext
+{
+    /// <summary>
+    /// The current schema being processed.
+    /// </summary>
+    public required JsonElement CurrentSchema { get; init; }
+
+    /// <summary>
+    /// The resource-root hash for the current schema.
+    /// </summary>
+    public string CurrentResourceRootHash { get; init; } = "";
+
+    /// <summary>
+    /// The hash of the current schema.
+    /// </summary>
+    public required string CurrentHash { get; init; }
+
+    /// <summary>
+    /// Function to get the hash for a subschema.
+    /// </summary>
+    public required Func<JsonElement, string> GetSubschemaHash { get; init; }
+
+    /// <summary>
+    /// Function to resolve a local $ref (e.g., "#/$defs/foo") to the target schema,
+    /// against the document root. Use ResolveLocalRefInResource when the current
+    /// subschema is inside a nested $id resource.
+    /// </summary>
+    public required Func<string, JsonElement?> ResolveLocalRef { get; init; }
+
+    /// <summary>
+    /// Function to resolve a URI to an internal schema that has a matching $id.
+    /// </summary>
+    public required Func<string, JsonElement?> ResolveInternalId { get; init; }
+
+    /// <summary>
+    /// Function to resolve a local $ref within a specific schema resource.
+    /// Required for correct fragment resolution inside nested $id boundaries.
+    /// </summary>
+    public required Func<string, JsonElement, JsonElement?> ResolveLocalRefInResource { get; init; }
+
+    /// <summary>
+    /// The schema resource root for this subschema: the nearest ancestor with $id
+    /// (or id for Draft 4), or the document root if none. Used to scope local ref
+    /// resolution.
+    /// </summary>
+    public JsonElement? ResourceRoot { get; init; }
+
+    /// <summary>
+    /// The effective base URI for this subschema.
+    /// </summary>
+    public Uri? BaseUri { get; init; }
+
+    /// <summary>
+    /// The root schema base URI.
+    /// </summary>
+    public Uri? RootBaseUri { get; init; }
+
+    /// <summary>
+    /// Function to resolve subschema metadata by hash.
+    /// </summary>
+    public required Func<string, SubschemaInfo?> GetSubschemaInfo { get; init; }
+
+    /// <summary>
+    /// The detected JSON Schema draft version for this schema.
+    /// Used to honor draft-specific keyword behavior.
+    /// </summary>
+    public SchemaDraft DetectedDraft { get; init; } = SchemaDraft.Draft202012;
+
+    /// <summary>
+    /// Whether Draft 2020-12 should assert supported "format" values. Earlier
+    /// supported drafts still assert format by default.
+    /// </summary>
+    public bool FormatAssertionEnabled { get; init; }
+
+    /// <summary>
+    /// Whether the active metaschema enables the validation vocabulary.
+    /// When false, validation-vocabulary keywords must be treated as unknown.
+    /// </summary>
+    public bool ValidationVocabularyEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Whether generated validators need a registry parameter for external refs.
+    /// </summary>
+    public bool RequiresRegistry { get; init; }
+
+    /// <summary>
+    /// Whether generated validators need dynamic scope propagation for $dynamicRef.
+    /// </summary>
+    public bool RequiresScopeTracking { get; init; }
+
+    /// <summary>
+    /// The JS expression for the registry object.
+    /// </summary>
+    public string RegistryExpr { get; init; } = "_registry";
+
+    /// <summary>
+    /// The JS expression for the current dynamic scope stack.
+    /// </summary>
+    public string ScopeExpr { get; init; } = "_scope";
+
+    /// <summary>
+    /// Whether the schema tree contains unevaluatedProperties.
+    /// When true, property evaluation must be tracked.
+    /// </summary>
+    public bool RequiresPropertyAnnotations { get; init; }
+
+    /// <summary>
+    /// Whether the schema tree contains unevaluatedItems.
+    /// When true, item evaluation must be tracked.
+    /// </summary>
+    public bool RequiresItemAnnotations { get; init; }
+
+    /// <summary>
+    /// Whether annotation tracking requires passing state/location through calls.
+    /// </summary>
+    public bool RequiresAnnotationTracking => RequiresPropertyAnnotations || RequiresItemAnnotations;
+
+    /// <summary>
+    /// The JS expression for the evaluated-state object.
+    /// </summary>
+    public string EvaluatedStateExpr { get; init; } = "_eval";
+
+    /// <summary>
+    /// The JS expression for the current instance location.
+    /// </summary>
+    public string LocationExpr { get; init; } = "_loc";
+
+    /// <summary>
+    /// The JS expression for the element being validated (usually "v").
+    /// </summary>
+    public string ElementExpr { get; init; } = "v";
+
+    /// <summary>
+    /// Generates a call to validate a subschema with the current element expression.
+    /// </summary>
+    public string GenerateValidateCall(string hash)
+    {
+        return BuildValidateCall(hash, ElementExpr, LocationExpr);
+    }
+
+    public string GenerateValidateCall(JsonElement schema)
+    {
+        return BuildValidateCall(schema, ElementExpr, LocationExpr);
+    }
+
+    /// <summary>
+    /// Generates a call to validate a subschema with a different element expression.
+    /// </summary>
+    public string GenerateValidateCallForExpr(string hash, string expr)
+    {
+        return BuildValidateCall(hash, expr, LocationExpr);
+    }
+
+    public string GenerateValidateCallForExpr(JsonElement schema, string expr)
+    {
+        return BuildValidateCall(schema, expr, LocationExpr);
+    }
+
+    /// <summary>
+    /// Generates a call to validate a property value and pushes the property onto the instance location.
+    /// </summary>
+    public string GenerateValidateCallForProperty(string hash, string expr, string propertyNameExpr)
+    {
+        var loc = RequiresAnnotationTracking
+            ? $"{LocationExpr} + \"/\" + escapeJsonPointer({propertyNameExpr})"
+            : LocationExpr;
+        return BuildValidateCall(hash, expr, loc);
+    }
+
+    public string GenerateValidateCallForProperty(JsonElement schema, string expr, string propertyNameExpr)
+    {
+        var loc = RequiresAnnotationTracking
+            ? $"{LocationExpr} + \"/\" + escapeJsonPointer({propertyNameExpr})"
+            : LocationExpr;
+        return BuildValidateCall(schema, expr, loc);
+    }
+
+    /// <summary>
+    /// Generates a call to validate an array item and pushes the index onto the instance location.
+    /// </summary>
+    public string GenerateValidateCallForItem(string hash, string expr, string indexExpr)
+    {
+        var loc = RequiresAnnotationTracking
+            ? $"{LocationExpr} + \"/\" + {indexExpr}"
+            : LocationExpr;
+        return BuildValidateCall(hash, expr, loc);
+    }
+
+    public string GenerateValidateCallForItem(JsonElement schema, string expr, string indexExpr)
+    {
+        var loc = RequiresAnnotationTracking
+            ? $"{LocationExpr} + \"/\" + {indexExpr}"
+            : LocationExpr;
+        return BuildValidateCall(schema, expr, loc);
+    }
+
+    private string BuildValidateCall(JsonElement schema, string expr, string locExpr)
+    {
+        if (!IsInlineableRefSchema(schema))
+        {
+            return BuildValidateCall(GetSubschemaHash(schema), expr, locExpr);
+        }
+
+        var inlineContext = CreateChildContext(schema, expr, locExpr);
+        var code = schema.TryGetProperty("$ref", out _)
+            ? new TsRefCodeGenerator().GenerateCode(inlineContext)
+            : new TsDynamicRefCodeGenerator().GenerateCode(inlineContext);
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("(() => {");
+        foreach (var line in code.Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            sb.Append("  ");
+            sb.AppendLine(line.TrimEnd());
+        }
+        sb.Append("  return true;\n})()");
+        return sb.ToString();
+    }
+
+    private string BuildValidateCall(string hash, string expr, string locExpr)
+    {
+        var args = new List<string> { expr };
+        if (RequiresScopeTracking)
+        {
+            args.Add(ScopeExpr);
+        }
+        if (RequiresAnnotationTracking)
+        {
+            args.Add(EvaluatedStateExpr);
+        }
+        if (RequiresScopeTracking || RequiresAnnotationTracking)
+        {
+            args.Add(locExpr);
+        }
+        if (RequiresRegistry)
+        {
+            args.Add(RegistryExpr);
+        }
+        return $"validate_{hash}({string.Join(", ", args)})";
+    }
+
+    private TsCodeGenerationContext CreateChildContext(JsonElement schema, string expr, string locExpr)
+    {
+        return new TsCodeGenerationContext
+        {
+            CurrentSchema = schema,
+            CurrentResourceRootHash = CurrentResourceRootHash,
+            CurrentHash = GetSubschemaHash(schema),
+            GetSubschemaHash = GetSubschemaHash,
+            ResolveLocalRef = ResolveLocalRef,
+            ResolveInternalId = ResolveInternalId,
+            ResolveLocalRefInResource = ResolveLocalRefInResource,
+            ResourceRoot = ResourceRoot,
+            BaseUri = BaseUri,
+            RootBaseUri = RootBaseUri,
+            GetSubschemaInfo = GetSubschemaInfo,
+            DetectedDraft = DetectedDraft,
+            FormatAssertionEnabled = FormatAssertionEnabled,
+            ValidationVocabularyEnabled = ValidationVocabularyEnabled,
+            RequiresRegistry = RequiresRegistry,
+            RequiresScopeTracking = RequiresScopeTracking,
+            RegistryExpr = RegistryExpr,
+            ScopeExpr = ScopeExpr,
+            RequiresPropertyAnnotations = RequiresPropertyAnnotations,
+            RequiresItemAnnotations = RequiresItemAnnotations,
+            EvaluatedStateExpr = EvaluatedStateExpr,
+            LocationExpr = locExpr,
+            ElementExpr = expr
+        };
+    }
+
+    private static bool IsInlineableRefSchema(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        var count = 0;
+        var hasInlineableKeyword = false;
+        foreach (var property in schema.EnumerateObject())
+        {
+            count++;
+            if ((property.Name == "$ref" || property.Name == "$dynamicRef") &&
+                property.Value.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(property.Value.GetString()))
+            {
+                hasInlineableKeyword = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        return hasInlineableKeyword && count == 1;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsArrayConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsArrayConstraintsCodeGenerator.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for array constraint keywords: minItems, maxItems, uniqueItems.
+/// </summary>
+public sealed class TsArrayConstraintsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "minItems/maxItems/uniqueItems";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minItems", out _) ||
+               schema.TryGetProperty("maxItems", out _) ||
+               schema.TryGetProperty("uniqueItems", out _);
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minItems", out var minElem) &&
+                     TryGetIntegerValue(minElem, out var min);
+        var hasMax = schema.TryGetProperty("maxItems", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out var max);
+        var hasUnique = schema.TryGetProperty("uniqueItems", out var unElem) &&
+                        unElem.ValueKind == JsonValueKind.True;
+
+        if (!hasMin && !hasMax && !hasUnique) return string.Empty;
+
+        TryGetIntegerValue(minElem, out min);
+        TryGetIntegerValue(maxElem, out max);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        if (hasMin) sb.AppendLine($"  if ({v}.length < {min}) return false;");
+        if (hasMax) sb.AppendLine($"  if ({v}.length > {max}) return false;");
+        if (hasUnique)
+        {
+            sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+            sb.AppendLine($"    for (let _j = _i + 1; _j < {v}.length; _j++) {{");
+            sb.AppendLine($"      if (deepEquals({v}[_i], {v}[_j])) return false;");
+            sb.AppendLine($"    }}");
+            sb.AppendLine($"  }}");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            yield break;
+        }
+
+        if (context.CurrentSchema.ValueKind == JsonValueKind.Object &&
+            context.CurrentSchema.TryGetProperty("uniqueItems", out var u) &&
+            u.ValueKind == JsonValueKind.True)
+        {
+            yield return "deepEquals";
+        }
+    }
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        TsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsContainsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsContainsCodeGenerator.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "contains" keyword with minContains/maxContains.
+/// contains was introduced in Draft 6; minContains/maxContains in Draft 2019-09.
+/// Draft 4 (MVP support) does not have this keyword — emitter no-ops for Draft 4.
+/// </summary>
+public sealed class TsContainsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "contains";
+    public int Priority => 35;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object && schema.TryGetProperty("contains", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft6) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("contains", out var containsElem))
+        {
+            return string.Empty;
+        }
+
+        var hash = context.GetSubschemaHash(containsElem);
+        long min = 1;
+        long max = long.MaxValue;
+        if (context.DetectedDraft >= SchemaDraft.Draft201909 && context.ValidationVocabularyEnabled)
+        {
+            if (context.CurrentSchema.TryGetProperty("minContains", out var minElem) &&
+                TryGetIntegerValue(minElem, out var mn)) min = mn;
+            if (context.CurrentSchema.TryGetProperty("maxContains", out var maxElem) &&
+                TryGetIntegerValue(maxElem, out var mx)) max = mx;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        sb.AppendLine("  let _count = 0;");
+        sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+        sb.AppendLine($"    if ({context.GenerateValidateCallForItem(hash, $"{v}[_i]", "_i")}) {{");
+        sb.AppendLine("      _count++;");
+        if (context.RequiresItemAnnotations)
+        {
+            sb.AppendLine($"      {context.EvaluatedStateExpr}.markItemEvaluated({context.LocationExpr}, _i);");
+        }
+        if (max != long.MaxValue)
+        {
+            sb.AppendLine($"      if (_count > {max}) return false;");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine("  }");
+        sb.AppendLine($"  if (_count < {min}) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        TsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsDependentCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsDependentCodeGenerator.cs
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "dependentRequired" keyword (Draft 2019-09+).
+/// </summary>
+public sealed class TsDependentRequiredCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "dependentRequired";
+    public int Priority => 55;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("dependentRequired", out var d) &&
+        d.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled) return string.Empty;
+        if (context.DetectedDraft < SchemaDraft.Draft201909) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("dependentRequired", out var depElem) ||
+            depElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+        return EmitDependentRequired(context.ElementExpr, depElem);
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+
+    internal static string EmitDependentRequired(string v, JsonElement depElem)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var dep in depElem.EnumerateObject())
+        {
+            if (dep.Value.ValueKind != JsonValueKind.Array) continue;
+            var trigger = TsLiteral.String(dep.Name);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {trigger})) {{");
+            foreach (var required in dep.Value.EnumerateArray())
+            {
+                if (required.ValueKind != JsonValueKind.String) continue;
+                sb.AppendLine($"    if (!Object.prototype.hasOwnProperty.call({v}, {TsLiteral.String(required.GetString()!)})) return false;");
+            }
+            sb.AppendLine("  }");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Generates TypeScript code for the "dependentSchemas" keyword (Draft 2019-09+).
+/// </summary>
+public sealed class TsDependentSchemasCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "dependentSchemas";
+    public int Priority => 55;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("dependentSchemas", out var d) &&
+        d.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft201909) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("dependentSchemas", out var depElem) ||
+            depElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+        return EmitDependentSchemas(context, depElem);
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+
+    internal static string EmitDependentSchemas(TsCodeGenerationContext context, JsonElement depElem)
+    {
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var dep in depElem.EnumerateObject())
+        {
+            var trigger = TsLiteral.String(dep.Name);
+            var hash = context.GetSubschemaHash(dep.Value);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {trigger})) {{");
+            sb.AppendLine($"    if (!{context.GenerateValidateCall(hash)}) return false;");
+            sb.AppendLine("  }");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Generates TypeScript code for the "dependencies" keyword.
+/// In Draft 4-7, each dependency value can be an array of required property names
+/// or a schema — the combined form later split into dependentRequired/dependentSchemas.
+/// Draft 2019-09+ still exercises this through optional compatibility tests.
+/// </summary>
+public sealed class TsDependenciesCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "dependencies";
+    public int Priority => 55;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("dependencies", out var d) &&
+        d.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled && context.DetectedDraft >= SchemaDraft.Draft201909)
+        {
+            return string.Empty;
+        }
+
+        if (!context.CurrentSchema.TryGetProperty("dependencies", out var depElem) ||
+            depElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var dep in depElem.EnumerateObject())
+        {
+            var trigger = TsLiteral.String(dep.Name);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {trigger})) {{");
+            if (dep.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var required in dep.Value.EnumerateArray())
+                {
+                    if (required.ValueKind != JsonValueKind.String) continue;
+                    sb.AppendLine($"    if (!Object.prototype.hasOwnProperty.call({v}, {TsLiteral.String(required.GetString()!)})) return false;");
+                }
+            }
+            else
+            {
+                var hash = context.GetSubschemaHash(dep.Value);
+                sb.AppendLine($"    if (!{context.GenerateValidateCall(hash)}) return false;");
+            }
+            sb.AppendLine("  }");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsDynamicRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsDynamicRefCodeGenerator.cs
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for "$dynamicRef" in Draft 2020-12.
+/// </summary>
+public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "$dynamicRef";
+    public int Priority => 199;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        if (!schema.TryGetProperty("$dynamicRef", out var r)) return false;
+        return r.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(r.GetString());
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft != SchemaDraft.Draft202012 ||
+            !context.CurrentSchema.TryGetProperty("$dynamicRef", out var refElem))
+        {
+            return string.Empty;
+        }
+
+        var refValue = refElem.GetString();
+        if (string.IsNullOrEmpty(refValue))
+        {
+            return string.Empty;
+        }
+
+        if (refValue.StartsWith("#/"))
+        {
+            return GenerateLocalRefLikeCode(context, refValue);
+        }
+
+        if (refValue.StartsWith('#'))
+        {
+            return GenerateLocalDynamicRefCode(context, refValue[1..], refValue);
+        }
+
+        return GenerateExternalDynamicRefCode(context, refValue);
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+
+    private static string GenerateLocalDynamicRefCode(TsCodeGenerationContext context, string anchorName, string refValue)
+    {
+        var localDynamicAnchor = context.ResourceRoot.HasValue
+            ? FindDynamicAnchorInResource(anchorName, context.ResourceRoot.Value)
+            : null;
+        if (!localDynamicAnchor.HasValue)
+        {
+            return GenerateLocalRefLikeCode(context, refValue);
+        }
+
+        var localHash = context.GetSubschemaHash(localDynamicAnchor.Value);
+        return GenerateDynamicLookupCode(context, anchorName, localHash);
+    }
+
+    private static string GenerateExternalDynamicRefCode(TsCodeGenerationContext context, string refValue)
+    {
+        if (!TryResolveUri(context, refValue, out var targetUri))
+        {
+            throw new InvalidOperationException("Could not resolve $dynamicRef URI during TypeScript code generation.");
+        }
+
+        var fragment = targetUri.Fragment;
+        if (string.IsNullOrEmpty(fragment) || fragment == "#" || fragment.StartsWith("#/", StringComparison.Ordinal))
+        {
+            return GenerateExternalRefLikeCode(context, targetUri);
+        }
+
+        var anchorName = fragment[1..];
+        var targetUriWithoutFragment = new Uri(targetUri.GetLeftPart(UriPartial.Query));
+        var internalSchema = context.ResolveInternalId(targetUriWithoutFragment.AbsoluteUri);
+        if (internalSchema.HasValue)
+        {
+            var localDynamicAnchor = FindDynamicAnchorInResource(anchorName, internalSchema.Value);
+            if (!localDynamicAnchor.HasValue)
+            {
+                return GenerateExternalRefLikeCode(context, targetUri);
+            }
+
+            var localHash = context.GetSubschemaHash(localDynamicAnchor.Value);
+            return GenerateDynamicLookupCode(context, anchorName, localHash);
+        }
+
+        var uriLiteral = TsLiteral.String(targetUri.AbsoluteUri);
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine($"  const _dynValidator = {context.ScopeExpr}.tryResolveDynamicAnchor({TsLiteral.String(anchorName)});");
+        sb.AppendLine("  if (_dynValidator !== null) {");
+        sb.AppendLine($"    if (!{BuildDynamicValidatorCall(context, "_dynValidator")}) return false;");
+        sb.AppendLine("  } else {");
+        sb.AppendLine($"    const _refValidator = {context.RegistryExpr}?.tryGetValidator?.({uriLiteral}) ?? null;");
+        sb.AppendLine("    if (_refValidator === null) return false;");
+        TsRefCodeGenerator.EmitExternalDispatch(sb, context, "    ");
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GenerateLocalRefLikeCode(TsCodeGenerationContext context, string refValue)
+    {
+        JsonElement? target = context.ResourceRoot.HasValue
+            ? context.ResolveLocalRefInResource(refValue, context.ResourceRoot.Value)
+            : context.ResolveLocalRef(refValue);
+        if (!target.HasValue)
+        {
+            throw new InvalidOperationException("Could not resolve $dynamicRef during TypeScript code generation.");
+        }
+
+        return GenerateScopeAwareCall(context, context.GetSubschemaHash(target.Value));
+    }
+
+    private static string GenerateExternalRefLikeCode(TsCodeGenerationContext context, Uri targetUri)
+    {
+        var targetUriWithoutFragment = new Uri(targetUri.GetLeftPart(UriPartial.Query));
+        var internalSchema = context.ResolveInternalId(targetUriWithoutFragment.AbsoluteUri);
+        if (internalSchema.HasValue)
+        {
+            JsonElement? targetSchema = internalSchema.Value;
+            var fragment = targetUri.Fragment;
+            if (!string.IsNullOrEmpty(fragment) && fragment != "#")
+            {
+                targetSchema = context.ResolveLocalRefInResource(fragment, internalSchema.Value);
+            }
+
+            if (!targetSchema.HasValue)
+            {
+                throw new InvalidOperationException("Could not resolve internal $dynamicRef during TypeScript code generation.");
+            }
+
+            return GenerateScopeAwareCall(context, context.GetSubschemaHash(targetSchema.Value));
+        }
+
+        if (targetUri.Fragment == "#")
+        {
+            targetUri = new Uri(targetUri.GetLeftPart(UriPartial.Query));
+        }
+
+        var uriLiteral = TsLiteral.String(targetUri.AbsoluteUri);
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine($"  const _refValidator = {context.RegistryExpr}?.tryGetValidator?.({uriLiteral}) ?? null;");
+        sb.AppendLine("  if (_refValidator === null) return false;");
+        TsRefCodeGenerator.EmitExternalDispatch(sb, context, "  ");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GenerateDynamicLookupCode(TsCodeGenerationContext context, string anchorName, string localHash)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine($"  const _dynValidator = {context.ScopeExpr}.tryResolveDynamicAnchor({TsLiteral.String(anchorName)});");
+        sb.AppendLine("  if (_dynValidator !== null) {");
+        sb.AppendLine($"    if (!{BuildDynamicValidatorCall(context, "_dynValidator")}) return false;");
+        sb.AppendLine("  } else {");
+        foreach (var line in GenerateScopeAwareCall(context, localHash).Split('\n'))
+        {
+            if (!string.IsNullOrWhiteSpace(line))
+            {
+                sb.AppendLine($"    {line.TrimEnd()}");
+            }
+        }
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string BuildDynamicValidatorCall(TsCodeGenerationContext context, string validatorExpr)
+    {
+        var args = new List<string> { context.ElementExpr, context.ScopeExpr };
+        if (context.RequiresAnnotationTracking)
+        {
+            args.Add(context.EvaluatedStateExpr);
+        }
+        args.Add(context.LocationExpr);
+        if (context.RequiresRegistry)
+        {
+            args.Add(context.RegistryExpr);
+        }
+        return $"{validatorExpr}({string.Join(", ", args)})";
+    }
+
+    private static string GenerateScopeAwareCall(TsCodeGenerationContext context, string targetHash)
+    {
+        if (!context.RequiresScopeTracking)
+        {
+            return $"if (!{context.GenerateValidateCall(targetHash)}) return false;";
+        }
+
+        var targetInfo = context.GetSubschemaInfo(targetHash);
+        if (targetInfo == null ||
+            targetInfo.IsResourceRoot ||
+            targetInfo.ResourceRootHash == context.CurrentResourceRootHash)
+        {
+            return $"if (!{context.GenerateValidateCall(targetHash)}) return false;";
+        }
+
+        var resourceRootInfo = context.GetSubschemaInfo(targetInfo.ResourceRootHash);
+        if (resourceRootInfo == null || resourceRootInfo.ResourceAnchors.Count == 0)
+        {
+            return $"if (!{context.GenerateValidateCall(targetHash)}) return false;";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine("const _targetScope = _scope.push({");
+        sb.AppendLine("  dynamicAnchors: {");
+        foreach (var (anchorName, schemaHash) in resourceRootInfo.ResourceAnchors)
+        {
+            var delegateExpr = context.RequiresAnnotationTracking
+                ? context.RequiresRegistry
+                    ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
+                    : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
+                : context.RequiresRegistry
+                    ? $"(data, scope, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
+                    : $"(data, scope, location = \"\") => validate_{schemaHash}(data, scope, location)";
+            sb.AppendLine($"    {TsLiteral.String(anchorName)}: {delegateExpr},");
+        }
+        sb.AppendLine("  }");
+        sb.AppendLine("});");
+        var args = new List<string> { context.ElementExpr, "_targetScope" };
+        if (context.RequiresAnnotationTracking)
+        {
+            args.Add(context.EvaluatedStateExpr);
+        }
+        args.Add(context.LocationExpr);
+        if (context.RequiresRegistry)
+        {
+            args.Add(context.RegistryExpr);
+        }
+        sb.AppendLine($"if (!validate_{targetHash}({string.Join(", ", args)})) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static bool TryResolveUri(TsCodeGenerationContext context, string refValue, out Uri targetUri)
+    {
+        if (Uri.TryCreate(refValue, UriKind.Absolute, out var absoluteUri))
+        {
+            targetUri = absoluteUri;
+            return true;
+        }
+
+        if (context.BaseUri != null && Uri.TryCreate(context.BaseUri, refValue, out var resolvedUri))
+        {
+            targetUri = resolvedUri;
+            return true;
+        }
+
+        try
+        {
+            targetUri = new Uri(refValue, UriKind.RelativeOrAbsolute);
+            return targetUri.IsAbsoluteUri;
+        }
+        catch
+        {
+            targetUri = null!;
+            return false;
+        }
+    }
+
+    private static JsonElement? FindDynamicAnchorInResource(string anchorName, JsonElement resourceRoot)
+    {
+        return FindDynamicAnchorInSchema(anchorName, resourceRoot);
+    }
+
+    private static JsonElement? FindDynamicAnchorInSchema(string anchorName, JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (schema.TryGetProperty("$dynamicAnchor", out var dynamicAnchor) &&
+            dynamicAnchor.ValueKind == JsonValueKind.String &&
+            dynamicAnchor.GetString() == anchorName)
+        {
+            return schema;
+        }
+
+        foreach (var property in schema.EnumerateObject())
+        {
+            if (property.Value.ValueKind == JsonValueKind.Object)
+            {
+                if (property.Value.TryGetProperty("$id", out var idElement) &&
+                    idElement.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrEmpty(idElement.GetString()) &&
+                    !idElement.GetString()!.StartsWith('#'))
+                {
+                    continue;
+                }
+
+                var result = FindDynamicAnchorInSchema(anchorName, property.Value);
+                if (result.HasValue) return result;
+            }
+            else if (property.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in property.Value.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    if (item.TryGetProperty("$id", out var idElement) &&
+                        idElement.ValueKind == JsonValueKind.String &&
+                        !string.IsNullOrEmpty(idElement.GetString()) &&
+                        !idElement.GetString()!.StartsWith('#'))
+                    {
+                        continue;
+                    }
+
+                    var result = FindDynamicAnchorInSchema(anchorName, item);
+                    if (result.HasValue) return result;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsEnumConstCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsEnumConstCodeGenerator.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "enum" keyword.
+/// Uses the runtime deepEquals helper for structural comparison.
+/// </summary>
+public sealed class TsEnumCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "enum";
+    public int Priority => 80;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("enum", out var e) &&
+               e.ValueKind == JsonValueKind.Array;
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        if (!context.CurrentSchema.TryGetProperty("enum", out var enumElem) ||
+            enumElem.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var checks = new List<string>();
+        foreach (var item in enumElem.EnumerateArray())
+        {
+            checks.Add($"deepEquals({v}, {TsLiteral.JSONAsExpression(item)})");
+        }
+        if (checks.Count == 0)
+        {
+            // Empty enum never matches.
+            return "return false;";
+        }
+
+        var sb = new StringBuilder();
+        sb.Append("if (!(");
+        sb.Append(string.Join(" || ", checks));
+        sb.AppendLine(")) return false;");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            yield break;
+        }
+
+        if (context.CurrentSchema.ValueKind == JsonValueKind.Object &&
+            context.CurrentSchema.TryGetProperty("enum", out var e) &&
+            e.ValueKind == JsonValueKind.Array &&
+            e.GetArrayLength() > 0)
+        {
+            yield return "deepEquals";
+        }
+    }
+}
+
+/// <summary>
+/// Generates TypeScript code for the "const" keyword.
+/// </summary>
+public sealed class TsConstCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "const";
+    public int Priority => 80;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("const", out _);
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        // const was introduced in Draft 6; for Draft 4 it is an unknown keyword
+        // and must be ignored (annotation-only), not enforced.
+        if (context.DetectedDraft < SchemaDraft.Draft6) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("const", out var constElem))
+        {
+            return string.Empty;
+        }
+        var v = context.ElementExpr;
+        return $"if (!deepEquals({v}, {TsLiteral.JSONAsExpression(constElem)})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled) yield break;
+        if (context.DetectedDraft < SchemaDraft.Draft6) yield break;
+        yield return "deepEquals";
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsFormatCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsFormatCodeGenerator.cs
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "format" keyword.
+/// Emits eager validation for legacy drafts that treated format as asserting.
+/// For Draft 2020-12, format stays annotation-only unless assertion is enabled.
+/// </summary>
+public sealed class TsFormatCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "format";
+    public int Priority => 40;
+
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SupportedFormatsByDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "date-time", "email", "hostname", "ipv4", "ipv6", "uri",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "date-time", "date", "time",
+            "email", "idn-email",
+            "hostname", "idn-hostname",
+            "ipv4", "ipv6",
+            "uri", "uri-reference", "uri-template",
+            "iri", "iri-reference",
+            "json-pointer", "relative-json-pointer",
+            "regex", "uuid",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "date-time", "date", "time", "duration",
+            "email", "idn-email",
+            "hostname", "idn-hostname",
+            "ipv4", "ipv6",
+            "uri", "uri-reference", "uri-template",
+            "iri", "iri-reference",
+            "json-pointer", "relative-json-pointer",
+            "regex", "uuid",
+        },
+    };
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        if (!schema.TryGetProperty("format", out var f)) return false;
+        return f.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(f.GetString());
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!ShouldAssertFormat(context)) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("format", out var formatElem)) return string.Empty;
+        var format = formatElem.GetString();
+        if (string.IsNullOrEmpty(format)) return string.Empty;
+
+        if (!SupportedFormatsByDraft.TryGetValue(context.DetectedDraft, out var supported) ||
+            !supported.Contains(format))
+        {
+            return string.Empty; // annotation-only for this draft
+        }
+
+        var importName = MapFormatToImport(format);
+        if (importName == null) return string.Empty;
+        var v = context.ElementExpr;
+        return $"if (!{importName}({v})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!ShouldAssertFormat(context)) yield break;
+        if (!context.CurrentSchema.TryGetProperty("format", out var formatElem) ||
+            formatElem.ValueKind != JsonValueKind.String)
+        {
+            yield break;
+        }
+        var format = formatElem.GetString();
+        if (string.IsNullOrEmpty(format)) yield break;
+
+        if (!SupportedFormatsByDraft.TryGetValue(context.DetectedDraft, out var supported) ||
+            !supported.Contains(format))
+        {
+            yield break;
+        }
+        var importName = MapFormatToImport(format);
+        if (importName != null) yield return importName;
+    }
+
+    private static bool ShouldAssertFormat(TsCodeGenerationContext context)
+    {
+        return context.DetectedDraft switch
+        {
+            SchemaDraft.Draft202012 => context.FormatAssertionEnabled,
+            _ => true,
+        };
+    }
+
+    private static string? MapFormatToImport(string format) => format switch
+    {
+        "date-time" => "isValidDateTime",
+        "date" => "isValidDate",
+        "time" => "isValidTime",
+        "duration" => "isValidDuration",
+        "email" => "isValidEmail",
+        "idn-email" => "isValidIdnEmail",
+        "hostname" => "isValidHostname",
+        "idn-hostname" => "isValidIdnHostname",
+        "ipv4" => "isValidIpv4",
+        "ipv6" => "isValidIpv6",
+        "uri" => "isValidUri",
+        "uri-reference" => "isValidUriReference",
+        "uri-template" => "isValidUriTemplate",
+        "iri" => "isValidIri",
+        "iri-reference" => "isValidIriReference",
+        "json-pointer" => "isValidJsonPointer",
+        "relative-json-pointer" => "isValidRelativeJsonPointer",
+        "regex" => "isValidRegex",
+        "uuid" => "isValidUuid",
+        _ => null,
+    };
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsIfThenElseCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsIfThenElseCodeGenerator.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "if"/"then"/"else" keywords (Draft 7+).
+/// </summary>
+public sealed class TsIfThenElseCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "if/then/else";
+    public int Priority => 25;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("if", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        // if/then/else were introduced in Draft 7; earlier drafts must ignore them.
+        if (context.DetectedDraft < SchemaDraft.Draft7) return string.Empty;
+        var schema = context.CurrentSchema;
+        if (!schema.TryGetProperty("if", out var ifElem))
+        {
+            return string.Empty;
+        }
+        var hasThen = schema.TryGetProperty("then", out var thenElem);
+        var hasElse = schema.TryGetProperty("else", out var elseElem);
+        if (!hasThen && !hasElse && !context.RequiresAnnotationTracking) return string.Empty;
+
+        var ifHash = context.GetSubschemaHash(ifElem);
+        var sb = new StringBuilder();
+        if (context.RequiresAnnotationTracking)
+        {
+            sb.AppendLine("{");
+            sb.AppendLine($"  const _ifteBase = {context.EvaluatedStateExpr}.clone();");
+            sb.AppendLine($"  {context.EvaluatedStateExpr}.reset();");
+            sb.AppendLine($"  const _ifResult = {context.GenerateValidateCall(ifHash)};");
+            sb.AppendLine($"  const _ifAnn = {context.EvaluatedStateExpr}.clone();");
+
+            sb.AppendLine("  if (_ifResult) {");
+            if (hasThen)
+            {
+                var thenHash = context.GetSubschemaHash(thenElem);
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.reset();");
+                sb.AppendLine($"    if (!{context.GenerateValidateCall(thenHash)}) return false;");
+                sb.AppendLine($"    const _thenAnn = {context.EvaluatedStateExpr}.clone();");
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.restoreFrom(_ifteBase);");
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.mergeFrom(_ifAnn);");
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.mergeFrom(_thenAnn);");
+            }
+            else
+            {
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.restoreFrom(_ifteBase);");
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.mergeFrom(_ifAnn);");
+            }
+            sb.AppendLine("  } else {");
+            if (hasElse)
+            {
+                var elseHash = context.GetSubschemaHash(elseElem);
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.reset();");
+                sb.AppendLine($"    if (!{context.GenerateValidateCall(elseHash)}) return false;");
+                sb.AppendLine($"    const _elseAnn = {context.EvaluatedStateExpr}.clone();");
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.restoreFrom(_ifteBase);");
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.mergeFrom(_elseAnn);");
+            }
+            else
+            {
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.restoreFrom(_ifteBase);");
+            }
+            sb.AppendLine("  }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        sb.AppendLine($"if ({context.GenerateValidateCall(ifHash)}) {{");
+        if (hasThen)
+        {
+            var thenHash = context.GetSubschemaHash(thenElem);
+            sb.AppendLine($"  if (!{context.GenerateValidateCall(thenHash)}) return false;");
+        }
+        sb.AppendLine("} else {");
+        if (hasElse)
+        {
+            var elseHash = context.GetSubschemaHash(elseElem);
+            sb.AppendLine($"  if (!{context.GenerateValidateCall(elseHash)}) return false;");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsItemsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsItemsCodeGenerator.cs
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "items" keyword.
+/// Draft 2020-12: items is a single schema applying to indices >= prefixItems count.
+/// Draft 4 (MVP's other supported draft): items is either a single schema or an
+/// array (tuple validation). The array-form branch also matches Draft 2019-09
+/// keyword semantics at the code level, but Draft 2019-09 is rejected by
+/// TsCapabilityGate for the JS target.
+/// </summary>
+public sealed class TsItemsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "items";
+    public int Priority => 40;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object && schema.TryGetProperty("items", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("items", out var items))
+        {
+            return string.Empty;
+        }
+        return context.DetectedDraft == SchemaDraft.Draft202012
+            ? GenerateDraft202012(context, items)
+            : GenerateLegacy(context, items);
+    }
+
+    private static string GenerateDraft202012(TsCodeGenerationContext ctx, JsonElement items)
+    {
+        if (items.ValueKind == JsonValueKind.Array)
+        {
+            // Draft 2020-12 replaced the tuple form of items with prefixItems.
+            // Silently no-opping would let an invalid schema compile too loosely,
+            // so surface this as a generation failure (matches dynamic validator).
+            throw new InvalidOperationException(
+                "Schema uses array-form \"items\" under Draft 2020-12. " +
+                "Use \"prefixItems\" for tuple validation in 2020-12; \"items\" must be a single schema.");
+        }
+        var v = ctx.ElementExpr;
+        var prefixCount = 0;
+        if (ctx.CurrentSchema.TryGetProperty("prefixItems", out var prefixItems) &&
+            prefixItems.ValueKind == JsonValueKind.Array)
+        {
+            prefixCount = prefixItems.GetArrayLength();
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        sb.AppendLine($"  for (let _i = {prefixCount}; _i < {v}.length; _i++) {{");
+        sb.AppendLine($"    if (!{ctx.GenerateValidateCallForItem(items, $"{v}[_i]", "_i")}) return false;");
+        sb.AppendLine("  }");
+        if (ctx.RequiresItemAnnotations)
+        {
+            sb.AppendLine($"  {ctx.EvaluatedStateExpr}.setEvaluatedItemsUpTo({ctx.LocationExpr}, {v}.length);");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string GenerateLegacy(TsCodeGenerationContext ctx, JsonElement items)
+    {
+        var v = ctx.ElementExpr;
+        if (items.ValueKind == JsonValueKind.Array)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            var idx = 0;
+            foreach (var sub in items.EnumerateArray())
+            {
+                sb.AppendLine($"  if ({v}.length > {idx} && !{ctx.GenerateValidateCallForItem(sub, $"{v}[{idx}]", idx.ToString(System.Globalization.CultureInfo.InvariantCulture))}) return false;");
+                idx++;
+            }
+            if (ctx.RequiresItemAnnotations)
+            {
+                sb.AppendLine($"  {ctx.EvaluatedStateExpr}.setEvaluatedItemsUpTo({ctx.LocationExpr}, Math.min({idx}, {v}.length));");
+            }
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        if (items.ValueKind == JsonValueKind.Object ||
+            items.ValueKind == JsonValueKind.True ||
+            items.ValueKind == JsonValueKind.False)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+            sb.AppendLine($"    if (!{ctx.GenerateValidateCallForItem(items, $"{v}[_i]", "_i")}) return false;");
+            sb.AppendLine("  }");
+            if (ctx.RequiresItemAnnotations)
+            {
+                sb.AppendLine($"  {ctx.EvaluatedStateExpr}.setEvaluatedItemsUpTo({ctx.LocationExpr}, {v}.length);");
+            }
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        return string.Empty;
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates TypeScript code for the "prefixItems" keyword (Draft 2020-12 only).
+/// </summary>
+public sealed class TsPrefixItemsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "prefixItems";
+    public int Priority => 45;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("prefixItems", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft != SchemaDraft.Draft202012) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("prefixItems", out var prefix) ||
+            prefix.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        var idx = 0;
+        foreach (var sub in prefix.EnumerateArray())
+        {
+            sb.AppendLine($"  if ({v}.length > {idx} && !{context.GenerateValidateCallForItem(sub, $"{v}[{idx}]", idx.ToString(System.Globalization.CultureInfo.InvariantCulture))}) return false;");
+            idx++;
+        }
+        if (context.RequiresItemAnnotations)
+        {
+            sb.AppendLine($"  {context.EvaluatedStateExpr}.setEvaluatedItemsUpTo({context.LocationExpr}, Math.min({idx}, {v}.length));");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates TypeScript code for the "additionalItems" keyword (Draft 4 in the TypeScript
+/// target; also applies to Draft 2019-09 semantically but that draft is rejected
+/// by TsCapabilityGate, so this generator only fires for Draft 4 schemas here).
+/// Removed in Draft 2020-12. Only meaningful when items is an array (tuple validation).
+/// </summary>
+public sealed class TsAdditionalItemsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "additionalItems";
+    public int Priority => 42;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("additionalItems", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft == SchemaDraft.Draft202012) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("additionalItems", out var additional))
+        {
+            return string.Empty;
+        }
+        if (!context.CurrentSchema.TryGetProperty("items", out var items) ||
+            items.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        var tupleLen = items.GetArrayLength();
+        var v = context.ElementExpr;
+
+        if (additional.ValueKind == JsonValueKind.False)
+        {
+            return $"if (Array.isArray({v}) && {v}.length > {tupleLen}) return false;";
+        }
+        if (additional.ValueKind == JsonValueKind.True)
+        {
+            return string.Empty;
+        }
+        if (additional.ValueKind != JsonValueKind.Object)
+        {
+            // Invalid schema: additionalItems must be object/boolean per spec.
+            // SubschemaExtractor skips non-schema values, so emitting a
+            // validate_<hash> call would be undefined at runtime.
+            throw new InvalidOperationException(
+                "Schema's \"additionalItems\" value must be an object or boolean; got " +
+                $"{additional.ValueKind}.");
+        }
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (Array.isArray({v})) {{");
+        sb.AppendLine($"  for (let _i = {tupleLen}; _i < {v}.length; _i++) {{");
+        sb.AppendLine($"    if (!{context.GenerateValidateCallForItem(additional, $"{v}[_i]", "_i")}) return false;");
+        sb.AppendLine("  }");
+        if (context.RequiresItemAnnotations)
+        {
+            sb.AppendLine($"  {context.EvaluatedStateExpr}.setEvaluatedItemsUpTo({context.LocationExpr}, {v}.length);");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsLiteral.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsLiteral.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Globalization;
+using System.Text;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// JavaScript source-literal helpers used by keyword emitters.
+/// Centralises escaping so every emitter produces syntactically safe output.
+/// </summary>
+internal static class TsLiteral
+{
+    // U+2028 / U+2029 referenced via hex to keep them out of the C# source itself:
+    // both code points are line terminators in the C# lexer too, so embedding them
+    // inline breaks character-literal parsing.
+    private const char LineSeparator = (char)0x2028;
+    private const char ParagraphSeparator = (char)0x2029;
+    private const string LineSeparatorEscape = "\\u2028";
+    private const string ParagraphSeparatorEscape = "\\u2029";
+
+    /// <summary>
+    /// Emits a JavaScript double-quoted string literal, including delimiters.
+    /// Escapes the characters needed for JS source safety.
+    /// </summary>
+    public static string String(string value)
+    {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\f': sb.Append("\\f"); break;
+                case '\b': sb.Append("\\b"); break;
+                case LineSeparator: sb.Append(LineSeparatorEscape); break;
+                case ParagraphSeparator: sb.Append(ParagraphSeparatorEscape); break;
+                default:
+                    if (c < 0x20)
+                    {
+                        sb.Append("\\u").Append(((int)c).ToString("X4", CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                    break;
+            }
+        }
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emits a JSON element as a JavaScript expression literal. Starts from the raw
+    /// JSON text (which is always valid JS grammar) and escapes U+2028/U+2029 inside
+    /// string literals. Those code points are legal in JSON strings but were illegal
+    /// in JS string literals pre-ES2019, and some tooling still chokes on them.
+    /// Literal control characters inside strings are impossible (JSON forbids them).
+    /// </summary>
+    public static string JSONAsExpression(System.Text.Json.JsonElement element)
+    {
+        var raw = element.GetRawText();
+        if (raw.IndexOf(LineSeparator) < 0 && raw.IndexOf(ParagraphSeparator) < 0)
+        {
+            return raw;
+        }
+        return raw
+            .Replace(LineSeparator.ToString(), LineSeparatorEscape)
+            .Replace(ParagraphSeparator.ToString(), ParagraphSeparatorEscape);
+    }
+
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsLogicKeywordsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsLogicKeywordsCodeGenerator.cs
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "allOf" keyword.
+/// </summary>
+public sealed class TsAllOfCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "allOf";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("allOf", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("allOf", out var allOf) ||
+            allOf.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        if (context.RequiresAnnotationTracking)
+        {
+            var branches = allOf.EnumerateArray().ToArray();
+            var sbTracked = new StringBuilder();
+            sbTracked.AppendLine("{");
+            sbTracked.AppendLine($"  const _allOfBase = {context.EvaluatedStateExpr}.clone();");
+            for (var i = 0; i < branches.Length; i++)
+            {
+                var hash = context.GetSubschemaHash(branches[i]);
+                sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.reset();");
+                sbTracked.AppendLine($"  if (!{context.GenerateValidateCall(hash)}) return false;");
+                sbTracked.AppendLine($"  const _allOfBranch{i} = {context.EvaluatedStateExpr}.clone();");
+            }
+            sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.restoreFrom(_allOfBase);");
+            for (var i = 0; i < branches.Length; i++)
+            {
+                sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.mergeFrom(_allOfBranch{i});");
+            }
+            sbTracked.AppendLine("}");
+            return sbTracked.ToString();
+        }
+        var sb = new StringBuilder();
+        foreach (var sub in allOf.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            sb.AppendLine($"if (!{context.GenerateValidateCall(hash)}) return false;");
+        }
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates TypeScript code for the "anyOf" keyword.
+/// </summary>
+public sealed class TsAnyOfCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "anyOf";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("anyOf", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("anyOf", out var anyOf) ||
+            anyOf.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        if (context.RequiresAnnotationTracking)
+        {
+            var branches = anyOf.EnumerateArray().ToArray();
+            var sbTracked = new StringBuilder();
+            sbTracked.AppendLine("{");
+            sbTracked.AppendLine($"  const _anyOfBase = {context.EvaluatedStateExpr}.clone();");
+            sbTracked.AppendLine("  const _anyOfMatches = [];");
+            foreach (var branch in branches)
+            {
+                var hash = context.GetSubschemaHash(branch);
+                sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.reset();");
+                sbTracked.AppendLine($"  if ({context.GenerateValidateCall(hash)}) _anyOfMatches.push({context.EvaluatedStateExpr}.clone());");
+            }
+            sbTracked.AppendLine("  if (_anyOfMatches.length === 0) return false;");
+            sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.restoreFrom(_anyOfBase);");
+            sbTracked.AppendLine($"  for (const _m of _anyOfMatches) {context.EvaluatedStateExpr}.mergeFrom(_m);");
+            sbTracked.AppendLine("}");
+            return sbTracked.ToString();
+        }
+        var checks = new List<string>();
+        foreach (var sub in anyOf.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            checks.Add(context.GenerateValidateCall(hash));
+        }
+        if (checks.Count == 0) return string.Empty;
+        return $"if (!({string.Join(" || ", checks)})) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates TypeScript code for the "oneOf" keyword.
+/// </summary>
+public sealed class TsOneOfCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "oneOf";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("oneOf", out var a) &&
+        a.ValueKind == JsonValueKind.Array;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("oneOf", out var oneOf) ||
+            oneOf.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+        if (context.RequiresAnnotationTracking)
+        {
+            var branches = oneOf.EnumerateArray().ToArray();
+            var sbTracked = new StringBuilder();
+            sbTracked.AppendLine("{");
+            sbTracked.AppendLine($"  const _oneOfBase = {context.EvaluatedStateExpr}.clone();");
+            sbTracked.AppendLine("  let _oneOfMatch = null;");
+            sbTracked.AppendLine("  let _matches = 0;");
+            foreach (var branch in branches)
+            {
+                var hash = context.GetSubschemaHash(branch);
+                sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.reset();");
+                sbTracked.AppendLine($"  if ({context.GenerateValidateCall(hash)}) {{");
+                sbTracked.AppendLine("    _matches++;");
+                sbTracked.AppendLine("    if (_matches > 1) return false;");
+                sbTracked.AppendLine($"    _oneOfMatch = {context.EvaluatedStateExpr}.clone();");
+                sbTracked.AppendLine("  }");
+            }
+            sbTracked.AppendLine("  if (_matches !== 1) return false;");
+            sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.restoreFrom(_oneOfBase);");
+            sbTracked.AppendLine($"  {context.EvaluatedStateExpr}.mergeFrom(_oneOfMatch);");
+            sbTracked.AppendLine("}");
+            return sbTracked.ToString();
+        }
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine("  let _matches = 0;");
+        foreach (var sub in oneOf.EnumerateArray())
+        {
+            var hash = context.GetSubschemaHash(sub);
+            sb.AppendLine($"  if ({context.GenerateValidateCall(hash)}) _matches++;");
+            sb.AppendLine("  if (_matches > 1) return false;");
+        }
+        sb.AppendLine("  if (_matches !== 1) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates TypeScript code for the "not" keyword.
+/// </summary>
+public sealed class TsNotCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "not";
+    public int Priority => 30;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("not", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("not", out var notElem))
+        {
+            return string.Empty;
+        }
+        var hash = context.GetSubschemaHash(notElem);
+        if (context.RequiresAnnotationTracking)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine($"  const _notSnapshot = {context.EvaluatedStateExpr}.clone();");
+            sb.AppendLine($"  {context.EvaluatedStateExpr}.reset();");
+            sb.AppendLine($"  const _notResult = {context.GenerateValidateCall(hash)};");
+            sb.AppendLine($"  {context.EvaluatedStateExpr}.restoreFrom(_notSnapshot);");
+            sb.AppendLine("  if (_notResult) return false;");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        return $"if ({context.GenerateValidateCall(hash)}) return false;";
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsNumericConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsNumericConstraintsCodeGenerator.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for numeric constraint keywords:
+/// minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf.
+/// Handles Draft 4's boolean exclusiveMinimum/exclusiveMaximum form by pairing
+/// with the sibling minimum/maximum value.
+/// multipleOf mirrors the C# compiled path's IEEE-754 quotient-snapping logic.
+/// </summary>
+public sealed class TsNumericConstraintsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "minimum/maximum/exclusiveMinimum/exclusiveMaximum/multipleOf";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minimum", out _) ||
+               schema.TryGetProperty("maximum", out _) ||
+               schema.TryGetProperty("exclusiveMinimum", out _) ||
+               schema.TryGetProperty("exclusiveMaximum", out _) ||
+               schema.TryGetProperty("multipleOf", out _);
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minimum", out var minElem);
+        var hasMax = schema.TryGetProperty("maximum", out var maxElem);
+        var hasExMin = schema.TryGetProperty("exclusiveMinimum", out var exMinElem);
+        var hasExMax = schema.TryGetProperty("exclusiveMaximum", out var exMaxElem);
+        var hasMul = schema.TryGetProperty("multipleOf", out var mulElem);
+
+        if (!hasMin && !hasMax && !hasExMin && !hasExMax && !hasMul) return string.Empty;
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        // Number.isFinite guard: NaN/Infinity would bypass every comparison below
+        // (NaN comparisons always return false) and silently accept invalid values.
+        // JSON can't express them, but direct API callers can, so reject defensively.
+        sb.AppendLine($"if (typeof {v} === \"number\" && Number.isFinite({v})) {{");
+
+        if (hasMin && minElem.TryGetDouble(out var min))
+        {
+            sb.AppendLine($"  if ({v} < {Fmt(min)}) return false;");
+        }
+        if (hasMax && maxElem.TryGetDouble(out var max))
+        {
+            sb.AppendLine($"  if ({v} > {Fmt(max)}) return false;");
+        }
+
+        if (hasExMin)
+        {
+            if (exMinElem.ValueKind == JsonValueKind.Number && exMinElem.TryGetDouble(out var exMin))
+            {
+                sb.AppendLine($"  if ({v} <= {Fmt(exMin)}) return false;");
+            }
+            else if (exMinElem.ValueKind == JsonValueKind.True && hasMin && minElem.TryGetDouble(out var minVal))
+            {
+                // Draft 4: exclusiveMinimum: true alongside minimum.
+                sb.AppendLine($"  if ({v} <= {Fmt(minVal)}) return false;");
+            }
+        }
+
+        if (hasExMax)
+        {
+            if (exMaxElem.ValueKind == JsonValueKind.Number && exMaxElem.TryGetDouble(out var exMax))
+            {
+                sb.AppendLine($"  if ({v} >= {Fmt(exMax)}) return false;");
+            }
+            else if (exMaxElem.ValueKind == JsonValueKind.True && hasMax && maxElem.TryGetDouble(out var maxVal))
+            {
+                sb.AppendLine($"  if ({v} >= {Fmt(maxVal)}) return false;");
+            }
+        }
+
+        if (hasMul && mulElem.TryGetDouble(out var mul) && mul != 0)
+        {
+            // Tolerance: C# compiled path uses double.Epsilon (~4.9e-324 — the
+            // smallest positive denormal). The JS equivalent is Number.MIN_VALUE,
+            // not Number.EPSILON (~2.22e-16). Using EPSILON would be much more
+            // lenient and diverge from C# verdicts on near-multiple edge cases.
+            var divisor = Fmt(mul);
+            sb.AppendLine($"  {{");
+            sb.AppendLine($"    if (Math.abs({v} % {divisor}) >= Number.MIN_VALUE) {{");
+            sb.AppendLine($"      let _q = {v} / {divisor};");
+            sb.AppendLine($"      if (!(!isFinite(_q) && Math.abs({v} % 1) < Number.MIN_VALUE && Math.abs(1 % {divisor}) < Number.MIN_VALUE)) {{");
+            sb.AppendLine($"        _q = Math.round((_q + 0.000001) * 100) / 100;");
+            sb.AppendLine($"        if (!(Math.abs(_q - Math.round(_q)) < Number.MIN_VALUE)) return false;");
+            sb.AppendLine($"      }}");
+            sb.AppendLine($"    }}");
+            sb.AppendLine($"  }}");
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+
+    private static string Fmt(double d) => d.ToString("G17", CultureInfo.InvariantCulture);
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsObjectConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsObjectConstraintsCodeGenerator.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for object constraint keywords: minProperties, maxProperties.
+/// </summary>
+public sealed class TsObjectConstraintsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "minProperties/maxProperties";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minProperties", out _) ||
+               schema.TryGetProperty("maxProperties", out _);
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minProperties", out var minElem) &&
+                     TryGetIntegerValue(minElem, out var min);
+        var hasMax = schema.TryGetProperty("maxProperties", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out var max);
+        if (!hasMin && !hasMax) return string.Empty;
+
+        TryGetIntegerValue(minElem, out min);
+        TryGetIntegerValue(maxElem, out max);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.AppendLine($"  const _keys = Object.keys({v});");
+        if (hasMin) sb.AppendLine($"  if (_keys.length < {min}) return false;");
+        if (hasMax) sb.AppendLine($"  if (_keys.length > {max}) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        TsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsPatternCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsPatternCodeGenerator.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "pattern" keyword.
+/// Uses the runtime's cached-regex helper so schema patterns are compiled once
+/// and then reused across validations. Constructor form remains hidden behind
+/// the helper so schema-supplied text never participates in JS tokenisation.
+/// Regex timeouts don't exist in JS; pathological patterns are a known limitation
+/// inherited from the spec (documented in KNOWN_LIMITATIONS.md).
+/// </summary>
+public sealed class TsPatternCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "pattern";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("pattern", out var p) &&
+               p.ValueKind == JsonValueKind.String;
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        if (!context.CurrentSchema.TryGetProperty("pattern", out var patternElement))
+        {
+            return string.Empty;
+        }
+
+        var pattern = patternElement.GetString();
+        if (string.IsNullOrEmpty(pattern))
+        {
+            // Dynamic validator rejects empty "pattern" as an invalid schema; surface
+            // the same intent here rather than silently emitting no regex check.
+            throw new InvalidOperationException(
+                "Schema has an empty \"pattern\" string, which is invalid — pattern must be " +
+                "a non-empty ECMA-262 regular expression.");
+        }
+
+        var v = context.ElementExpr;
+        var patternLiteral = TsLiteral.String(pattern);
+        return $$"""
+            if (typeof {{v}} === "string") {
+              const _patternRe = getCachedRegex({{patternLiteral}});
+              if (!_patternRe.test({{v}})) return false;
+            }
+            """;
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            yield break;
+        }
+
+        if (context.CurrentSchema.TryGetProperty("pattern", out var patternElement) &&
+            patternElement.ValueKind == JsonValueKind.String &&
+            !string.IsNullOrEmpty(patternElement.GetString()))
+        {
+            yield return "getCachedRegex";
+        }
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsPropertiesCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsPropertiesCodeGenerator.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "properties" keyword.
+/// </summary>
+public sealed class TsPropertiesCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "properties";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("properties", out var props) &&
+               props.ValueKind == JsonValueKind.Object;
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("properties", out var properties) ||
+            properties.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+
+        foreach (var prop in properties.EnumerateObject())
+        {
+            var nameLiteral = TsLiteral.String(prop.Name);
+            var call = context.GenerateValidateCallForProperty(prop.Value, $"{v}[{nameLiteral}]", nameLiteral);
+            sb.AppendLine($"  if (Object.prototype.hasOwnProperty.call({v}, {nameLiteral})) {{");
+            sb.AppendLine($"    if (!{call}) return false;");
+            if (context.RequiresPropertyAnnotations)
+            {
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.markPropertyEvaluated({context.LocationExpr}, {nameLiteral});");
+            }
+            sb.AppendLine("  }");
+        }
+
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsPropertyApplicatorsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsPropertyApplicatorsCodeGenerator.cs
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using System.Linq;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "patternProperties" keyword.
+/// </summary>
+public sealed class TsPatternPropertiesCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "patternProperties";
+    public int Priority => 45;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("patternProperties", out var p) &&
+        p.ValueKind == JsonValueKind.Object;
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("patternProperties", out var patternsElem) ||
+            patternsElem.ValueKind != JsonValueKind.Object)
+        {
+            return string.Empty;
+        }
+
+        // Empty patternProperties {}: no pattern checks to emit.
+        var patternEnumerator = patternsElem.EnumerateObject();
+        if (!patternEnumerator.MoveNext())
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        // Hoist each pattern's RegExp outside the key loop. Without this we'd
+        // allocate a new RegExp per property name on every validate call;
+        // hoisting gives one RegExp per validate invocation instead.
+        var hoists = new StringBuilder();
+        var checks = new StringBuilder();
+        var idx = 0;
+        do
+        {
+            var pattern = patternEnumerator.Current;
+            var regexVar = $"_ppRe{idx}";
+            var hash = context.GetSubschemaHash(pattern.Value);
+            hoists.AppendLine($"  const {regexVar} = getCachedRegex({TsLiteral.String(pattern.Name)});");
+            checks.AppendLine($"    if ({regexVar}.test(_k)) {{");
+            checks.AppendLine($"      if (!{context.GenerateValidateCallForProperty(hash, $"{v}[_k]", "_k")}) return false;");
+            if (context.RequiresPropertyAnnotations)
+            {
+                checks.AppendLine($"      {context.EvaluatedStateExpr}.markPropertyEvaluated({context.LocationExpr}, _k);");
+            }
+            checks.AppendLine("    }");
+            idx++;
+        }
+        while (patternEnumerator.MoveNext());
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.Append(hoists);
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        sb.Append(checks);
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (context.CurrentSchema.TryGetProperty("patternProperties", out var patternsElem) &&
+            patternsElem.ValueKind == JsonValueKind.Object &&
+            patternsElem.EnumerateObject().Any())
+        {
+            yield return "getCachedRegex";
+        }
+    }
+}
+
+/// <summary>
+/// Generates TypeScript code for the "additionalProperties" keyword.
+/// Handles the three forms: false (reject unlisted), schema (validate unlisted), true (no-op).
+/// </summary>
+public sealed class TsAdditionalPropertiesCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "additionalProperties";
+    public int Priority => 20;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("additionalProperties", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("additionalProperties", out var addProps))
+        {
+            return string.Empty;
+        }
+        if (addProps.ValueKind == JsonValueKind.True)
+        {
+            if (!context.RequiresPropertyAnnotations)
+            {
+                return string.Empty;
+            }
+        }
+
+        var definedNames = CollectDefinedNames(context.CurrentSchema);
+        var patternRegexes = CollectPatternPatterns(context.CurrentSchema);
+
+        var v = context.ElementExpr;
+        // Hoist pattern regexes outside the key loop (same reason as
+        // patternProperties — avoid one RegExp allocation per property).
+        var hoists = new StringBuilder();
+        var regexVars = new List<string>();
+        for (var i = 0; i < patternRegexes.Count; i++)
+        {
+            var rv = $"_apRe{i}";
+            hoists.AppendLine($"  const {rv} = getCachedRegex({TsLiteral.String(patternRegexes[i])});");
+            regexVars.Add(rv);
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.Append(hoists);
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        if (definedNames.Count > 0)
+        {
+            var conds = definedNames.Select(n => $"_k === {TsLiteral.String(n)}");
+            sb.AppendLine($"    if ({string.Join(" || ", conds)}) continue;");
+        }
+        if (regexVars.Count > 0)
+        {
+            var conds = regexVars.Select(r => $"{r}.test(_k)");
+            sb.AppendLine($"    if ({string.Join(" || ", conds)}) continue;");
+        }
+        if (addProps.ValueKind == JsonValueKind.False)
+        {
+            sb.AppendLine("    return false;");
+        }
+        else if (addProps.ValueKind == JsonValueKind.True)
+        {
+            sb.AppendLine($"    {context.EvaluatedStateExpr}.markPropertyEvaluated({context.LocationExpr}, _k);");
+        }
+        else if (addProps.ValueKind == JsonValueKind.Object)
+        {
+            var hash = context.GetSubschemaHash(addProps);
+            sb.AppendLine($"    if (!{context.GenerateValidateCallForProperty(hash, $"{v}[_k]", "_k")}) return false;");
+            if (context.RequiresPropertyAnnotations)
+            {
+                sb.AppendLine($"    {context.EvaluatedStateExpr}.markPropertyEvaluated({context.LocationExpr}, _k);");
+            }
+        }
+        else
+        {
+            // Invalid schema: additionalProperties must be object/boolean per
+            // spec. SubschemaExtractor doesn't collect non-schema values, so
+            // emitting a validate_<hash> call would reference an undefined
+            // function at runtime. Fail fast with an actionable message,
+            // matching how the gate treats other invalid-schema shapes.
+            throw new InvalidOperationException(
+                "Schema's \"additionalProperties\" value must be an object or boolean; got " +
+                $"{addProps.ValueKind}.");
+        }
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (CollectPatternPatterns(context.CurrentSchema).Count > 0)
+        {
+            yield return "getCachedRegex";
+        }
+    }
+
+    private static List<string> CollectDefinedNames(JsonElement schema)
+    {
+        var names = new List<string>();
+        if (schema.TryGetProperty("properties", out var props) &&
+            props.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var p in props.EnumerateObject())
+            {
+                names.Add(p.Name);
+            }
+        }
+        return names;
+    }
+
+    private static List<string> CollectPatternPatterns(JsonElement schema)
+    {
+        var patternNames = new List<string>();
+        if (schema.TryGetProperty("patternProperties", out var patternsElement) &&
+            patternsElement.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var p in patternsElement.EnumerateObject())
+            {
+                patternNames.Add(p.Name);
+            }
+        }
+        return patternNames;
+    }
+}
+
+/// <summary>
+/// Generates TypeScript code for the "propertyNames" keyword (Draft 6+).
+/// </summary>
+public sealed class TsPropertyNamesCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "propertyNames";
+    public int Priority => 60;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("propertyNames", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        // propertyNames was introduced in Draft 6; Draft 4 must ignore it.
+        if (context.DetectedDraft < SchemaDraft.Draft6) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("propertyNames", out var pn))
+        {
+            return string.Empty;
+        }
+        if (pn.ValueKind != JsonValueKind.Object &&
+            pn.ValueKind != JsonValueKind.True &&
+            pn.ValueKind != JsonValueKind.False)
+        {
+            // Invalid schema: propertyNames must be a schema (object or boolean).
+            // Non-schema values aren't extracted by SubschemaExtractor, so the
+            // emitted validate_<hash> call would be undefined at runtime.
+            throw new InvalidOperationException(
+                "Schema's \"propertyNames\" value must be an object or boolean; got " +
+                $"{pn.ValueKind}.");
+        }
+        var hash = context.GetSubschemaHash(pn);
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+        sb.AppendLine($"    if (!{context.GenerateValidateCallForExpr(hash, "_k")}) return false;");
+        sb.AppendLine("  }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsRefCodeGenerator.cs
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for "$ref" references. Local references are
+/// resolved at generation time; external references are resolved from an
+/// optional runtime registry passed to validate(data, registry).
+/// </summary>
+public sealed class TsRefCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "$ref";
+    public int Priority => 200;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        if (!schema.TryGetProperty("$ref", out var r)) return false;
+        return r.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(r.GetString());
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.CurrentSchema.TryGetProperty("$ref", out var refElem)) return string.Empty;
+        var refValue = refElem.GetString();
+        if (string.IsNullOrEmpty(refValue)) return string.Empty;
+
+        if (!refValue.StartsWith('#'))
+        {
+            return GenerateExternalRefCode(context, refValue);
+        }
+
+        return GenerateLocalRefCode(context, refValue);
+    }
+
+    private static string GenerateLocalRefCode(TsCodeGenerationContext context, string refValue)
+    {
+        var target = context.ResourceRoot.HasValue
+            ? context.ResolveLocalRefInResource(refValue, context.ResourceRoot.Value)
+            : context.ResolveLocalRef(refValue);
+        if (!target.HasValue)
+        {
+            // An unresolved local ref at this point means the shared extractor
+            // or the gate missed something — fail codegen loudly rather than
+            // silently emitting "return false" that makes every instance fail.
+            // The message deliberately omits refValue so a ref containing
+            // newlines or other source-injection bait can't leak into output.
+            throw new InvalidOperationException(
+                "Could not resolve local $ref during TypeScript code generation.");
+        }
+        var hash = context.GetSubschemaHash(target.Value);
+        return GenerateScopeAwareCall(context, refValue, hash);
+    }
+
+    private static string GenerateExternalRefCode(TsCodeGenerationContext context, string refValue)
+    {
+        if (!TryResolveUri(context, refValue, out var targetUri))
+        {
+            throw new InvalidOperationException("Could not resolve external $ref URI during TypeScript code generation.");
+        }
+
+        if (context.RootBaseUri != null && targetUri.Fragment.Length > 0)
+        {
+            var refBase = new Uri(targetUri.GetLeftPart(UriPartial.Query));
+            var rootBase = new Uri(context.RootBaseUri.GetLeftPart(UriPartial.Query));
+            if (refBase.Equals(rootBase))
+            {
+                return GenerateLocalRefCode(context, targetUri.Fragment);
+            }
+        }
+
+        var targetUriWithoutFragment = new Uri(targetUri.GetLeftPart(UriPartial.Query));
+        var internalSchema = context.ResolveInternalId(targetUriWithoutFragment.AbsoluteUri);
+        if (internalSchema.HasValue)
+        {
+            JsonElement? targetSchema = internalSchema.Value;
+            var fragment = targetUri.Fragment;
+            if (!string.IsNullOrEmpty(fragment) && fragment != "#")
+            {
+                targetSchema = context.ResolveLocalRefInResource(fragment, internalSchema.Value);
+            }
+
+            if (!targetSchema.HasValue)
+            {
+                throw new InvalidOperationException("Could not resolve internal $id $ref during TypeScript code generation.");
+            }
+
+            var targetHash = context.GetSubschemaHash(targetSchema.Value);
+            return GenerateScopeAwareCall(context, refValue, targetHash);
+        }
+
+        if (targetUri.Fragment == "#")
+        {
+            targetUri = new Uri(targetUri.GetLeftPart(UriPartial.Query));
+        }
+
+        var uriLiteral = TsLiteral.String(targetUri.AbsoluteUri);
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine($"  const _refValidator = {context.RegistryExpr}?.tryGetValidator?.({uriLiteral}) ?? null;");
+        sb.AppendLine("  if (_refValidator === null) return false;");
+        EmitExternalDispatch(sb, context, "  ");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Emits a runtime dispatch over a resolved external _refValidator that
+    /// picks the best stable method on the target validator based on the
+    /// CALLER's feature needs. Method names on targets have fixed signatures:
+    ///   validateWithScopeAndState(data, scope, evaluatedState, location [, registry])
+    ///   validateWithState        (data, evaluatedState, location [, registry])
+    ///   validateWithScope        (data, scope, location [, registry])
+    ///   validate                 (data [, registry])
+    /// The caller falls through to the simpler method when the target doesn't
+    /// expose the richer form. Choices that drop scope or state leave the
+    /// caller's _scope / _eval unchanged for that branch — which is
+    /// spec-acceptable because the downgraded target can't produce the info
+    /// we'd otherwise merge.
+    /// </summary>
+    internal static void EmitExternalDispatch(System.Text.StringBuilder sb, TsCodeGenerationContext context, string indent)
+    {
+        var v = context.ElementExpr;
+        var scope = context.ScopeExpr;
+        var state = context.EvaluatedStateExpr;
+        var loc = context.LocationExpr;
+        var reg = context.RegistryExpr;
+
+        if (context.RequiresScopeTracking && context.RequiresAnnotationTracking)
+        {
+            sb.AppendLine($"{indent}const _refScopeAndState = typeof _refValidator === \"function\" ? null : _refValidator.validateWithScopeAndState;");
+            sb.AppendLine($"{indent}const _refState = typeof _refValidator === \"function\" ? null : _refValidator.validateWithState;");
+            sb.AppendLine($"{indent}const _refScope = typeof _refValidator === \"function\" ? null : _refValidator.validateWithScope;");
+            sb.AppendLine($"{indent}if (typeof _refScopeAndState === \"function\") {{");
+            sb.AppendLine($"{indent}  if (!_refScopeAndState({v}, {scope}, {state}, {loc}, {reg})) return false;");
+            sb.AppendLine($"{indent}}} else if (typeof _refState === \"function\") {{");
+            sb.AppendLine($"{indent}  if (!_refState({v}, {state}, {loc}, {reg})) return false;");
+            sb.AppendLine($"{indent}}} else if (typeof _refScope === \"function\") {{");
+            sb.AppendLine($"{indent}  if (!_refScope({v}, {scope}, {loc}, {reg})) return false;");
+            sb.AppendLine($"{indent}}} else {{");
+            sb.AppendLine($"{indent}  const _refValidate = typeof _refValidator === \"function\" ? _refValidator : _refValidator.validate;");
+            sb.AppendLine($"{indent}  if (typeof _refValidate !== \"function\") return false;");
+            sb.AppendLine($"{indent}  if (!_refValidate({v}, {reg})) return false;");
+            sb.AppendLine($"{indent}}}");
+        }
+        else if (context.RequiresAnnotationTracking)
+        {
+            sb.AppendLine($"{indent}const _refState = typeof _refValidator === \"function\" ? null : _refValidator.validateWithState;");
+            sb.AppendLine($"{indent}if (typeof _refState === \"function\") {{");
+            sb.AppendLine($"{indent}  if (!_refState({v}, {state}, {loc}, {reg})) return false;");
+            sb.AppendLine($"{indent}}} else {{");
+            sb.AppendLine($"{indent}  const _refValidate = typeof _refValidator === \"function\" ? _refValidator : _refValidator.validate;");
+            sb.AppendLine($"{indent}  if (typeof _refValidate !== \"function\") return false;");
+            sb.AppendLine($"{indent}  if (!_refValidate({v}, {reg})) return false;");
+            sb.AppendLine($"{indent}}}");
+        }
+        else if (context.RequiresScopeTracking)
+        {
+            sb.AppendLine($"{indent}const _refScope = typeof _refValidator === \"function\" ? null : _refValidator.validateWithScope;");
+            sb.AppendLine($"{indent}if (typeof _refScope === \"function\") {{");
+            sb.AppendLine($"{indent}  if (!_refScope({v}, {scope}, {loc}, {reg})) return false;");
+            sb.AppendLine($"{indent}}} else {{");
+            sb.AppendLine($"{indent}  const _refValidate = typeof _refValidator === \"function\" ? _refValidator : _refValidator.validate;");
+            sb.AppendLine($"{indent}  if (typeof _refValidate !== \"function\") return false;");
+            sb.AppendLine($"{indent}  if (!_refValidate({v}, {reg})) return false;");
+            sb.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            sb.AppendLine($"{indent}const _refValidate = typeof _refValidator === \"function\" ? _refValidator : _refValidator.validate;");
+            sb.AppendLine($"{indent}if (typeof _refValidate !== \"function\") return false;");
+            sb.AppendLine($"{indent}if (!_refValidate({v}, {reg})) return false;");
+        }
+    }
+
+    private static bool TryResolveUri(TsCodeGenerationContext context, string refValue, out Uri targetUri)
+    {
+        if (Uri.TryCreate(refValue, UriKind.Absolute, out var absoluteUri))
+        {
+            targetUri = absoluteUri;
+            return true;
+        }
+
+        if (context.BaseUri != null && Uri.TryCreate(context.BaseUri, refValue, out var resolvedUri))
+        {
+            targetUri = resolvedUri;
+            return true;
+        }
+
+        try
+        {
+            targetUri = new Uri(refValue, UriKind.RelativeOrAbsolute);
+            return targetUri.IsAbsoluteUri;
+        }
+        catch
+        {
+            targetUri = null!;
+            return false;
+        }
+    }
+
+    private static string GenerateScopeAwareCall(TsCodeGenerationContext context, string refValue, string targetHash)
+    {
+        if (!context.RequiresScopeTracking)
+        {
+            return $"if (!{context.GenerateValidateCall(targetHash)}) return false;";
+        }
+
+        var targetInfo = context.GetSubschemaInfo(targetHash);
+        if (targetInfo == null ||
+            targetInfo.IsResourceRoot ||
+            targetInfo.ResourceRootHash == context.CurrentResourceRootHash)
+        {
+            return $"if (!{context.GenerateValidateCall(targetHash)}) return false;";
+        }
+
+        var resourceRootInfo = context.GetSubschemaInfo(targetInfo.ResourceRootHash);
+        if (resourceRootInfo == null || resourceRootInfo.ResourceAnchors.Count == 0)
+        {
+            return $"if (!{context.GenerateValidateCall(targetHash)}) return false;";
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine("  const _targetScope = _scope.push({");
+        sb.AppendLine("    dynamicAnchors: {");
+        foreach (var (anchorName, schemaHash) in resourceRootInfo.ResourceAnchors)
+        {
+            var delegateExpr = context.RequiresAnnotationTracking
+                ? context.RequiresRegistry
+                    ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
+                    : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
+                : context.RequiresRegistry
+                    ? $"(data, scope, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
+                    : $"(data, scope, location = \"\") => validate_{schemaHash}(data, scope, location)";
+            sb.AppendLine($"      {TsLiteral.String(anchorName)}: {delegateExpr},");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine("  });");
+        var args = new List<string> { context.ElementExpr, "_targetScope" };
+        if (context.RequiresAnnotationTracking)
+        {
+            args.Add(context.EvaluatedStateExpr);
+        }
+        args.Add(context.LocationExpr);
+        if (context.RequiresRegistry)
+        {
+            args.Add(context.RegistryExpr);
+        }
+        sb.AppendLine($"  if (!validate_{targetHash}({string.Join(", ", args)})) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsRequiredCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsRequiredCodeGenerator.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "required" keyword.
+/// </summary>
+public sealed class TsRequiredCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "required";
+    public int Priority => 95;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("required", out var req) &&
+               req.ValueKind == JsonValueKind.Array;
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        if (!context.CurrentSchema.TryGetProperty("required", out var required) ||
+            required.ValueKind != JsonValueKind.Array)
+        {
+            return string.Empty;
+        }
+
+        var names = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                names.Add(item.GetString()!);
+            }
+        }
+
+        if (names.Count == 0) return string.Empty;
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+        foreach (var name in names)
+        {
+            var literal = TsLiteral.String(name);
+            sb.AppendLine($"  if (!Object.prototype.hasOwnProperty.call({v}, {literal})) return false;");
+        }
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsSchemaNumeric.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsSchemaNumeric.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Shared numeric parsing helpers for JS keyword emitters.
+/// Centralises range/integer checks so every bounded-length keyword handles
+/// out-of-range schema values the same way.
+/// </summary>
+internal static class TsSchemaNumeric
+{
+    /// <summary>
+    /// Parses a JSON number as a non-negative integer count suitable for a
+    /// length/bound keyword (minLength, maxItems, minContains, etc.). Returns
+    /// false when the value isn't a number, is negative, is fractional, is
+    /// non-finite, or exceeds long.MaxValue — an explicit range check before
+    /// the double→long cast, since unchecked conversion outside range is
+    /// unspecified in C# and can emit bogus constraints into the JS output.
+    /// </summary>
+    public static bool TryGetNonNegativeIntegerValue(JsonElement element, out long value)
+    {
+        value = 0;
+        if (element.ValueKind != JsonValueKind.Number) return false;
+        if (!element.TryGetDouble(out var d)) return false;
+        if (!double.IsFinite(d)) return false;
+        if (d < 0) return false;
+        if (Math.Abs(d - Math.Floor(d)) > double.Epsilon) return false;
+        if (d > long.MaxValue) return false;
+        value = (long)d;
+        return true;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsStringConstraintsCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsStringConstraintsCodeGenerator.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for string constraint keywords: minLength, maxLength.
+/// Grapheme counting is delegated to the runtime's graphemeLength helper to match
+/// C# StringInfo.LengthInTextElements semantics.
+/// </summary>
+public sealed class TsStringConstraintsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "minLength/maxLength";
+    public int Priority => 50;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object) return false;
+        return schema.TryGetProperty("minLength", out _) ||
+               schema.TryGetProperty("maxLength", out _);
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minLength", out var minElem) &&
+                     TryGetIntegerValue(minElem, out var min);
+        var hasMax = schema.TryGetProperty("maxLength", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out var max);
+        if (!hasMin && !hasMax) return string.Empty;
+
+        TryGetIntegerValue(minElem, out min);
+        TryGetIntegerValue(maxElem, out max);
+
+        var v = context.ElementExpr;
+        var sb = new StringBuilder();
+        sb.AppendLine($"if (typeof {v} === \"string\") {{");
+        sb.AppendLine($"  const _len = graphemeLength({v});");
+        if (hasMin) sb.AppendLine($"  if (_len < {min}) return false;");
+        if (hasMax) sb.AppendLine($"  if (_len > {max}) return false;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            yield break;
+        }
+
+        // Only yield the import when GenerateCode will actually emit a
+        // graphemeLength call — skip for non-integer minLength/maxLength values
+        // that GenerateCode ignores, so unused imports don't creep into the
+        // emitted module.
+        var schema = context.CurrentSchema;
+        var hasMin = schema.TryGetProperty("minLength", out var minElem) &&
+                     TryGetIntegerValue(minElem, out _);
+        var hasMax = schema.TryGetProperty("maxLength", out var maxElem) &&
+                     TryGetIntegerValue(maxElem, out _);
+        if (hasMin || hasMax)
+        {
+            yield return "graphemeLength";
+        }
+    }
+
+    private static bool TryGetIntegerValue(JsonElement element, out long value) =>
+        TsSchemaNumeric.TryGetNonNegativeIntegerValue(element, out value);
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsTypeCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsTypeCodeGenerator.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "type" keyword.
+/// </summary>
+public sealed class TsTypeCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "type";
+    public int Priority => 100;
+
+    public bool CanGenerate(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("type", out _);
+    }
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            return string.Empty;
+        }
+
+        if (!context.CurrentSchema.TryGetProperty("type", out var typeElement))
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+
+        if (typeElement.ValueKind == JsonValueKind.String)
+        {
+            return RejectUnlessType(typeElement.GetString()!, v);
+        }
+
+        if (typeElement.ValueKind == JsonValueKind.Array)
+        {
+            return GenerateMultiTypeCheck(typeElement, v);
+        }
+
+        return string.Empty;
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        if (!context.ValidationVocabularyEnabled)
+        {
+            yield break;
+        }
+
+        if (!context.CurrentSchema.TryGetProperty("type", out var typeElement))
+        {
+            yield break;
+        }
+
+        if (ReferencesIntegerType(typeElement))
+        {
+            yield return "isInteger";
+        }
+    }
+
+    private static bool ReferencesIntegerType(JsonElement typeElement)
+    {
+        if (typeElement.ValueKind == JsonValueKind.String)
+        {
+            return typeElement.GetString() == "integer";
+        }
+        if (typeElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in typeElement.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String && item.GetString() == "integer")
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static string RejectUnlessType(string type, string v)
+    {
+        // "number" rejects NaN/Infinity to match JSON numeric semantics —
+        // JSON.parse can't produce them, but direct API callers can.
+        return type switch
+        {
+            "string" => $"if (typeof {v} !== \"string\") return false;",
+            "number" => $"if (typeof {v} !== \"number\" || !Number.isFinite({v})) return false;",
+            "integer" => $"if (!isInteger({v})) return false;",
+            "boolean" => $"if (typeof {v} !== \"boolean\") return false;",
+            "null" => $"if ({v} !== null) return false;",
+            "array" => $"if (!Array.isArray({v})) return false;",
+            "object" => $"if (typeof {v} !== \"object\" || {v} === null || Array.isArray({v})) return false;",
+            _ => string.Empty,
+        };
+    }
+
+    private static string GenerateMultiTypeCheck(JsonElement typeArray, string v)
+    {
+        var conditions = new List<string>();
+        foreach (var item in typeArray.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String) continue;
+            var cond = item.GetString() switch
+            {
+                "string" => $"typeof {v} === \"string\"",
+                "number" => $"(typeof {v} === \"number\" && Number.isFinite({v}))",
+                "integer" => $"isInteger({v})",
+                "boolean" => $"typeof {v} === \"boolean\"",
+                "null" => $"{v} === null",
+                "array" => $"Array.isArray({v})",
+                "object" => $"(typeof {v} === \"object\" && {v} !== null && !Array.isArray({v}))",
+                _ => null,
+            };
+            if (cond != null) conditions.Add(cond);
+        }
+
+        if (conditions.Count == 0) return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.Append("if (!(");
+        sb.Append(string.Join(" || ", conditions));
+        sb.AppendLine(")) return false;");
+        return sb.ToString();
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsUnevaluatedCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/Keywords/TsUnevaluatedCodeGenerator.cs
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+
+/// <summary>
+/// Generates TypeScript code for the "unevaluatedProperties" keyword.
+/// </summary>
+public sealed class TsUnevaluatedPropertiesCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "unevaluatedProperties";
+    public int Priority => -100;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("unevaluatedProperties", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft201909) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("unevaluatedProperties", out var unevaluated))
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var eval = context.EvaluatedStateExpr;
+        var loc = context.LocationExpr;
+        var sb = new StringBuilder();
+
+        if (unevaluated.ValueKind == JsonValueKind.False)
+        {
+            sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+            sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+            sb.AppendLine($"    if (!{eval}.isPropertyEvaluated({loc}, _k)) return false;");
+            sb.AppendLine("  }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        if (unevaluated.ValueKind == JsonValueKind.True)
+        {
+            sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+            sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+            sb.AppendLine($"    {eval}.markPropertyEvaluated({loc}, _k);");
+            sb.AppendLine("  }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        if (unevaluated.ValueKind == JsonValueKind.Object)
+        {
+            var hash = context.GetSubschemaHash(unevaluated);
+            sb.AppendLine($"if (typeof {v} === \"object\" && {v} !== null && !Array.isArray({v})) {{");
+            sb.AppendLine($"  for (const _k of Object.keys({v})) {{");
+            sb.AppendLine($"    if (!{eval}.isPropertyEvaluated({loc}, _k)) {{");
+            sb.AppendLine($"      if (!{context.GenerateValidateCallForProperty(hash, $"{v}[_k]", "_k")}) return false;");
+            sb.AppendLine($"      {eval}.markPropertyEvaluated({loc}, _k);");
+            sb.AppendLine("    }");
+            sb.AppendLine("  }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        throw new InvalidOperationException(
+            "Schema's \"unevaluatedProperties\" value must be an object or boolean; got " +
+            $"{unevaluated.ValueKind}.");
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}
+
+/// <summary>
+/// Generates TypeScript code for the "unevaluatedItems" keyword.
+/// </summary>
+public sealed class TsUnevaluatedItemsCodeGenerator : ITsKeywordCodeGenerator
+{
+    public string Keyword => "unevaluatedItems";
+    public int Priority => -100;
+
+    public bool CanGenerate(JsonElement schema) =>
+        schema.ValueKind == JsonValueKind.Object &&
+        schema.TryGetProperty("unevaluatedItems", out _);
+
+    public string GenerateCode(TsCodeGenerationContext context)
+    {
+        if (context.DetectedDraft < SchemaDraft.Draft201909) return string.Empty;
+        if (!context.CurrentSchema.TryGetProperty("unevaluatedItems", out var unevaluated))
+        {
+            return string.Empty;
+        }
+
+        var v = context.ElementExpr;
+        var eval = context.EvaluatedStateExpr;
+        var loc = context.LocationExpr;
+        var sb = new StringBuilder();
+
+        if (unevaluated.ValueKind == JsonValueKind.False)
+        {
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+            sb.AppendLine($"    if (!{eval}.isItemEvaluated({loc}, _i)) return false;");
+            sb.AppendLine("  }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        if (unevaluated.ValueKind == JsonValueKind.True)
+        {
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            sb.AppendLine($"  {eval}.setEvaluatedItemsUpTo({loc}, {v}.length);");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        if (unevaluated.ValueKind == JsonValueKind.Object)
+        {
+            var hash = context.GetSubschemaHash(unevaluated);
+            sb.AppendLine($"if (Array.isArray({v})) {{");
+            sb.AppendLine($"  for (let _i = 0; _i < {v}.length; _i++) {{");
+            sb.AppendLine($"    if (!{eval}.isItemEvaluated({loc}, _i)) {{");
+            sb.AppendLine($"      if (!{context.GenerateValidateCallForItem(hash, $"{v}[_i]", "_i")}) return false;");
+            sb.AppendLine($"      {eval}.markItemEvaluated({loc}, _i);");
+            sb.AppendLine("    }");
+            sb.AppendLine("  }");
+            sb.AppendLine($"  {eval}.setEvaluatedItemsUpTo({loc}, {v}.length);");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        throw new InvalidOperationException(
+            "Schema's \"unevaluatedItems\" value must be an object or boolean; got " +
+            $"{unevaluated.ValueKind}.");
+    }
+
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsCapabilityGate.cs
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+
+/// <summary>
+/// Gates the TS target to features actually supported by the MVP emitter.
+/// Walking is draft-aware: deferred-feature rejection and applicator recursion
+/// only apply when the keyword actually exists in the detected draft, so a
+/// Draft 4 schema using a post-Draft-4 name (e.g. unevaluatedProperties,
+/// $dynamicRef, propertyNames) is correctly accepted as an unknown-keyword
+/// annotation per spec, not rejected.
+/// </summary>
+public static class TsCapabilityGate
+{
+    /// <summary>
+    /// Stable prefix every gate-rejection message starts with. Callers (tests,
+    /// tooling) can pattern-match this constant to classify a codegen failure as
+    /// "gate rejection" without parsing free-form wording.
+    /// </summary>
+    public const string RejectionPrefix = "TS target MVP";
+
+    private static readonly HashSet<SchemaDraft> SupportedDrafts = new()
+    {
+        SchemaDraft.Draft4,
+        SchemaDraft.Draft201909,
+        SchemaDraft.Draft202012,
+    };
+
+    /// <summary>
+    /// Per-draft deferred-keyword set: reject only when the keyword exists in
+    /// the target draft. Empty for Draft 4 because none of these keywords were
+    /// part of that draft.
+    /// </summary>
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> DeferredPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal),
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "$recursiveRef",
+            "$recursiveAnchor",
+            // $dynamicRef / $dynamicAnchor are core keywords in Draft 2019-09
+            // but JsDynamicRefCodeGenerator only emits scope-aware dispatch
+            // under Draft 2020-12; reject pre-emission to avoid silently
+            // ignoring them. Remove when 2019-09 scope tracking lands.
+            "$dynamicRef",
+            "$dynamicAnchor",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "$recursiveRef",
+            "$recursiveAnchor",
+        },
+    };
+
+    /// <summary>
+    /// Per-draft keywords whose value is itself a schema (object or boolean).
+    /// Recursion only happens for keywords defined in the current draft; others
+    /// are treated as unknown annotations and not traversed.
+    /// </summary>
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaValuedPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "additionalProperties",
+            "additionalItems",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "if", "then", "else",
+            "contains",
+            "additionalProperties",
+            "propertyNames",
+            "unevaluatedProperties",
+            "unevaluatedItems",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "if", "then", "else",
+            "contains",
+            "additionalProperties",
+            "propertyNames",
+            "unevaluatedProperties",
+            "unevaluatedItems",
+            // contentSchema is annotation-only in this codebase (and in the default
+            // 2020-12 content vocabulary), so recursing into it would falsely reject
+            // schemas that use deferred keywords inside content metadata.
+        },
+    };
+
+    /// <summary>
+    /// Per-draft keywords whose value is an array of schemas.
+    /// </summary>
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaArrayPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+            "prefixItems",
+        },
+    };
+
+    /// <summary>
+    /// Per-draft keywords whose value is a map of name/pattern to schema.
+    /// </summary>
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaMapPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "definitions",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "$defs",
+            "definitions",
+            "dependentSchemas",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "$defs",
+            // definitions: not a standard 2020-12 keyword, but the shared
+            // SubschemaExtractor still walks it and #/definitions/... refs
+            // are legal JSON Pointers. Include so the gate matches emission
+            // reachability and so extractor-collected subschemas get emitted.
+            "definitions",
+            "dependentSchemas",
+        },
+    };
+
+    /// <summary>
+    /// Returns a rejection message if the schema uses deferred features,
+    /// or null if the schema is emit-safe for the MVP TS target.
+    /// </summary>
+    public static string? CheckSupported(JsonElement root, SchemaDraft detectedDraft)
+    {
+        if (!SupportedDrafts.Contains(detectedDraft))
+        {
+            return $"TS target MVP supports Draft 4, Draft 2019-09, and Draft 2020-12 only; detected {detectedDraft}. " +
+                   "Other drafts are tracked as follow-up work.";
+        }
+        return Walk(root, detectedDraft);
+    }
+
+    private static string? Walk(JsonElement node, SchemaDraft draft)
+    {
+        return node.ValueKind == JsonValueKind.Object ? WalkObject(node, draft) : null;
+    }
+
+    private static string? WalkObject(JsonElement node, SchemaDraft draft)
+    {
+        var deferred = DeferredPerDraft[draft];
+        var schemaValued = SchemaValuedPerDraft[draft];
+        var schemaArray = SchemaArrayPerDraft[draft];
+        var schemaMap = SchemaMapPerDraft[draft];
+
+        // Draft 7 and earlier: $ref masks all sibling keywords at emission time
+        // (see TsSchemaCodeGenerator.refMasksSiblings). Mirror that here so the
+        // gate doesn't reject schemas based on keywords the emitter will ignore.
+        // Match the emitter's "usable $ref" check — an empty or non-string $ref
+        // doesn't actually mask siblings in the emitter, so we don't mask here
+        // either.
+        var refMasksSiblings = draft <= SchemaDraft.Draft7 &&
+                               node.TryGetProperty("$ref", out var maskedRef) &&
+                               maskedRef.ValueKind == JsonValueKind.String &&
+                               !string.IsNullOrEmpty(maskedRef.GetString());
+
+        foreach (var prop in node.EnumerateObject())
+        {
+            if (refMasksSiblings && prop.Name != "$ref")
+            {
+                continue;
+            }
+            if (deferred.Contains(prop.Name))
+            {
+                return $"TS target MVP does not support '{prop.Name}'. " +
+                       $"Deferred to follow-up: support for '{prop.Name}' is not yet implemented.";
+            }
+
+            // Draft-specific "items": single schema in 2020-12; single or array in Draft 4.
+            // Only traverse when items is a known keyword in the current draft (it is in both
+            // MVP drafts, but the shape differs).
+            if (prop.Name == "items")
+            {
+                if (draft == SchemaDraft.Draft4 && prop.Value.ValueKind == JsonValueKind.Array)
+                {
+                    var rejection = WalkSchemaArray(prop.Value, draft);
+                    if (rejection != null) return rejection;
+                }
+                else
+                {
+                    var rejection = Walk(prop.Value, draft);
+                    if (rejection != null) return rejection;
+                }
+                continue;
+            }
+
+            // Draft 4 "dependencies": each value is either an array of property
+            // names (data) or a schema. Only recurse into schema-shaped values.
+            // In Draft 2020-12 "dependencies" is no longer a keyword; treat as
+            // unknown annotation and do not recurse.
+            if (prop.Name == "dependencies" && draft == SchemaDraft.Draft4 &&
+                prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var dep in prop.Value.EnumerateObject())
+                {
+                    if (dep.Value.ValueKind == JsonValueKind.Object ||
+                        dep.Value.ValueKind == JsonValueKind.True ||
+                        dep.Value.ValueKind == JsonValueKind.False)
+                    {
+                        var rejection = Walk(dep.Value, draft);
+                        if (rejection != null) return rejection;
+                    }
+                }
+                continue;
+            }
+
+            if (schemaValued.Contains(prop.Name))
+            {
+                var rejection = Walk(prop.Value, draft);
+                if (rejection != null) return rejection;
+            }
+            else if (schemaArray.Contains(prop.Name) &&
+                     prop.Value.ValueKind == JsonValueKind.Array)
+            {
+                var rejection = WalkSchemaArray(prop.Value, draft);
+                if (rejection != null) return rejection;
+            }
+            else if (schemaMap.Contains(prop.Name) &&
+                     prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                var rejection = WalkSchemaMap(prop.Value, draft);
+                if (rejection != null) return rejection;
+            }
+            // All other property values (data, annotations, unknown-in-this-draft
+            // keywords) are intentionally not walked.
+        }
+        return null;
+    }
+
+    private static string? WalkSchemaArray(JsonElement array, SchemaDraft draft)
+    {
+        foreach (var item in array.EnumerateArray())
+        {
+            var rejection = Walk(item, draft);
+            if (rejection != null) return rejection;
+        }
+        return null;
+    }
+
+    private static string? WalkSchemaMap(JsonElement map, SchemaDraft draft)
+    {
+        foreach (var entry in map.EnumerateObject())
+        {
+            var rejection = Walk(entry.Value, draft);
+            if (rejection != null) return rejection;
+        }
+        return null;
+    }
+
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsRuntime.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsRuntime.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+
+/// <summary>
+/// Accessor for the TypeScript migration runtime source.
+/// In this phase the runtime is valid TypeScript derived from the stable JS ABI,
+/// keeping JS and TS paths byte-for-byte comparable after tsc erases comments.
+/// </summary>
+public static class TsRuntime
+{
+    private const string JavaScriptRuntimeHeader = "// jsv-runtime.js";
+
+    /// <summary>
+    /// The filename used for the TypeScript runtime source.
+    /// </summary>
+    public const string FileName = "jsv-runtime.ts";
+
+    /// <summary>
+    /// The declaration filename used when compiling validators without emitting
+    /// the runtime module.
+    /// </summary>
+    public const string DeclarationFileName = "jsv-runtime.d.ts";
+
+    /// <summary>
+    /// Returns the runtime module source as TypeScript.
+    /// </summary>
+    public static string GetSource()
+    {
+        var source = JsRuntime.GetSource();
+        if (!source.Contains(JavaScriptRuntimeHeader, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"The JS runtime header marker '{JavaScriptRuntimeHeader}' was not found. " +
+                "Update the TypeScript runtime projection instead of silently omitting @ts-nocheck.");
+        }
+
+        return "// @ts-nocheck" + Environment.NewLine +
+            source.Replace(JavaScriptRuntimeHeader, "// jsv-runtime.ts", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Returns declarations for validator-only compilation when the consumer
+    /// supplies the runtime module separately.
+    /// </summary>
+    public static string GetDeclarationSource()
+    {
+        return """
+            export function escapeJsonPointer(segment: unknown): string;
+            export function getCachedRegex(pattern: string): RegExp;
+            export function graphemeLength(value: string): number;
+            export function isInteger(value: unknown): boolean;
+            export function deepEquals(a: unknown, b: unknown): boolean;
+            export class EvaluatedState {
+              clone(): EvaluatedState;
+              reset(): void;
+              restoreFrom(other: EvaluatedState): void;
+              mergeFrom(other: EvaluatedState): void;
+              markPropertyEvaluated(location: string, name: string): void;
+              markItemEvaluated(location: string, index: number): void;
+              setEvaluatedItemsUpTo(location: string, count: number): void;
+            }
+            export class Registry {
+              registerForUri(uri: string, validator: unknown): void;
+              tryGetValidator(uri: string): unknown;
+            }
+            export class CompiledValidatorScope {
+              static empty: CompiledValidatorScope;
+            }
+            export function isValidDate(value: string): boolean;
+            export function isValidTime(value: string): boolean;
+            export function isValidDateTime(value: string): boolean;
+            export function isValidDuration(value: string): boolean;
+            export function isValidEmail(value: string): boolean;
+            export function isValidIdnEmail(value: string): boolean;
+            export function isValidHostname(value: string): boolean;
+            export function isValidIdnHostname(value: string): boolean;
+            export function isValidIpv4(value: string): boolean;
+            export function isValidIpv6(value: string): boolean;
+            export function isValidUri(value: string): boolean;
+            export function isValidUriReference(value: string): boolean;
+            export function isValidIri(value: string): boolean;
+            export function isValidIriReference(value: string): boolean;
+            export function isValidUriTemplate(value: string): boolean;
+            export function isValidJsonPointer(value: string): boolean;
+            export function isValidRelativeJsonPointer(value: string): boolean;
+            export function isValidRegex(value: string): boolean;
+            export function isValidUuid(value: string): boolean;
+            """;
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsSchemaCodeGenerator.cs
@@ -1,0 +1,764 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript.Keywords;
+using FormFinch.JsonSchemaValidation.Common;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+
+/// <summary>
+/// Orchestrates TypeScript (ESM) validator emission for a JSON Schema.
+/// Reuses the language-agnostic schema analysis from JsonSchemaValidation.CodeGeneration
+/// and delegates per-keyword emission to ITsKeywordCodeGenerator implementations.
+/// </summary>
+public sealed class TsSchemaCodeGenerator
+{
+    private sealed record FragmentValidatorInfo(string Hash, string Uri);
+    private sealed record MetaSchemaBehavior(
+        bool ValidationVocabularyEnabled,
+        bool MetaSchemaDeclaresFormatAssertionVocabulary);
+
+    private readonly List<ITsKeywordCodeGenerator> _keywordGenerators;
+    private readonly SubschemaExtractor _extractor = new();
+
+    /// <summary>
+    /// The default draft version to use when a schema doesn't have an explicit $schema keyword.
+    /// If null, defaults to Draft 2020-12.
+    /// </summary>
+    public SchemaDraft? DefaultDraft { get; set; }
+
+    /// <summary>
+    /// Whether to assert supported "format" values for Draft 2020-12. Earlier
+    /// supported drafts still assert format by default. Defaults to false for
+    /// spec-conformant Draft 2020-12 output; tests and consumers can opt in.
+    /// </summary>
+    public bool FormatAssertionEnabled { get; set; }
+
+    /// <summary>
+    /// Forces property/item annotation tracking even when the schema itself does
+    /// not contain unevaluated* keywords. Useful for registry-preloaded validators
+    /// that may be referenced by a caller that does track unevaluated annotations.
+    /// </summary>
+    public bool AlwaysTrackAnnotations { get; set; }
+
+    /// <summary>
+    /// The import specifier used for the shared JS runtime module.
+    /// Defaults to a relative ESM import sibling to the emitted validator.
+    /// </summary>
+    public string RuntimeImportSpecifier { get; set; } = "./jsv-runtime.js";
+
+    /// <summary>
+    /// Optional preloaded schemas keyed by absolute URI. Used for metaschema-aware
+    /// generation decisions such as $vocabulary handling.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? ExternalSchemaDocuments { get; set; }
+
+    public TsSchemaCodeGenerator()
+    {
+        _keywordGenerators =
+        [
+            new TsRefCodeGenerator(),
+            new TsDynamicRefCodeGenerator(),
+            new TsTypeCodeGenerator(),
+            new TsRequiredCodeGenerator(),
+            new TsEnumCodeGenerator(),
+            new TsConstCodeGenerator(),
+            new TsPropertyNamesCodeGenerator(),
+            new TsDependentRequiredCodeGenerator(),
+            new TsDependentSchemasCodeGenerator(),
+            new TsDependenciesCodeGenerator(),
+            new TsNumericConstraintsCodeGenerator(),
+            new TsStringConstraintsCodeGenerator(),
+            new TsArrayConstraintsCodeGenerator(),
+            new TsObjectConstraintsCodeGenerator(),
+            new TsPatternCodeGenerator(),
+            new TsPrefixItemsCodeGenerator(),
+            new TsAdditionalItemsCodeGenerator(),
+            new TsItemsCodeGenerator(),
+            new TsContainsCodeGenerator(),
+            new TsPropertiesCodeGenerator(),
+            new TsPatternPropertiesCodeGenerator(),
+            new TsAdditionalPropertiesCodeGenerator(),
+            new TsAllOfCodeGenerator(),
+            new TsAnyOfCodeGenerator(),
+            new TsOneOfCodeGenerator(),
+            new TsNotCodeGenerator(),
+            new TsIfThenElseCodeGenerator(),
+            new TsFormatCodeGenerator(),
+            new TsUnevaluatedPropertiesCodeGenerator(),
+            new TsUnevaluatedItemsCodeGenerator(),
+        ];
+        _keywordGenerators.Sort((a, b) => b.Priority.CompareTo(a.Priority));
+    }
+
+    /// <summary>
+    /// Generates an ESM TypeScript validator module from a schema file.
+    /// </summary>
+    public GenerationResult Generate(string schemaPath)
+    {
+        try
+        {
+            var json = File.ReadAllText(schemaPath);
+            using var doc = JsonDocument.Parse(json);
+            return Generate(doc.RootElement, schemaPath);
+        }
+        catch (Exception ex)
+        {
+            return GenerationResult.Failed($"Failed to read schema: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Generates an ESM TypeScript validator module from a schema element.
+    /// </summary>
+    public GenerationResult Generate(JsonElement schema, string? sourcePath = null)
+    {
+        try
+        {
+            var draftResult = SchemaDraftDetector.DetectDraft(schema, DefaultDraft);
+            if (!draftResult.Success)
+            {
+                return GenerationResult.Failed(draftResult.ErrorMessage!);
+            }
+            var detectedDraft = draftResult.Draft;
+
+            var gateRejection = TsCapabilityGate.CheckSupported(schema, detectedDraft);
+            if (gateRejection != null)
+            {
+                return GenerationResult.Failed(gateRejection);
+            }
+
+            var schemaUri = ExtractSchemaUri(schema);
+            Uri? baseUri = null;
+            if (!string.IsNullOrEmpty(schemaUri))
+            {
+                Uri.TryCreate(schemaUri, UriKind.Absolute, out baseUri);
+            }
+
+            var uniqueSchemas = _extractor.ExtractUniqueSubschemas(schema, baseUri, DefaultDraft);
+            var rootHash = SchemaHasher.ComputeHash(schema);
+            var metaSchemaBehavior = DetermineMetaSchemaBehavior(schema, detectedDraft);
+            var effectiveFormatAssertionEnabled = detectedDraft == SchemaDraft.Draft202012 &&
+                                                 (FormatAssertionEnabled ||
+                                                  metaSchemaBehavior.MetaSchemaDeclaresFormatAssertionVocabulary);
+            var requiresPropertyAnnotations = AlwaysTrackAnnotations || _extractor.HasUnevaluatedProperties;
+            var requiresItemAnnotations = AlwaysTrackAnnotations || _extractor.HasUnevaluatedItems;
+            var rootBaseUri = uniqueSchemas.Values.FirstOrDefault(i => i.JsonPointerPath == string.Empty)?.EffectiveBaseUri;
+            var requiresScopeTracking = detectedDraft == SchemaDraft.Draft202012 &&
+                uniqueSchemas.Values.Any(s =>
+                    (s.Schema.ValueKind == JsonValueKind.Object && s.Schema.TryGetProperty("$dynamicRef", out _)) ||
+                    s.DynamicAnchors.Count > 0 ||
+                    s.ResourceAnchors.Count > 0);
+
+            // Reachability pass: filter out subschemas reached only through
+            // annotation-only keywords (contentSchema, default, examples, ...) so
+            // we don't emit validators for them — those would run JS emitters on
+            // metadata and can legitimately fail (e.g., items-as-array in 2020-12
+            // inside contentSchema). Also detects ambiguous-resource ref collapse
+            // and rejects pre-emission.
+            var reach = TsSchemaReachability.Analyze(
+                schema,
+                detectedDraft,
+                uniqueSchemas,
+                (refValue, resourceRoot) => _extractor.ResolveLocalRefInResource(refValue, resourceRoot));
+            if (reach.Rejection != null)
+            {
+                return GenerationResult.Failed(reach.Rejection);
+            }
+            var fragmentValidators = CollectFragmentValidators(uniqueSchemas, rootBaseUri, reach.ReachableHashes);
+            var requiresRegistryLookup = uniqueSchemas
+                .Where(kvp => reach.ReachableHashes.Contains(kvp.Key))
+                .Any(kvp => ContainsExternalRef(kvp.Value.Schema));
+            var requiresRegistryParameter = requiresRegistryLookup || requiresScopeTracking;
+
+            var methods = new StringBuilder();
+            var runtimeImports = new SortedSet<string>(StringComparer.Ordinal);
+            if (requiresPropertyAnnotations || requiresItemAnnotations)
+            {
+                runtimeImports.Add("EvaluatedState");
+                runtimeImports.Add("escapeJsonPointer");
+            }
+            if (requiresScopeTracking)
+            {
+                runtimeImports.Add("CompiledValidatorScope");
+            }
+            foreach (var (hash, subschemaInfo) in uniqueSchemas)
+            {
+                if (!reach.ReachableHashes.Contains(hash)) continue;
+                methods.AppendLine(GenerateValidationFunction(
+                    subschemaInfo,
+                    uniqueSchemas,
+                    detectedDraft,
+                    metaSchemaBehavior.ValidationVocabularyEnabled,
+                    effectiveFormatAssertionEnabled,
+                    requiresPropertyAnnotations,
+                    requiresItemAnnotations,
+                    rootBaseUri,
+                    requiresScopeTracking,
+                    requiresRegistryParameter,
+                    runtimeImports));
+                methods.AppendLine();
+            }
+
+            var module = GenerateModule(
+                schemaUri,
+                rootHash,
+                methods.ToString(),
+                runtimeImports,
+                requiresPropertyAnnotations || requiresItemAnnotations,
+                requiresScopeTracking,
+                requiresRegistryParameter,
+                fragmentValidators);
+            var fileName = DeriveFileName(schemaUri, sourcePath);
+            return GenerationResult.Succeeded(module, fileName);
+        }
+        catch (Exception ex)
+        {
+            return GenerationResult.Failed($"Code generation failed: {ex.Message}");
+        }
+    }
+
+    private string GenerateValidationFunction(
+        SubschemaInfo subschemaInfo,
+        Dictionary<string, SubschemaInfo> allSchemas,
+        SchemaDraft detectedDraft,
+        bool validationVocabularyEnabled,
+        bool effectiveFormatAssertionEnabled,
+        bool requiresPropertyAnnotations,
+        bool requiresItemAnnotations,
+        Uri? rootBaseUri,
+        bool requiresScopeTracking,
+        bool requiresRegistryParameter,
+        SortedSet<string> runtimeImports)
+    {
+        var context = CreateContext(
+            subschemaInfo,
+            allSchemas,
+            detectedDraft,
+            validationVocabularyEnabled,
+            effectiveFormatAssertionEnabled,
+            requiresPropertyAnnotations,
+            requiresItemAnnotations,
+            rootBaseUri,
+            requiresScopeTracking,
+            requiresRegistryParameter);
+        var sb = new StringBuilder();
+
+        var parameterParts = new List<string> { "v: JsonValue" };
+        if (requiresScopeTracking)
+        {
+            parameterParts.Add("_scope: any");
+        }
+        if (requiresPropertyAnnotations || requiresItemAnnotations)
+        {
+            parameterParts.Add("_eval: any");
+        }
+        if (requiresScopeTracking || requiresPropertyAnnotations || requiresItemAnnotations)
+        {
+            parameterParts.Add("_loc: string");
+        }
+        if (requiresRegistryParameter)
+        {
+            parameterParts.Add("_registry: ValidatorRegistry");
+        }
+        var parameters = string.Join(", ", parameterParts);
+        sb.AppendLine($"function validate_{subschemaInfo.Hash}({parameters}): boolean {{");
+
+        if (subschemaInfo.Schema.ValueKind == JsonValueKind.True)
+        {
+            sb.AppendLine("  return true;");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        if (requiresScopeTracking)
+        {
+            var scopeEntry = BuildScopePushCode(subschemaInfo, requiresPropertyAnnotations || requiresItemAnnotations, requiresRegistryParameter);
+            if (!string.IsNullOrWhiteSpace(scopeEntry))
+            {
+                foreach (var line in scopeEntry.Split('\n'))
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        sb.AppendLine();
+                    }
+                    else
+                    {
+                        sb.AppendLine($"  {line.TrimEnd()}");
+                    }
+                }
+            }
+        }
+        if (subschemaInfo.Schema.ValueKind == JsonValueKind.False)
+        {
+            sb.AppendLine("  return false;");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        // Draft 7 and earlier: $ref overrides all sibling keywords — but only
+        // when $ref is a USABLE string. A $ref: "" or $ref: {} would otherwise
+        // mask every sibling without TsRefCodeGenerator emitting anything,
+        // compiling to an always-true validator.
+        var refMasksSiblings = detectedDraft <= SchemaDraft.Draft7
+            && subschemaInfo.Schema.ValueKind == JsonValueKind.Object
+            && subschemaInfo.Schema.TryGetProperty("$ref", out var maskingRef)
+            && maskingRef.ValueKind == JsonValueKind.String
+            && !string.IsNullOrEmpty(maskingRef.GetString());
+
+        foreach (var generator in _keywordGenerators)
+        {
+            if (refMasksSiblings && generator.Keyword != "$ref")
+            {
+                continue;
+            }
+
+            if (!generator.CanGenerate(subschemaInfo.Schema))
+            {
+                continue;
+            }
+
+            foreach (var import in generator.GetRuntimeImports(context))
+            {
+                runtimeImports.Add(import);
+            }
+
+            var code = generator.GenerateCode(context);
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                continue;
+            }
+
+            foreach (var line in code.Split('\n'))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    sb.AppendLine();
+                }
+                else
+                {
+                    sb.AppendLine($"  {line.TrimEnd()}");
+                }
+            }
+        }
+
+        sb.AppendLine("  return true;");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private TsCodeGenerationContext CreateContext(
+        SubschemaInfo subschemaInfo,
+        Dictionary<string, SubschemaInfo> allSchemas,
+        SchemaDraft detectedDraft,
+        bool validationVocabularyEnabled,
+        bool effectiveFormatAssertionEnabled,
+        bool requiresPropertyAnnotations,
+        bool requiresItemAnnotations,
+        Uri? rootBaseUri,
+        bool requiresScopeTracking,
+        bool requiresRegistryParameter)
+    {
+        var effectiveBaseUri = subschemaInfo.EffectiveBaseUri ?? rootBaseUri;
+        return new TsCodeGenerationContext
+        {
+            CurrentSchema = subschemaInfo.Schema,
+            CurrentHash = subschemaInfo.Hash,
+            CurrentResourceRootHash = subschemaInfo.ResourceRootHash,
+            GetSubschemaHash = element => SchemaHasher.ComputeHash(element),
+            ResolveLocalRef = refValue => _extractor.ResolveLocalRef(refValue),
+            ResolveInternalId = uri => _extractor.ResolveInternalId(uri),
+            ResolveLocalRefInResource = (refValue, resourceRoot) =>
+                _extractor.ResolveLocalRefInResource(refValue, resourceRoot),
+            ResourceRoot = subschemaInfo.ResourceRoot,
+            BaseUri = effectiveBaseUri,
+            RootBaseUri = rootBaseUri,
+            GetSubschemaInfo = hash => allSchemas.TryGetValue(hash, out var info) ? info : null,
+            DetectedDraft = detectedDraft,
+            RequiresPropertyAnnotations = requiresPropertyAnnotations,
+            RequiresItemAnnotations = requiresItemAnnotations,
+            FormatAssertionEnabled = effectiveFormatAssertionEnabled,
+            ValidationVocabularyEnabled = validationVocabularyEnabled,
+            RequiresScopeTracking = requiresScopeTracking,
+            RequiresRegistry = requiresRegistryParameter
+        };
+    }
+
+    private MetaSchemaBehavior DetermineMetaSchemaBehavior(JsonElement schema, SchemaDraft detectedDraft)
+    {
+        if ((detectedDraft != SchemaDraft.Draft201909 && detectedDraft != SchemaDraft.Draft202012) ||
+            schema.ValueKind != JsonValueKind.Object ||
+            !schema.TryGetProperty("$schema", out var schemaProperty) ||
+            schemaProperty.ValueKind != JsonValueKind.String)
+        {
+            return new MetaSchemaBehavior(
+                ValidationVocabularyEnabled: true,
+                MetaSchemaDeclaresFormatAssertionVocabulary: false);
+        }
+
+        var schemaUri = schemaProperty.GetString();
+        if (string.IsNullOrEmpty(schemaUri) ||
+            ExternalSchemaDocuments == null ||
+            !ExternalSchemaDocuments.TryGetValue(schemaUri, out var metaSchemaJson))
+        {
+            return new MetaSchemaBehavior(
+                ValidationVocabularyEnabled: true,
+                MetaSchemaDeclaresFormatAssertionVocabulary: false);
+        }
+
+        try
+        {
+            using var metaSchemaDoc = JsonDocument.Parse(metaSchemaJson);
+            var metaSchemaRoot = metaSchemaDoc.RootElement;
+            if (metaSchemaRoot.ValueKind != JsonValueKind.Object ||
+                !metaSchemaRoot.TryGetProperty("$vocabulary", out var vocabularyElement) ||
+                vocabularyElement.ValueKind != JsonValueKind.Object)
+            {
+                return new MetaSchemaBehavior(
+                    ValidationVocabularyEnabled: true,
+                    MetaSchemaDeclaresFormatAssertionVocabulary: false);
+            }
+
+            var validationVocabularyUri = detectedDraft == SchemaDraft.Draft201909
+                ? "https://json-schema.org/draft/2019-09/vocab/validation"
+                : "https://json-schema.org/draft/2020-12/vocab/validation";
+            var formatAssertionVocabularyUri = detectedDraft == SchemaDraft.Draft201909
+                ? "https://json-schema.org/draft/2019-09/vocab/format"
+                : "https://json-schema.org/draft/2020-12/vocab/format-assertion";
+
+            // Spec §8.1: a $vocabulary entry's true/false value indicates whether
+            // support is required (true) or optional (false). Presence in the map
+            // is what declares the vocabulary as "in use" by the metaschema.
+            // Consistent with how we handle the format-assertion vocabulary below.
+            var validationVocabularyEnabled =
+                vocabularyElement.TryGetProperty(validationVocabularyUri, out _);
+            var declaresFormatAssertionVocabulary =
+                vocabularyElement.TryGetProperty(formatAssertionVocabularyUri, out _);
+
+            return new MetaSchemaBehavior(
+                ValidationVocabularyEnabled: validationVocabularyEnabled,
+                MetaSchemaDeclaresFormatAssertionVocabulary: declaresFormatAssertionVocabulary);
+        }
+        catch
+        {
+            return new MetaSchemaBehavior(
+                ValidationVocabularyEnabled: true,
+                MetaSchemaDeclaresFormatAssertionVocabulary: false);
+        }
+    }
+
+    private string GenerateModule(
+        string? schemaUri,
+        string rootHash,
+        string methods,
+        SortedSet<string> runtimeImports,
+        bool requiresAnnotationTracking,
+        bool requiresScopeTracking,
+        bool requiresRegistry,
+        IReadOnlyList<FragmentValidatorInfo> fragmentValidators)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// This code was generated by jsv-codegen (TypeScript target).");
+        sb.AppendLine("// Do not edit this file manually.");
+        sb.AppendLine();
+
+        if (runtimeImports.Count > 0)
+        {
+            sb.Append("import { ");
+            sb.Append(string.Join(", ", runtimeImports));
+            sb.AppendLine($" }} from {TsLiteral.String(RuntimeImportSpecifier)};");
+            sb.AppendLine();
+        }
+
+        sb.Append(TypeScriptPreamble());
+        sb.AppendLine();
+
+        sb.Append(methods);
+        sb.AppendLine();
+
+        var exportParameters = requiresRegistry
+            ? "data: JsonValue, registry: ValidatorRegistry = null"
+            : "data: JsonValue";
+        // Stable named-export signatures (keep each method's shape unambiguous
+        // across modules so cross-module registry composition is safe):
+        //   validate(data [, registry])
+        //   validateWithScope(data, scope, location [, registry])
+        //   validateWithState(data, evaluatedState, location [, registry])
+        //   validateWithScopeAndState(data, scope, evaluatedState, location [, registry])
+        if (requiresScopeTracking && requiresAnnotationTracking)
+        {
+            if (requiresRegistry)
+            {
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, new EvaluatedState(), location, registry); }}");
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, evaluatedState, location, registry); }}");
+                sb.AppendLine($"export function validateWithScopeAndState(data: JsonValue, scope: any, evaluatedState: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, evaluatedState, location, registry); }}");
+                sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, new EvaluatedState(), \"\", registry); }}");
+            }
+            else
+            {
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\"): boolean {{ return validate_{rootHash}(data, scope, new EvaluatedState(), location); }}");
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\"): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, evaluatedState, location); }}");
+                sb.AppendLine($"export function validateWithScopeAndState(data: JsonValue, scope: any, evaluatedState: any, location = \"\"): boolean {{ return validate_{rootHash}(data, scope, evaluatedState, location); }}");
+                sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, new EvaluatedState(), \"\"); }}");
+            }
+        }
+        else if (requiresScopeTracking)
+        {
+            if (requiresRegistry)
+            {
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, location, registry); }}");
+                sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithScope(data, CompiledValidatorScope.empty, \"\", registry); }}");
+            }
+            else
+            {
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\"): boolean {{ return validate_{rootHash}(data, scope, location); }}");
+                sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithScope(data, CompiledValidatorScope.empty, \"\"); }}");
+            }
+        }
+        else if (requiresAnnotationTracking)
+        {
+            if (requiresRegistry)
+            {
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, evaluatedState, location, registry); }}");
+                sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithState(data, new EvaluatedState(), \"\", registry); }}");
+            }
+            else
+            {
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\"): boolean {{ return validate_{rootHash}(data, evaluatedState, location); }}");
+                sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithState(data, new EvaluatedState(), \"\"); }}");
+            }
+        }
+        else if (requiresRegistry)
+        {
+            sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validate_{rootHash}(data, registry); }}");
+        }
+        else
+        {
+            sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validate_{rootHash}(data); }}");
+        }
+        sb.AppendLine();
+
+        var schemaUriLiteral = string.IsNullOrEmpty(schemaUri)
+            ? "null"
+            : TsLiteral.String(schemaUri);
+        sb.AppendLine($"export const schemaUri = {schemaUriLiteral};");
+        sb.AppendLine();
+
+        sb.AppendLine("export const fragmentValidators = {");
+        foreach (var fragment in fragmentValidators)
+        {
+            sb.AppendLine($"  {TsLiteral.String(fragment.Uri)}: {{");
+            if (requiresScopeTracking && requiresAnnotationTracking && requiresRegistry)
+            {
+                sb.AppendLine($"    validate(data, registry = null) {{ return validate_{fragment.Hash}(data, CompiledValidatorScope.empty, new EvaluatedState(), \"\", registry); }},");
+                sb.AppendLine($"    validateWithScope(data, scope, location = \"\", registry = null) {{ return validate_{fragment.Hash}(data, scope, new EvaluatedState(), location, registry); }},");
+                sb.AppendLine($"    validateWithState(data, evaluatedState, location = \"\", registry = null) {{ return validate_{fragment.Hash}(data, CompiledValidatorScope.empty, evaluatedState, location, registry); }},");
+                sb.AppendLine($"    validateWithScopeAndState(data, scope, evaluatedState, location = \"\", registry = null) {{ return validate_{fragment.Hash}(data, scope, evaluatedState, location, registry); }}");
+            }
+            else if (requiresScopeTracking && requiresAnnotationTracking)
+            {
+                sb.AppendLine($"    validate(data) {{ return validate_{fragment.Hash}(data, CompiledValidatorScope.empty, new EvaluatedState(), \"\"); }},");
+                sb.AppendLine($"    validateWithScope(data, scope, location = \"\") {{ return validate_{fragment.Hash}(data, scope, new EvaluatedState(), location); }},");
+                sb.AppendLine($"    validateWithState(data, evaluatedState, location = \"\") {{ return validate_{fragment.Hash}(data, CompiledValidatorScope.empty, evaluatedState, location); }},");
+                sb.AppendLine($"    validateWithScopeAndState(data, scope, evaluatedState, location = \"\") {{ return validate_{fragment.Hash}(data, scope, evaluatedState, location); }}");
+            }
+            else if (requiresScopeTracking && requiresRegistry)
+            {
+                sb.AppendLine($"    validate(data, registry = null) {{ return validate_{fragment.Hash}(data, CompiledValidatorScope.empty, \"\", registry); }},");
+                sb.AppendLine($"    validateWithScope(data, scope, location = \"\", registry = null) {{ return validate_{fragment.Hash}(data, scope, location, registry); }}");
+            }
+            else if (requiresScopeTracking)
+            {
+                sb.AppendLine($"    validate(data) {{ return validate_{fragment.Hash}(data, CompiledValidatorScope.empty, \"\"); }},");
+                sb.AppendLine($"    validateWithScope(data, scope, location = \"\") {{ return validate_{fragment.Hash}(data, scope, location); }}");
+            }
+            else if (requiresAnnotationTracking && requiresRegistry)
+            {
+                sb.AppendLine($"    validate(data, registry = null) {{ return validate_{fragment.Hash}(data, new EvaluatedState(), \"\", registry); }},");
+                sb.AppendLine($"    validateWithState(data, evaluatedState, location = \"\", registry = null) {{ return validate_{fragment.Hash}(data, evaluatedState, location, registry); }}");
+            }
+            else if (requiresAnnotationTracking)
+            {
+                sb.AppendLine($"    validate(data) {{ return validate_{fragment.Hash}(data, new EvaluatedState(), \"\"); }},");
+                sb.AppendLine($"    validateWithState(data, evaluatedState, location = \"\") {{ return validate_{fragment.Hash}(data, evaluatedState, location); }}");
+            }
+            else if (requiresRegistry)
+            {
+                sb.AppendLine($"    validate(data, registry = null) {{ return validate_{fragment.Hash}(data, registry); }}");
+            }
+            else
+            {
+                sb.AppendLine($"    validate(data) {{ return validate_{fragment.Hash}(data); }}");
+            }
+            sb.AppendLine("  },");
+        }
+        sb.AppendLine("};");
+        sb.AppendLine();
+
+        var defaultExportMembers = new List<string> { "validate" };
+        if (requiresScopeTracking) defaultExportMembers.Add("validateWithScope");
+        if (requiresAnnotationTracking) defaultExportMembers.Add("validateWithState");
+        if (requiresScopeTracking && requiresAnnotationTracking) defaultExportMembers.Add("validateWithScopeAndState");
+        defaultExportMembers.Add("schemaUri");
+        if (fragmentValidators.Count > 0) defaultExportMembers.Add("fragmentValidators");
+        sb.AppendLine($"export default {{ {string.Join(", ", defaultExportMembers)} }};");
+        return sb.ToString();
+    }
+
+    private static string TypeScriptPreamble()
+    {
+        return """
+            type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+            type ValidatorRegistry = { tryGetValidator(uri: string): any } | null;
+
+            """;
+    }
+
+    private static string BuildScopePushCode(
+        SubschemaInfo subschemaInfo,
+        bool requiresAnnotationTracking,
+        bool requiresRegistry)
+    {
+        var anchorsToInclude = subschemaInfo.IsResourceRoot
+            ? subschemaInfo.ResourceAnchors
+            : subschemaInfo.DynamicAnchors.Select(name => (name, subschemaInfo.Hash)).ToList();
+        if (anchorsToInclude.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("_scope = _scope.push({");
+        sb.AppendLine("  dynamicAnchors: {");
+        foreach (var (anchorName, schemaHash) in anchorsToInclude)
+        {
+            var delegateExpr = requiresAnnotationTracking
+                ? requiresRegistry
+                    ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
+                    : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
+                : requiresRegistry
+                    ? $"(data, scope, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
+                    : $"(data, scope, location = \"\") => validate_{schemaHash}(data, scope, location)";
+            sb.AppendLine($"    {TsLiteral.String(anchorName)}: {delegateExpr},");
+        }
+        sb.AppendLine("  }");
+        sb.AppendLine("});");
+        sb.AppendLine();
+        return sb.ToString();
+    }
+
+    private static IReadOnlyList<FragmentValidatorInfo> CollectFragmentValidators(
+        Dictionary<string, SubschemaInfo> uniqueSchemas,
+        Uri? rootBaseUri,
+        ISet<string> reachableHashes)
+    {
+        var result = new Dictionary<string, FragmentValidatorInfo>(StringComparer.Ordinal);
+        foreach (var (hash, subschemaInfo) in uniqueSchemas)
+        {
+            // Unreachable hashes don't get a validate_<hash> emitted, so any
+            // fragment URI pointing to them would reference an undefined
+            // function at runtime. Skip the whole registration for those.
+            if (!reachableHashes.Contains(hash))
+            {
+                continue;
+            }
+
+            if (rootBaseUri != null && !string.IsNullOrEmpty(subschemaInfo.JsonPointerPath))
+            {
+                var pointerUri = $"{rootBaseUri.AbsoluteUri}#{subschemaInfo.JsonPointerPath}";
+                result.TryAdd(pointerUri, new FragmentValidatorInfo(hash, pointerUri));
+            }
+
+            if (subschemaInfo.Schema.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var anchorBaseUri = subschemaInfo.EffectiveBaseUri;
+            if (anchorBaseUri == null)
+            {
+                continue;
+            }
+
+            anchorBaseUri = new Uri(anchorBaseUri.GetLeftPart(UriPartial.Query));
+            if (subschemaInfo.Schema.TryGetProperty("$anchor", out var anchorElement) &&
+                anchorElement.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(anchorElement.GetString()))
+            {
+                var anchorUri = $"{anchorBaseUri.AbsoluteUri}#{anchorElement.GetString()}";
+                result.TryAdd(anchorUri, new FragmentValidatorInfo(hash, anchorUri));
+            }
+
+            if (subschemaInfo.Schema.TryGetProperty("$dynamicAnchor", out var dynamicAnchorElement) &&
+                dynamicAnchorElement.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(dynamicAnchorElement.GetString()))
+            {
+                var dynamicAnchorUri = $"{anchorBaseUri.AbsoluteUri}#{dynamicAnchorElement.GetString()}";
+                result.TryAdd(dynamicAnchorUri, new FragmentValidatorInfo(hash, dynamicAnchorUri));
+            }
+        }
+
+        return result.Values.ToList();
+    }
+
+    private static string? ExtractSchemaUri(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        if (schema.TryGetProperty("$id", out var idElement) && idElement.ValueKind == JsonValueKind.String)
+        {
+            return idElement.GetString();
+        }
+        if (schema.TryGetProperty("id", out var legacyIdElement) && legacyIdElement.ValueKind == JsonValueKind.String)
+        {
+            return legacyIdElement.GetString();
+        }
+        return null;
+    }
+
+    private static string DeriveFileName(string? schemaUri, string? sourcePath)
+    {
+        // Only derive from the URI when it's absolute and hierarchical; relative
+        // $ids like "person" or "schemas/person.JSON" are valid in JSON Schema but
+        // cannot be parsed as absolute URIs. Fall back to sourcePath in that case.
+        if (!string.IsNullOrEmpty(schemaUri) &&
+            Uri.TryCreate(schemaUri, UriKind.Absolute, out var uri) &&
+            uri.IsAbsoluteUri && !uri.IsFile)
+        {
+            var lastSegment = uri.Segments.LastOrDefault()?.TrimEnd('/');
+            if (!string.IsNullOrEmpty(lastSegment))
+            {
+                return $"{SanitizeFileName(Path.GetFileNameWithoutExtension(lastSegment))}.ts";
+            }
+        }
+        if (!string.IsNullOrEmpty(sourcePath))
+        {
+            return $"{SanitizeFileName(Path.GetFileNameWithoutExtension(sourcePath))}.ts";
+        }
+        return "validator.ts";
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            sb.Append(char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '_');
+        }
+        return sb.Length > 0 ? sb.ToString() : "validator";
+    }
+
+    private static bool ContainsExternalRef(JsonElement schema)
+    {
+        return schema.ValueKind == JsonValueKind.Object &&
+               schema.TryGetProperty("$ref", out var refElem) &&
+               refElem.ValueKind == JsonValueKind.String &&
+               !string.IsNullOrEmpty(refElem.GetString()) &&
+               !refElem.GetString()!.StartsWith('#');
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsSchemaReachability.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TsSchemaReachability.cs
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.Common;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+
+/// <summary>
+/// Walks a schema using the TS target's own notion of applicator keywords
+/// (the same sets the capability gate uses), producing:
+///
+/// 1. The set of subschema hashes that are actually reachable from the root
+///    via JS-emittable keywords. Subschemas under annotation-only keywords
+///    like contentSchema, default, examples are excluded so they do not get
+///    turned into dead — and sometimes invalid — validator functions.
+///    Annotation-dependent applicators such as unevaluatedProperties and
+///    unevaluatedItems are included because they emit real validation code.
+///
+/// 2. A resource-root identity per hash, so we can detect when two text-
+///    identical ref-containing subschemas appear under different resource
+///    roots. The shared SubschemaExtractor deduplicates by content hash and
+///    keeps only the first resource root, which would make local-ref
+///    resolution resolve against the wrong resource at the second call site.
+///    The safest MVP behavior is to detect that case and reject the schema
+///    rather than silently validate against the wrong target.
+/// </summary>
+internal static class TsSchemaReachability
+{
+    // Keyword-shape sets kept in sync with TsCapabilityGate. Duplicated here
+    // rather than shared to avoid accidental gate-mutation coupling; these
+    // drive emission, the gate drives rejection.
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaValuedPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "additionalProperties",
+            "additionalItems",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "if", "then", "else",
+            "contains",
+            "additionalProperties",
+            "propertyNames",
+            "unevaluatedProperties",
+            "unevaluatedItems",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "not",
+            "if", "then", "else",
+            "contains",
+            "additionalProperties",
+            "propertyNames",
+            "unevaluatedProperties",
+            "unevaluatedItems",
+        },
+    };
+
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaArrayPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "allOf", "anyOf", "oneOf",
+            "prefixItems",
+        },
+    };
+
+    private static readonly Dictionary<SchemaDraft, HashSet<string>> SchemaMapPerDraft = new()
+    {
+        [SchemaDraft.Draft4] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "definitions",
+        },
+        [SchemaDraft.Draft201909] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "$defs",
+            "definitions",
+            "dependentSchemas",
+        },
+        [SchemaDraft.Draft202012] = new(StringComparer.Ordinal)
+        {
+            "properties",
+            "patternProperties",
+            "$defs",
+            "definitions", // legacy keyword, still walked by SubschemaExtractor
+            "dependentSchemas",
+        },
+    };
+
+    public sealed record Result(
+        HashSet<string> ReachableHashes,
+        string? Rejection);
+
+    public static Result Analyze(
+        JsonElement root,
+        SchemaDraft draft,
+        IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas,
+        Func<string, JsonElement, JsonElement?> resolveLocalRefInResource)
+    {
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+        // Identity map: hash -> set of resource-root hashes under which this
+        // subschema was seen. A hash that shows up under more than one resource
+        // root AND contains a local $ref is the ambiguous case we reject.
+        var resourceRootsByHash = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+
+        Walk(root, currentResourceRoot: root, currentResourceRootHash: SchemaHasher.ComputeHash(root),
+            draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+
+        // Second pass: flag ambiguous-resource ref-containing subschemas.
+        foreach (var (hash, resourceRoots) in resourceRootsByHash)
+        {
+            if (resourceRoots.Count <= 1) continue;
+            if (!uniqueSchemas.TryGetValue(hash, out var info)) continue;
+            if (info.Schema.ValueKind == JsonValueKind.Object &&
+                ((info.Schema.TryGetProperty("$ref", out var refElem) &&
+                  refElem.ValueKind == JsonValueKind.String &&
+                  !IsInlineableBareRefSchema(info.Schema)) ||
+                 (info.Schema.TryGetProperty("$dynamicRef", out var dynamicRefElem) &&
+                  dynamicRefElem.ValueKind == JsonValueKind.String &&
+                  !IsInlineableBareRefSchema(info.Schema))))
+            {
+                return new Result(reachable,
+                    "TS target MVP cannot safely compile a schema where an identical ref-containing " +
+                    "subschema appears under multiple nested $id resources: the shared analyzer " +
+                    "collapses them by content hash, so the emitted validator would resolve the ref " +
+                    "against the wrong resource. Differentiate the subschemas (e.g., include the $id " +
+                    "in the containing object) or split the schema so each resource's refs are unique.");
+            }
+        }
+
+        return new Result(reachable, null);
+    }
+
+    private static bool IsInlineableBareRefSchema(JsonElement schema)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        var count = 0;
+        foreach (var property in schema.EnumerateObject())
+        {
+            count++;
+            if (count > 1)
+            {
+                return false;
+            }
+
+            if ((property.Name != "$ref" && property.Name != "$dynamicRef") ||
+                property.Value.ValueKind != JsonValueKind.String ||
+                string.IsNullOrEmpty(property.Value.GetString()))
+            {
+                return false;
+            }
+        }
+
+        return count == 1;
+    }
+
+    private static void Walk(
+        JsonElement node,
+        JsonElement currentResourceRoot,
+        string currentResourceRootHash,
+        SchemaDraft draft,
+        HashSet<string> reachable,
+        Dictionary<string, HashSet<string>> resourceRootsByHash,
+        IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas,
+        Func<string, JsonElement, JsonElement?> resolveLocalRefInResource)
+    {
+        if (node.ValueKind == JsonValueKind.True || node.ValueKind == JsonValueKind.False)
+        {
+            var boolHash = SchemaHasher.ComputeHash(node);
+            reachable.Add(boolHash);
+            RecordResourceRoot(resourceRootsByHash, boolHash, currentResourceRootHash);
+            return;
+        }
+        if (node.ValueKind != JsonValueKind.Object) return;
+
+        var hash = SchemaHasher.ComputeHash(node);
+        // Early-return on revisit to break ref cycles safely.
+        if (!reachable.Add(hash))
+        {
+            RecordResourceRoot(resourceRootsByHash, hash, currentResourceRootHash);
+            return;
+        }
+        RecordResourceRoot(resourceRootsByHash, hash, currentResourceRootHash);
+
+        // An $id on this object opens a new resource boundary.
+        var nextResourceRootHash = DetectResourceRootHash(node, currentResourceRootHash, draft);
+        var nextResourceRoot = nextResourceRootHash == currentResourceRootHash ? currentResourceRoot : node;
+
+        // Follow local refs to mark the referenced subschema reachable. Resolve
+        // against the current resource root, not the document root: nested $id
+        // resources have their own fragment namespace, and anchor refs such as
+        // "#foo" cannot be matched by a root-relative JsonPointerPath scan.
+        FollowLocalRef(
+            node,
+            "$ref",
+            nextResourceRoot,
+            nextResourceRootHash,
+            draft,
+            reachable,
+            resourceRootsByHash,
+            uniqueSchemas,
+            resolveLocalRefInResource);
+        FollowLocalRef(
+            node,
+            "$dynamicRef",
+            nextResourceRoot,
+            nextResourceRootHash,
+            draft,
+            reachable,
+            resourceRootsByHash,
+            uniqueSchemas,
+            resolveLocalRefInResource);
+
+        var schemaValued = SchemaValuedPerDraft[draft];
+        var schemaArray = SchemaArrayPerDraft[draft];
+        var schemaMap = SchemaMapPerDraft[draft];
+
+        foreach (var prop in node.EnumerateObject())
+        {
+            // items: shape depends on draft.
+            if (prop.Name == "items")
+            {
+                if (draft == SchemaDraft.Draft4 && prop.Value.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var item in prop.Value.EnumerateArray())
+                    {
+                        Walk(item, nextResourceRoot, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+                    }
+                }
+                else
+                {
+                    Walk(prop.Value, nextResourceRoot, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+                }
+                continue;
+            }
+
+            // Legacy dependencies compatibility: in Draft 4-7 this is a real
+            // keyword, and in 2019-09+/2020-12 the optional compatibility tests
+            // still expect schema-valued entries to behave like dependentSchemas.
+            if (prop.Name == "dependencies" &&
+                prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var dep in prop.Value.EnumerateObject())
+                {
+                    if (dep.Value.ValueKind == JsonValueKind.Object ||
+                        dep.Value.ValueKind == JsonValueKind.True ||
+                        dep.Value.ValueKind == JsonValueKind.False)
+                    {
+                        Walk(dep.Value, nextResourceRoot, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+                    }
+                }
+                continue;
+            }
+
+            if (schemaValued.Contains(prop.Name))
+            {
+                Walk(prop.Value, nextResourceRoot, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+            }
+            else if (schemaArray.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in prop.Value.EnumerateArray())
+                {
+                    Walk(item, nextResourceRoot, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+                }
+            }
+            else if (schemaMap.Contains(prop.Name) && prop.Value.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var entry in prop.Value.EnumerateObject())
+                {
+                    Walk(entry.Value, nextResourceRoot, nextResourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+                }
+            }
+            // Data / annotation keywords (contentSchema, default, examples, enum,
+            // const, etc.) intentionally not walked — any subschema-shaped text
+            // inside them is annotation, not a validation applicator.
+        }
+    }
+
+    private static void FollowLocalRef(
+        JsonElement node,
+        string keyword,
+        JsonElement resourceRoot,
+        string resourceRootHash,
+        SchemaDraft draft,
+        HashSet<string> reachable,
+        Dictionary<string, HashSet<string>> resourceRootsByHash,
+        IReadOnlyDictionary<string, SubschemaInfo> uniqueSchemas,
+        Func<string, JsonElement, JsonElement?> resolveLocalRefInResource)
+    {
+        if (!node.TryGetProperty(keyword, out var refElem) ||
+            refElem.ValueKind != JsonValueKind.String)
+        {
+            return;
+        }
+
+        var refValue = refElem.GetString();
+        if (string.IsNullOrEmpty(refValue) || !refValue.StartsWith("#", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var target = resolveLocalRefInResource(refValue, resourceRoot);
+        if (target.HasValue)
+        {
+            Walk(target.Value, resourceRoot, resourceRootHash, draft, reachable, resourceRootsByHash, uniqueSchemas, resolveLocalRefInResource);
+        }
+    }
+
+    private static string DetectResourceRootHash(JsonElement node, string currentRootHash, SchemaDraft draft)
+    {
+        // Nested $id (Draft 2020-12) or id (Draft 4) opens a new resource.
+        var idKey = draft == SchemaDraft.Draft4 ? "id" : "$id";
+        if (node.TryGetProperty(idKey, out var idElem) && idElem.ValueKind == JsonValueKind.String)
+        {
+            return SchemaHasher.ComputeHash(node);
+        }
+        return currentRootHash;
+    }
+
+    private static void RecordResourceRoot(
+        Dictionary<string, HashSet<string>> map,
+        string subschemaHash,
+        string resourceRootHash)
+    {
+        if (!map.TryGetValue(subschemaHash, out var set))
+        {
+            set = new HashSet<string>(StringComparer.Ordinal);
+            map[subschemaHash] = set;
+        }
+        set.Add(resourceRootHash);
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TypeScriptCompilationResult.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TypeScriptCompilationResult.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+
+/// <summary>
+/// Result of invoking the TypeScript compiler.
+/// </summary>
+public sealed class TypeScriptCompilationResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public string? StandardOutput { get; init; }
+    public string? StandardError { get; init; }
+
+    public static TypeScriptCompilationResult Succeeded(string? standardOutput, string? standardError)
+    {
+        return new TypeScriptCompilationResult
+        {
+            Success = true,
+            StandardOutput = standardOutput,
+            StandardError = standardError
+        };
+    }
+
+    public static TypeScriptCompilationResult Failed(string error, string? standardOutput = null, string? standardError = null)
+    {
+        return new TypeScriptCompilationResult
+        {
+            Success = false,
+            Error = error,
+            StandardOutput = standardOutput,
+            StandardError = standardError
+        };
+    }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TypeScriptCompiler.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/TypeScript/TypeScriptCompiler.cs
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+
+/// <summary>
+/// Thin wrapper around the TypeScript compiler used by the TS-first JS pipeline.
+/// </summary>
+public static partial class TypeScriptCompiler
+{
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+    private const int MinimumMajorVersion = 5;
+    private const int MinimumMinorVersion = 0;
+
+    /// <summary>
+    /// Returns true when a TypeScript compiler executable can be found.
+    /// </summary>
+    public static bool IsAvailable(string tscExecutable = "tsc")
+    {
+        try
+        {
+            var result = RunTsc(
+                tscExecutable,
+                ["--version"],
+                workingDirectory: null,
+                timeoutMilliseconds: 10_000);
+            return result.ExitCode == 0 && IsSupportedVersionOutput(result.StandardOutput);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Compiles generated TypeScript modules to ESM JavaScript with an explicit tsc target.
+    /// </summary>
+    public static TypeScriptCompilationResult Compile(
+        IReadOnlyList<string> sourcePaths,
+        string outputDirectory,
+        string ecmaScriptTarget,
+        string tscExecutable = "tsc",
+        int timeoutMilliseconds = 60_000)
+    {
+        if (sourcePaths.Count == 0)
+        {
+            return TypeScriptCompilationResult.Failed("At least one TypeScript source path is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            return TypeScriptCompilationResult.Failed("An output directory is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(ecmaScriptTarget) ||
+            !TscTargetRegex().IsMatch(ecmaScriptTarget))
+        {
+            return TypeScriptCompilationResult.Failed(
+                $"Invalid ECMAScript target '{ecmaScriptTarget}'. Pass a tsc-compatible target such as ES2020 or ESNext.");
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+
+        var arguments = new List<string>
+        {
+            "--target", ecmaScriptTarget,
+            "--module", "ES2020",
+            "--moduleResolution", "Bundler",
+            "--lib", "ES2022,DOM",
+            "--outDir", outputDirectory,
+            "--noImplicitAny", "false",
+            "--strict", "false",
+            "--skipLibCheck", "true",
+            "--declaration", "false",
+            "--sourceMap", "false",
+            "--ignoreDeprecations", "6.0"
+        };
+        arguments.AddRange(sourcePaths);
+
+        try
+        {
+            var versionResult = RunTsc(
+                tscExecutable,
+                ["--version"],
+                workingDirectory: null,
+                timeoutMilliseconds: Math.Min(timeoutMilliseconds, 10_000));
+            if (versionResult.ExitCode != 0 || !IsSupportedVersionOutput(versionResult.StandardOutput))
+            {
+                var detectedVersion = string.IsNullOrWhiteSpace(versionResult.StandardOutput)
+                    ? "<unknown>"
+                    : versionResult.StandardOutput.Trim();
+                return TypeScriptCompilationResult.Failed(
+                    $"TypeScript compiler {MinimumMajorVersion}.{MinimumMinorVersion}+ is required for the TS codegen pipeline " +
+                    $"because it emits with --moduleResolution Bundler. Detected: {detectedVersion}",
+                    versionResult.StandardOutput,
+                    versionResult.StandardError);
+            }
+
+            var result = RunTsc(tscExecutable, arguments, workingDirectory: null, timeoutMilliseconds);
+            if (result.ExitCode == 0)
+            {
+                return TypeScriptCompilationResult.Succeeded(result.StandardOutput, result.StandardError);
+            }
+
+            return TypeScriptCompilationResult.Failed(
+                $"tsc failed with exit code {result.ExitCode}.",
+                result.StandardOutput,
+                result.StandardError);
+        }
+        catch (Exception ex)
+        {
+            return TypeScriptCompilationResult.Failed($"Failed to invoke tsc: {ex.Message}");
+        }
+    }
+
+    [GeneratedRegex("^[A-Za-z0-9_.-]+$", RegexOptions.CultureInvariant)]
+    private static partial Regex TscTargetRegex();
+
+    [GeneratedRegex(@"Version\s+(?<major>\d+)\.(?<minor>\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex TscVersionRegex();
+
+    private static bool IsSupportedVersionOutput(string output)
+    {
+        var match = TscVersionRegex().Match(output);
+        if (!match.Success ||
+            !int.TryParse(match.Groups["major"].Value, out var major) ||
+            !int.TryParse(match.Groups["minor"].Value, out var minor))
+        {
+            return false;
+        }
+
+        return major > MinimumMajorVersion ||
+               (major == MinimumMajorVersion && minor >= MinimumMinorVersion);
+    }
+
+    private static ProcessResult RunTsc(
+        string tscExecutable,
+        IReadOnlyList<string> arguments,
+        string? workingDirectory,
+        int timeoutMilliseconds)
+    {
+        var startInfo = CreateStartInfo(tscExecutable, arguments);
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        var startedAt = Stopwatch.GetTimestamp();
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start TypeScript compiler process.");
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(timeoutMilliseconds))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"TypeScript compiler did not finish within {timeoutMilliseconds} ms.");
+        }
+
+        var elapsedMilliseconds = (int)Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds;
+        var remainingMilliseconds = Math.Max(1, timeoutMilliseconds - elapsedMilliseconds);
+        if (!Task.WaitAll([standardOutputTask, standardErrorTask], remainingMilliseconds))
+        {
+            throw new TimeoutException($"TypeScript compiler output did not finish within {timeoutMilliseconds} ms.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            standardOutputTask.Result,
+            standardErrorTask.Result);
+    }
+
+    private static ProcessStartInfo CreateStartInfo(string tscExecutable, IReadOnlyList<string> arguments)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Utf8NoBom,
+                StandardErrorEncoding = Utf8NoBom
+            };
+            startInfo.ArgumentList.Add("/d");
+            startInfo.ArgumentList.Add("/s");
+            startInfo.ArgumentList.Add("/c");
+            startInfo.ArgumentList.Add(BuildWindowsCommand(tscExecutable, arguments));
+            return startInfo;
+        }
+
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = tscExecutable,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Utf8NoBom,
+            StandardErrorEncoding = Utf8NoBom
+        };
+        foreach (var arg in arguments)
+        {
+            processStartInfo.ArgumentList.Add(arg);
+        }
+        return processStartInfo;
+    }
+
+    private static string BuildWindowsCommand(string tscExecutable, IReadOnlyList<string> arguments)
+    {
+        var parts = new List<string> { QuoteWindowsArgument(tscExecutable) };
+        parts.AddRange(arguments.Select(QuoteWindowsArgument));
+        return string.Join(" ", parts);
+    }
+
+    private static string QuoteWindowsArgument(string value)
+    {
+        if (value.Length == 0)
+        {
+            return "\"\"";
+        }
+
+        if (!value.Any(c => char.IsWhiteSpace(c) || c == '"' || c == '&' || c == '|' || c == '<' || c == '>' || c == '^'))
+        {
+            return value;
+        }
+
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+
+    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsTestSuiteRunner.cs
@@ -38,18 +38,6 @@ public sealed class JsDraft202012SuiteFixture : IDisposable
         try { Directory.Delete(_moduleRoot, recursive: true); } catch { /* best effort */ }
     }
 
-    public static string? FindTestSuitePath()
-    {
-        var dir = AppContext.BaseDirectory;
-        for (var i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, "submodules", "JSON-Schema-Test-Suite");
-            if (Directory.Exists(Path.Combine(candidate, "tests"))) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        return null;
-    }
-
     private void WriteRegistryModule()
     {
         var registrations = BuildRemoteRegistrations();
@@ -77,7 +65,7 @@ public sealed class JsDraft202012SuiteFixture : IDisposable
 
     private List<RemoteRegistration> BuildRemoteRegistrations()
     {
-        var suitePath = FindTestSuitePath();
+        var suitePath = JsonSchemaTestSuiteHelpers.FindTestSuitePath();
         if (suitePath == null)
         {
             return [];
@@ -90,20 +78,20 @@ public sealed class JsDraft202012SuiteFixture : IDisposable
         }
 
         var pendingSchemas = new List<(Uri SchemaUri, string Content)>();
-        CollectRemotesFromPath(
+        JsonSchemaTestSuiteHelpers.CollectRemotesFromPath(
             pendingSchemas,
             Path.Combine(remotesPath, "draft2020-12"),
             "http://localhost:1234/draft2020-12/");
-        CollectRemotesFromPath(
+        JsonSchemaTestSuiteHelpers.CollectRemotesFromPath(
             pendingSchemas,
             Path.Combine(remotesPath, "draft2019-09"),
             "http://localhost:1234/draft2019-09/");
-        CollectRemotesFromPath(
+        JsonSchemaTestSuiteHelpers.CollectRemotesFromPath(
             pendingSchemas,
             remotesPath,
             "http://localhost:1234/",
             topLevelOnly: true);
-        CollectBundledDraft202012Schemas(pendingSchemas);
+        JsonSchemaTestSuiteHelpers.CollectBundledDraft202012Schemas(pendingSchemas);
 
         foreach (var (schemaUri, content) in pendingSchemas)
         {
@@ -149,197 +137,6 @@ public sealed class JsDraft202012SuiteFixture : IDisposable
         }
 
         return registrations;
-    }
-
-    private static void CollectRemotesFromPath(
-        List<(Uri SchemaUri, string Content)> schemas,
-        string path,
-        string baseUrl,
-        bool topLevelOnly = false)
-    {
-        if (!Directory.Exists(path))
-        {
-            return;
-        }
-
-        var searchOption = topLevelOnly ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
-        foreach (var file in Directory.GetFiles(path, "*.json", searchOption))
-        {
-            try
-            {
-                var content = File.ReadAllText(file);
-                var relativePath = Path.GetRelativePath(path, file).Replace("\\", "/");
-                var schemaUri = new Uri(baseUrl + relativePath);
-                content = InjectIdIfMissing(content, schemaUri.AbsoluteUri);
-                schemas.Add((schemaUri, content));
-                ExtractSelfContainedSubschemas(schemas, schemaUri, content);
-            }
-            catch
-            {
-                // Ignore malformed or unreadable remotes here; the suite cases
-                // that depend on them will still surface failures if needed.
-            }
-        }
-    }
-
-    private static void CollectBundledDraft202012Schemas(List<(Uri SchemaUri, string Content)> schemas)
-    {
-        var repoRoot = FindRepoRoot();
-        if (repoRoot == null)
-        {
-            return;
-        }
-
-        var dataPath = Path.Combine(repoRoot, "JsonSchemaValidation", "Draft202012", "Data");
-        if (!Directory.Exists(dataPath))
-        {
-            return;
-        }
-
-        foreach (var file in Directory.GetFiles(dataPath, "*.json", SearchOption.TopDirectoryOnly))
-        {
-            try
-            {
-                var content = File.ReadAllText(file);
-                using var doc = JsonDocument.Parse(content);
-                if (!doc.RootElement.TryGetProperty("$id", out var idElement) ||
-                    idElement.ValueKind != JsonValueKind.String ||
-                    string.IsNullOrEmpty(idElement.GetString()) ||
-                    !Uri.TryCreate(idElement.GetString(), UriKind.Absolute, out var schemaUri))
-                {
-                    continue;
-                }
-
-                schemas.Add((schemaUri, content));
-            }
-            catch
-            {
-                // Best effort preload; suite failures remain visible if this misses something.
-            }
-        }
-    }
-
-    private static string? FindRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        for (var i = 0; i < 8 && dir != null; i++)
-        {
-            if (Directory.Exists(Path.Combine(dir, "JsonSchemaValidation")) &&
-                Directory.Exists(Path.Combine(dir, "JsonSchemaValidation.CodeGenerator.Tests")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-        return null;
-    }
-
-    private static string InjectIdIfMissing(string content, string id)
-    {
-        try
-        {
-            // Parse to a mutable JsonNode tree, add $id first (so it appears
-            // near the top in re-serialized form), and emit back. Avoids the
-            // regex-insertion-with-trailing-comma fragility of string splicing
-            // — in particular, schemas like {"$schema": "..."} with no other
-            // properties used to produce invalid "...,}" output.
-            var node = System.Text.Json.Nodes.JsonNode.Parse(content);
-            if (node is not System.Text.Json.Nodes.JsonObject obj || obj.ContainsKey("$id"))
-            {
-                return content;
-            }
-
-            var reordered = new System.Text.Json.Nodes.JsonObject();
-            if (obj.ContainsKey("$schema"))
-            {
-                var schemaNode = obj["$schema"];
-                obj.Remove("$schema");
-                reordered["$schema"] = schemaNode?.DeepClone();
-            }
-            reordered["$id"] = id;
-            foreach (var (key, value) in obj.ToList())
-            {
-                reordered[key] = value?.DeepClone();
-            }
-            return reordered.ToJsonString();
-        }
-        catch
-        {
-            return content;
-        }
-    }
-
-    private static void ExtractSelfContainedSubschemas(
-        List<(Uri SchemaUri, string Content)> schemas,
-        Uri baseUri,
-        string content)
-    {
-        try
-        {
-            using var doc = JsonDocument.Parse(content);
-            var root = doc.RootElement;
-            if (root.ValueKind != JsonValueKind.Object)
-            {
-                return;
-            }
-
-            if (root.TryGetProperty("$defs", out var defs) && defs.ValueKind == JsonValueKind.Object)
-            {
-                foreach (var def in defs.EnumerateObject())
-                {
-                    var subschemaContent = def.Value.GetRawText();
-                    if (!subschemaContent.Contains("\"$ref\"", StringComparison.Ordinal) &&
-                        !subschemaContent.Contains("\"$dynamicRef\"", StringComparison.Ordinal))
-                    {
-                        schemas.Add((new Uri($"{baseUri.GetLeftPart(UriPartial.Query)}#/$defs/{def.Name}"), subschemaContent));
-                    }
-                }
-            }
-
-            ExtractSelfContainedAnchors(schemas, baseUri, root);
-        }
-        catch
-        {
-            // Ignore parse failures during best-effort fragment extraction.
-        }
-    }
-
-    private static void ExtractSelfContainedAnchors(
-        List<(Uri SchemaUri, string Content)> schemas,
-        Uri baseUri,
-        JsonElement element)
-    {
-        if (element.ValueKind != JsonValueKind.Object)
-        {
-            return;
-        }
-
-        var content = element.GetRawText();
-        if (!content.Contains("\"$ref\"", StringComparison.Ordinal) &&
-            !content.Contains("\"$dynamicRef\"", StringComparison.Ordinal))
-        {
-            if (element.TryGetProperty("$anchor", out var anchor) &&
-                anchor.ValueKind == JsonValueKind.String &&
-                !string.IsNullOrEmpty(anchor.GetString()))
-            {
-                schemas.Add((new Uri($"{baseUri.GetLeftPart(UriPartial.Query)}#{anchor.GetString()}"), content));
-            }
-
-            if (element.TryGetProperty("$dynamicAnchor", out var dynamicAnchor) &&
-                dynamicAnchor.ValueKind == JsonValueKind.String &&
-                !string.IsNullOrEmpty(dynamicAnchor.GetString()))
-            {
-                schemas.Add((new Uri($"{baseUri.GetLeftPart(UriPartial.Query)}#{dynamicAnchor.GetString()}"), content));
-            }
-        }
-
-        if (element.TryGetProperty("$defs", out var defs) && defs.ValueKind == JsonValueKind.Object)
-        {
-            foreach (var def in defs.EnumerateObject())
-            {
-                ExtractSelfContainedAnchors(schemas, baseUri, def.Value);
-            }
-        }
     }
 
     private sealed record RemoteRegistration(string Uri, string ModuleName);
@@ -490,15 +287,15 @@ public class JsTestSuiteRunner : IClassFixture<JsDraft202012SuiteFixture>
     public void Draft4(TestCase tc) => RunCase(tc);
 
     public static IEnumerable<object[]> Draft202012Cases() =>
-        EnumerateKeywordCases("draft2020-12", Draft202012Keywords, SchemaDraft.Draft202012, formatAssertionEnabled: false)
+        JsonSchemaTestSuiteHelpers.EnumerateKeywordCases("draft2020-12", Draft202012Keywords, SchemaDraft.Draft202012, formatAssertionEnabled: false)
             .Select(tc => new object[] { tc });
 
     public static IEnumerable<object[]> Draft202012FormatAssertionCases() =>
-        EnumerateKeywordCases("draft2020-12", Draft202012FormatAssertionKeywords, SchemaDraft.Draft202012, formatAssertionEnabled: true)
+        JsonSchemaTestSuiteHelpers.EnumerateKeywordCases("draft2020-12", Draft202012FormatAssertionKeywords, SchemaDraft.Draft202012, formatAssertionEnabled: true)
             .Select(tc => new object[] { tc });
 
     public static IEnumerable<object[]> Draft4Cases() =>
-        EnumerateKeywordCases("draft4", Draft4Keywords, SchemaDraft.Draft4, formatAssertionEnabled: false)
+        JsonSchemaTestSuiteHelpers.EnumerateKeywordCases("draft4", Draft4Keywords, SchemaDraft.Draft4, formatAssertionEnabled: false)
             .Select(tc => new object[] { tc });
 
     private void RunCase(TestCase tc)
@@ -548,69 +345,6 @@ public class JsTestSuiteRunner : IClassFixture<JsDraft202012SuiteFixture>
         {
             try { File.Delete(validatorPath); } catch { /* best effort */ }
         }
-    }
-
-    private static IEnumerable<TestCase> EnumerateKeywordCases(
-        string draftFolder,
-        IEnumerable<string> keywords,
-        SchemaDraft draft,
-        bool formatAssertionEnabled)
-    {
-        var suitePath = JsDraft202012SuiteFixture.FindTestSuitePath();
-        if (suitePath == null)
-        {
-            yield return TestCase.MissingSuite(draft, formatAssertionEnabled);
-            yield break;
-        }
-
-        var root = Path.Combine(suitePath, "tests", draftFolder);
-        if (!Directory.Exists(root))
-        {
-            yield break;
-        }
-
-        var wanted = keywords
-            .Select(NormalizeKeyword)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var file in Directory.GetFiles(root, "*.json", SearchOption.AllDirectories))
-        {
-            var relative = Path.GetRelativePath(root, file).Replace("\\", "/");
-            var relativeNoExt = NormalizeKeyword(relative);
-            if (!wanted.Contains(relativeNoExt))
-            {
-                continue;
-            }
-
-            var json = File.ReadAllText(file);
-            using var doc = JsonDocument.Parse(json);
-            foreach (var group in doc.RootElement.EnumerateArray())
-            {
-                var groupDesc = group.GetProperty("description").GetString() ?? string.Empty;
-                var schema = group.GetProperty("schema").GetRawText();
-                foreach (var test in group.GetProperty("tests").EnumerateArray())
-                {
-                    yield return new TestCase(
-                        draft,
-                        relative,
-                        relativeNoExt,
-                        groupDesc,
-                        test.GetProperty("description").GetString() ?? string.Empty,
-                        schema,
-                        test.GetProperty("data").GetRawText(),
-                        test.GetProperty("valid").GetBoolean(),
-                        formatAssertionEnabled);
-                }
-            }
-        }
-    }
-
-    private static string NormalizeKeyword(string keyword)
-    {
-        var normalized = keyword.Replace("\\", "/").TrimStart('/');
-        return normalized.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
-            ? normalized[..^5]
-            : normalized;
     }
 
     public sealed record TestCase(

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaTestSuiteHelpers.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaTestSuiteHelpers.cs
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+internal static class JsonSchemaTestSuiteHelpers
+{
+    public static string? FindTestSuitePath()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "submodules", "JSON-Schema-Test-Suite");
+            if (Directory.Exists(Path.Combine(candidate, "tests"))) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+
+    public static void CollectRemotesFromPath(
+        List<(Uri SchemaUri, string Content)> schemas,
+        string path,
+        string baseUrl,
+        bool topLevelOnly = false)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        var searchOption = topLevelOnly ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
+        foreach (var file in Directory.GetFiles(path, "*.json", searchOption))
+        {
+            try
+            {
+                var content = File.ReadAllText(file);
+                var relativePath = Path.GetRelativePath(path, file).Replace("\\", "/");
+                var schemaUri = new Uri(baseUrl + relativePath);
+                content = InjectIdIfMissing(content, schemaUri.AbsoluteUri);
+                schemas.Add((schemaUri, content));
+                ExtractSelfContainedSubschemas(schemas, schemaUri, content);
+            }
+            catch
+            {
+                // Ignore malformed or unreadable remotes here; suite cases that
+                // depend on them still surface failures if needed.
+            }
+        }
+    }
+
+    public static void CollectBundledDraft202012Schemas(List<(Uri SchemaUri, string Content)> schemas)
+    {
+        var repoRoot = FindRepoRoot();
+        if (repoRoot == null)
+        {
+            return;
+        }
+
+        var dataPath = Path.Combine(repoRoot, "JsonSchemaValidation", "Draft202012", "Data");
+        if (!Directory.Exists(dataPath))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.GetFiles(dataPath, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            try
+            {
+                var content = File.ReadAllText(file);
+                using var doc = JsonDocument.Parse(content);
+                if (!doc.RootElement.TryGetProperty("$id", out var idElement) ||
+                    idElement.ValueKind != JsonValueKind.String ||
+                    string.IsNullOrEmpty(idElement.GetString()) ||
+                    !Uri.TryCreate(idElement.GetString(), UriKind.Absolute, out var schemaUri))
+                {
+                    continue;
+                }
+
+                schemas.Add((schemaUri, content));
+            }
+            catch
+            {
+                // Best effort preload; suite failures remain visible if this misses something.
+            }
+        }
+    }
+
+    public static IEnumerable<JsTestSuiteRunner.TestCase> EnumerateKeywordCases(
+        string draftFolder,
+        IEnumerable<string> keywords,
+        SchemaDraft draft,
+        bool formatAssertionEnabled)
+    {
+        var suitePath = FindTestSuitePath();
+        if (suitePath == null)
+        {
+            yield return JsTestSuiteRunner.TestCase.MissingSuite(draft, formatAssertionEnabled);
+            yield break;
+        }
+
+        var root = Path.Combine(suitePath, "tests", draftFolder);
+        if (!Directory.Exists(root))
+        {
+            yield break;
+        }
+
+        var wanted = keywords
+            .Select(NormalizeKeyword)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.GetFiles(root, "*.json", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, file).Replace("\\", "/");
+            var relativeNoExt = NormalizeKeyword(relative);
+            if (!wanted.Contains(relativeNoExt))
+            {
+                continue;
+            }
+
+            var json = File.ReadAllText(file);
+            using var doc = JsonDocument.Parse(json);
+            foreach (var group in doc.RootElement.EnumerateArray())
+            {
+                var groupDesc = group.GetProperty("description").GetString() ?? string.Empty;
+                var schema = group.GetProperty("schema").GetRawText();
+                foreach (var test in group.GetProperty("tests").EnumerateArray())
+                {
+                    yield return new JsTestSuiteRunner.TestCase(
+                        draft,
+                        relative,
+                        relativeNoExt,
+                        groupDesc,
+                        test.GetProperty("description").GetString() ?? string.Empty,
+                        schema,
+                        test.GetProperty("data").GetRawText(),
+                        test.GetProperty("valid").GetBoolean(),
+                        formatAssertionEnabled);
+                }
+            }
+        }
+    }
+
+    private static string? FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            if (Directory.Exists(Path.Combine(dir, "JsonSchemaValidation")) &&
+                Directory.Exists(Path.Combine(dir, "JsonSchemaValidation.CodeGenerator.Tests")))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+
+    private static string InjectIdIfMissing(string content, string id)
+    {
+        try
+        {
+            var node = JsonNode.Parse(content);
+            if (node is not JsonObject obj || obj.ContainsKey("$id"))
+            {
+                return content;
+            }
+
+            var reordered = new JsonObject();
+            if (obj.ContainsKey("$schema"))
+            {
+                var schemaNode = obj["$schema"];
+                obj.Remove("$schema");
+                reordered["$schema"] = schemaNode?.DeepClone();
+            }
+            reordered["$id"] = id;
+            foreach (var (key, value) in obj.ToList())
+            {
+                reordered[key] = value?.DeepClone();
+            }
+            return reordered.ToJsonString();
+        }
+        catch
+        {
+            return content;
+        }
+    }
+
+    private static void ExtractSelfContainedSubschemas(
+        List<(Uri SchemaUri, string Content)> schemas,
+        Uri baseUri,
+        string content)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+
+            if (root.TryGetProperty("$defs", out var defs) && defs.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var def in defs.EnumerateObject())
+                {
+                    var subschemaContent = def.Value.GetRawText();
+                    if (!subschemaContent.Contains("\"$ref\"", StringComparison.Ordinal) &&
+                        !subschemaContent.Contains("\"$dynamicRef\"", StringComparison.Ordinal))
+                    {
+                        schemas.Add((new Uri($"{baseUri.GetLeftPart(UriPartial.Query)}#/$defs/{def.Name}"), subschemaContent));
+                    }
+                }
+            }
+
+            ExtractSelfContainedAnchors(schemas, baseUri, root);
+        }
+        catch
+        {
+            // Ignore parse failures during best-effort fragment extraction.
+        }
+    }
+
+    private static void ExtractSelfContainedAnchors(
+        List<(Uri SchemaUri, string Content)> schemas,
+        Uri baseUri,
+        JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var content = element.GetRawText();
+        if (!content.Contains("\"$ref\"", StringComparison.Ordinal) &&
+            !content.Contains("\"$dynamicRef\"", StringComparison.Ordinal))
+        {
+            if (element.TryGetProperty("$anchor", out var anchor) &&
+                anchor.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(anchor.GetString()))
+            {
+                schemas.Add((new Uri($"{baseUri.GetLeftPart(UriPartial.Query)}#{anchor.GetString()}"), content));
+            }
+
+            if (element.TryGetProperty("$dynamicAnchor", out var dynamicAnchor) &&
+                dynamicAnchor.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(dynamicAnchor.GetString()))
+            {
+                schemas.Add((new Uri($"{baseUri.GetLeftPart(UriPartial.Query)}#{dynamicAnchor.GetString()}"), content));
+            }
+        }
+
+        if (element.TryGetProperty("$defs", out var defs) && defs.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var def in defs.EnumerateObject())
+            {
+                ExtractSelfContainedAnchors(schemas, baseUri, def.Value);
+            }
+        }
+    }
+
+    private static string NormalizeKeyword(string keyword)
+    {
+        var normalized = keyword.Replace("\\", "/").TrimStart('/');
+        return normalized.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+            ? normalized[..^5]
+            : normalized;
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/TsSchemaCodeGeneratorTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/TsSchemaCodeGeneratorTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+using Jint;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+public class TsSchemaCodeGeneratorTests
+{
+    private readonly TsSchemaCodeGenerator _generator = new();
+
+    [Fact]
+    public void Generate_SimpleSchema_EmitsTypeScriptModule()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""{ "type": "string" }""").RootElement);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("validator.ts", result.FileName);
+        Assert.Contains("TypeScript target", result.GeneratedCode);
+        Assert.DoesNotContain("@ts-nocheck", result.GeneratedCode);
+        Assert.Contains("type JsonValue", result.GeneratedCode);
+        Assert.Contains("export function validate(data: JsonValue): boolean", result.GeneratedCode);
+        Assert.Contains("export default", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_PreservesRuntimeImportSpecifierForTscOutput()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""{ "minLength": 2 }""").RootElement);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("""from "./jsv-runtime.js";""", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Compile_WithTscAvailable_ProducesExecutableJavaScript()
+    {
+        if (!TypeScriptCompiler.IsAvailable())
+        {
+            throw Xunit.Sdk.SkipException.ForSkip("TypeScript compiler 'tsc' is required for this test.");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-ts-test-" + Guid.NewGuid().ToString("N"));
+        var outputDir = Path.Combine(tempDir, "out");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var result = _generator.Generate(JsonDocument.Parse("""{ "type": "integer", "minimum": 3 }""").RootElement);
+            Assert.True(result.Success, result.Error);
+
+            var validatorPath = Path.Combine(tempDir, result.FileName!);
+            var runtimePath = Path.Combine(tempDir, TsRuntime.FileName);
+            File.WriteAllText(validatorPath, result.GeneratedCode);
+            File.WriteAllText(runtimePath, TsRuntime.GetSource());
+
+            var compileResult = TypeScriptCompiler.Compile(
+                [validatorPath, runtimePath],
+                outputDir,
+                ecmaScriptTarget: "ES2020");
+
+            Assert.True(compileResult.Success, compileResult.Error);
+
+            var engine = new Engine(opts => opts.EnableModules(outputDir));
+            var module = engine.Modules.Import("./validator.js");
+            var validate = module.Get("validate");
+
+            Assert.True(engine.Invoke(validate, 4).AsBoolean());
+            Assert.False(engine.Invoke(validate, 2).AsBoolean());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Compile_WithTscAvailable_SupportsLowerEcmaScriptTarget()
+    {
+        if (!TypeScriptCompiler.IsAvailable())
+        {
+            throw Xunit.Sdk.SkipException.ForSkip("TypeScript compiler 'tsc' is required for this test.");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-ts-es5-test-" + Guid.NewGuid().ToString("N"));
+        var outputDir = Path.Combine(tempDir, "out");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var result = _generator.Generate(JsonDocument.Parse("""{ "type": "string" }""").RootElement);
+            Assert.True(result.Success, result.Error);
+
+            var validatorPath = Path.Combine(tempDir, result.FileName!);
+            var runtimePath = Path.Combine(tempDir, TsRuntime.FileName);
+            File.WriteAllText(validatorPath, result.GeneratedCode);
+            File.WriteAllText(runtimePath, TsRuntime.GetSource());
+
+            var compileResult = TypeScriptCompiler.Compile(
+                [validatorPath, runtimePath],
+                outputDir,
+                ecmaScriptTarget: "ES5");
+
+            Assert.True(compileResult.Success, compileResult.Error);
+            Assert.True(File.Exists(Path.Combine(outputDir, "validator.js")));
+            Assert.True(File.Exists(Path.Combine(outputDir, "jsv-runtime.js")));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Compile_WithTscAvailable_FollowsPointerRefInsideNestedResource()
+    {
+        if (!TypeScriptCompiler.IsAvailable())
+        {
+            throw Xunit.Sdk.SkipException.ForSkip("TypeScript compiler 'tsc' is required for this test.");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-ts-anchor-ref-test-" + Guid.NewGuid().ToString("N"));
+        var outputDir = Path.Combine(tempDir, "out");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            using var schema = JsonDocument.Parse("""
+                {
+                  "properties": {
+                    "x": {
+                      "$id": "https://example.com/nested",
+                      "$ref": "#/x-target",
+                      "x-target": { "type": "string" }
+                    }
+                  }
+                }
+                """);
+            var result = _generator.Generate(schema.RootElement.Clone());
+            Assert.True(result.Success, result.Error);
+
+            var validatorPath = Path.Combine(tempDir, result.FileName!);
+            var runtimePath = Path.Combine(tempDir, TsRuntime.FileName);
+            File.WriteAllText(validatorPath, result.GeneratedCode);
+            File.WriteAllText(runtimePath, TsRuntime.GetSource());
+
+            var compileResult = TypeScriptCompiler.Compile(
+                [validatorPath, runtimePath],
+                outputDir,
+                ecmaScriptTarget: "ES2020");
+
+            Assert.True(compileResult.Success, compileResult.Error);
+
+            var engine = new Engine(opts => opts.EnableModules(outputDir));
+            var module = engine.Modules.Import("./validator.js");
+            var validate = module.Get("validate");
+            var valid = engine.Evaluate("""JSON.parse("{\"x\":\"ok\"}")""");
+            var invalid = engine.Evaluate("""JSON.parse("{\"x\":42}")""");
+
+            Assert.True(engine.Invoke(validate, valid).AsBoolean());
+            Assert.False(engine.Invoke(validate, invalid).AsBoolean());
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RuntimeProjection_InsertsNoCheckPragma()
+    {
+        var source = TsRuntime.GetSource();
+
+        Assert.StartsWith("// @ts-nocheck", source);
+        Assert.Contains("// jsv-runtime.ts", source);
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/TsTestSuiteRunner.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/TsTestSuiteRunner.cs
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
+using Jint;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+/// <summary>
+/// Precompiles the Draft 2020-12 JSON-Schema-Test-Suite through the TypeScript
+/// generator and tsc. The per-case tests execute the compiled JS output, so this
+/// proves the TS-first pipeline rather than the direct JS emitter.
+/// </summary>
+public sealed class TsDraft202012SuiteFixture : IDisposable
+{
+    private const int TscBatchSize = 20;
+
+    private readonly string _moduleRoot;
+    private readonly string _sourceRoot;
+    private readonly Dictionary<string, string> _externalSchemaDocuments = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _compiledModulesByCaseKey = new(StringComparer.Ordinal);
+
+    public TsDraft202012SuiteFixture()
+    {
+        if (!TypeScriptCompiler.IsAvailable())
+        {
+            throw Xunit.Sdk.SkipException.ForSkip(
+                "TypeScript compiler 'tsc' is required for the TS JSON-Schema-Test-Suite runner.");
+        }
+
+        _moduleRoot = Path.Combine(Path.GetTempPath(), "jsv-ts-suite-fixture-" + Guid.NewGuid().ToString("N"));
+        _sourceRoot = Path.Combine(_moduleRoot, "ts-src");
+        Directory.CreateDirectory(_sourceRoot);
+        File.WriteAllText(Path.Combine(_sourceRoot, TsRuntime.FileName), TsRuntime.GetSource());
+
+        var sourcePaths = new List<string>();
+        var (remoteSourcePaths, remoteRegistrations) = GenerateRemoteSources();
+        sourcePaths.AddRange(remoteSourcePaths);
+        WriteRegistryModule(remoteRegistrations);
+        sourcePaths.AddRange(GenerateSuiteValidatorSources());
+        CompileSources(sourcePaths);
+    }
+
+    public string ModuleRoot => _moduleRoot;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_moduleRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    public string GetCompiledModuleFile(JsTestSuiteRunner.TestCase testCase)
+    {
+        return _compiledModulesByCaseKey[GetCaseKey(testCase)];
+    }
+
+    private (List<string> SourcePaths, List<RemoteRegistration> Registrations) GenerateRemoteSources()
+    {
+        var pendingSchemas = new List<(Uri SchemaUri, string Content)>();
+        var suitePath = JsonSchemaTestSuiteHelpers.FindTestSuitePath();
+        if (suitePath == null)
+        {
+            return ([], []);
+        }
+
+        var remotesPath = Path.Combine(suitePath, "remotes");
+        JsonSchemaTestSuiteHelpers.CollectRemotesFromPath(
+            pendingSchemas,
+            Path.Combine(remotesPath, "draft2020-12"),
+            "http://localhost:1234/draft2020-12/");
+        JsonSchemaTestSuiteHelpers.CollectRemotesFromPath(
+            pendingSchemas,
+            Path.Combine(remotesPath, "draft2019-09"),
+            "http://localhost:1234/draft2019-09/");
+        JsonSchemaTestSuiteHelpers.CollectRemotesFromPath(
+            pendingSchemas,
+            remotesPath,
+            "http://localhost:1234/",
+            topLevelOnly: true);
+        JsonSchemaTestSuiteHelpers.CollectBundledDraft202012Schemas(pendingSchemas);
+
+        foreach (var (schemaUri, content) in pendingSchemas)
+        {
+            _externalSchemaDocuments[schemaUri.AbsoluteUri] = content;
+        }
+
+        var generator = new TsSchemaCodeGenerator
+        {
+            AlwaysTrackAnnotations = true,
+            ExternalSchemaDocuments = _externalSchemaDocuments
+        };
+        var sourcePaths = new List<string>();
+        var registrations = new List<RemoteRegistration>();
+        var seenUris = new HashSet<string>(StringComparer.Ordinal);
+        var index = 0;
+
+        foreach (var (schemaUri, content) in pendingSchemas)
+        {
+            if (!seenUris.Add(schemaUri.AbsoluteUri))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(content);
+                var result = generator.Generate(doc.RootElement.Clone(), sourcePath: $"remote_{index}.json");
+                if (!result.Success)
+                {
+                    continue;
+                }
+
+                var moduleName = $"remote_{index}.ts";
+                var sourcePath = Path.Combine(_sourceRoot, moduleName);
+                File.WriteAllText(sourcePath, result.GeneratedCode!);
+                sourcePaths.Add(sourcePath);
+                registrations.Add(new RemoteRegistration(schemaUri.AbsoluteUri, Path.ChangeExtension(moduleName, ".js")));
+                index++;
+            }
+            catch
+            {
+                // Remote preload is best effort. Cases that require unsupported
+                // remotes fail visibly when the registry cannot resolve them.
+            }
+        }
+
+        return (sourcePaths, registrations);
+    }
+
+    private List<string> GenerateSuiteValidatorSources()
+    {
+        var cases = EnumerateCasesForPrecompile()
+            .Where(tc => !tc.IsMissingSuiteSentinel)
+            .GroupBy(GetCaseKey, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToList();
+
+        var sourcePaths = new List<string>(cases.Count);
+        var index = 0;
+        foreach (var testCase in cases)
+        {
+            var generator = new TsSchemaCodeGenerator
+            {
+                DefaultDraft = testCase.Draft,
+                FormatAssertionEnabled = testCase.FormatAssertionEnabled,
+                ExternalSchemaDocuments = _externalSchemaDocuments
+            };
+
+            using var schemaDoc = JsonDocument.Parse(testCase.SchemaJson);
+            var result = generator.Generate(schemaDoc.RootElement.Clone(), sourcePath: $"validator_{index}.json");
+            if (!result.Success)
+            {
+                throw new InvalidOperationException($"TS codegen failed for {testCase}: {result.Error}");
+            }
+
+            var moduleName = $"validator_{index}.ts";
+            var sourcePath = Path.Combine(_sourceRoot, moduleName);
+            File.WriteAllText(sourcePath, result.GeneratedCode!);
+            sourcePaths.Add(sourcePath);
+            _compiledModulesByCaseKey[GetCaseKey(testCase)] = Path.ChangeExtension(moduleName, ".js");
+            index++;
+        }
+
+        return sourcePaths;
+    }
+
+    private void CompileSources(IReadOnlyList<string> sourcePaths)
+    {
+        var runtimePath = Path.Combine(_sourceRoot, TsRuntime.FileName);
+        foreach (var batch in sourcePaths.Chunk(TscBatchSize))
+        {
+            var compileResult = TypeScriptCompiler.Compile(
+                [runtimePath, .. batch],
+                _moduleRoot,
+                ecmaScriptTarget: "ES2020",
+                timeoutMilliseconds: 240_000);
+            if (!compileResult.Success)
+            {
+                throw new InvalidOperationException(
+                    $"TypeScript suite compilation failed: {compileResult.Error}\n{compileResult.StandardError}\n{compileResult.StandardOutput}");
+            }
+        }
+    }
+
+    private void WriteRegistryModule(IReadOnlyList<RemoteRegistration> remoteRegistrations)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// Auto-generated by TsDraft202012SuiteFixture.");
+        sb.AppendLine("import { Registry } from \"./jsv-runtime.js\";");
+
+        for (var i = 0; i < remoteRegistrations.Count; i++)
+        {
+            sb.AppendLine($"import remote_{i}, {{ fragmentValidators as remoteFragments_{i} }} from \"./{remoteRegistrations[i].ModuleName}\";");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("const registry = new Registry();");
+        for (var i = 0; i < remoteRegistrations.Count; i++)
+        {
+            sb.AppendLine($"registry.registerForUri({JsonSerializer.Serialize(remoteRegistrations[i].Uri)}, remote_{i});");
+            sb.AppendLine($"for (const [uri, validator] of Object.entries(remoteFragments_{i})) registry.registerForUri(uri, validator);");
+        }
+        sb.AppendLine();
+        sb.AppendLine("export default registry;");
+
+        File.WriteAllText(Path.Combine(_moduleRoot, "registry.js"), sb.ToString());
+    }
+
+    private static IEnumerable<JsTestSuiteRunner.TestCase> EnumerateCasesForPrecompile()
+    {
+        return JsTestSuiteRunner.Draft202012Cases()
+            .Concat(JsTestSuiteRunner.Draft202012FormatAssertionCases())
+            .Select(row => (JsTestSuiteRunner.TestCase)row[0]);
+    }
+
+    private static string GetCaseKey(JsTestSuiteRunner.TestCase testCase)
+    {
+        var input = $"{testCase.Draft}|{testCase.FormatAssertionEnabled}|{testCase.SchemaJson}";
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes);
+    }
+
+    private sealed record RemoteRegistration(string Uri, string ModuleName);
+}
+
+public class TsTestSuiteRunner : IClassFixture<TsDraft202012SuiteFixture>
+{
+    private readonly TsDraft202012SuiteFixture _fixture;
+
+    public TsTestSuiteRunner(TsDraft202012SuiteFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [MemberData(nameof(Draft202012Cases))]
+    public void Draft202012(JsTestSuiteRunner.TestCase tc) => RunCase(tc);
+
+    [Theory]
+    [MemberData(nameof(Draft202012FormatAssertionCases))]
+    public void Draft202012FormatAssertion(JsTestSuiteRunner.TestCase tc) => RunCase(tc);
+
+    public static IEnumerable<object[]> Draft202012Cases() => JsTestSuiteRunner.Draft202012Cases();
+
+    public static IEnumerable<object[]> Draft202012FormatAssertionCases() => JsTestSuiteRunner.Draft202012FormatAssertionCases();
+
+    private void RunCase(JsTestSuiteRunner.TestCase tc)
+    {
+        if (tc.IsMissingSuiteSentinel)
+        {
+            Assert.Fail(
+                "JSON-Schema-Test-Suite submodule is not available on this machine. " +
+                "Run 'git submodule update --init' before running the TS suite runner.");
+        }
+
+        var moduleFile = _fixture.GetCompiledModuleFile(tc);
+        var engine = new Engine(opts => opts.EnableModules(_fixture.ModuleRoot));
+        var registry = engine.Modules.Import("./registry.js").Get("default");
+        var module = engine.Modules.Import("./" + moduleFile);
+        var validate = module.Get("validate");
+
+        var parsed = engine.Evaluate($"JSON.parse({JsTestHelpers.ToJsStringLiteral(tc.DataJson)})");
+        var verdictRaw = engine.Invoke(validate, parsed, registry);
+        Assert.True(verdictRaw.IsBoolean(), $"Non-boolean verdict for {tc}");
+        var actual = verdictRaw.AsBoolean();
+        Assert.True(actual == tc.Expected,
+            $"{tc}\nExpected: {tc.Expected}, Got: {actual}\nSchema: {tc.SchemaJson}\nData: {tc.DataJson}");
+    }
+}

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
 using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
 using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.TypeScript;
 using FormFinch.JsonSchemaValidation.Common;
 
 namespace FormFinch.JsonSchemaValidation.CodeGenerator;
@@ -27,6 +28,7 @@ internal static class Program
         {
             "generate" => HandleGenerate(remainingArgs),
             "generate-js" => HandleGenerateJs(remainingArgs),
+            "generate-ts" => HandleGenerateTs(remainingArgs),
             "generate-metaschemas" => HandleGenerateMetaschemas(remainingArgs),
             "compile-test-schemas" => HandleCompileTestSchemas(remainingArgs),
             "analyze" => HandleAnalyze(remainingArgs),
@@ -45,6 +47,7 @@ internal static class Program
             Commands:
               generate              Generate compiled C# validator from schema file
               generate-js           Generate compiled JavaScript (ESM) validator from schema file
+              generate-ts           Generate compiled TypeScript (ESM) validator from schema file
               generate-metaschemas  Generate compiled validators for all metaschemas
               compile-test-schemas  Generate compiled validators for JSON-Schema-Test-Suite schemas
               analyze               Analyze schema for compilation compatibility
@@ -58,8 +61,18 @@ internal static class Program
             generate-js options:
               -s, --schema <path>    Input schema file (required)
               -o, --output <path>    Output directory (required). Emits <schema>.js and jsv-runtime.js.
+              --pipeline <mode>      JS emission pipeline: direct (default) or typescript.
+              --ecmascript-target <target>
+                                     tsc target for --pipeline typescript (default: ES2020).
+              --tsc <path>           TypeScript compiler executable for --pipeline typescript (default: tsc).
               --assert-format       Assert supported format values for Draft 2020-12.
               --no-runtime           Skip writing jsv-runtime.js (useful when runtime is already present).
+
+            generate-ts options:
+              -s, --schema <path>    Input schema file (required)
+              -o, --output <path>    Output directory (required). Emits <schema>.ts and jsv-runtime.ts.
+              --assert-format        Assert supported format values for Draft 2020-12.
+              --no-runtime           Skip writing jsv-runtime.ts.
 
             generate-js supported scope:
               - Drafts: 2020-12, 2019-09, and 4 (other drafts rejected pre-emission).
@@ -89,6 +102,8 @@ internal static class Program
             Examples:
               jsv-codegen generate -s schema.json -o ./Generated/
               jsv-codegen generate-js -s schema.json -o ./src/validators/
+              jsv-codegen generate-js -s schema.json -o ./src/validators/ --pipeline typescript --ecmascript-target ES2020
+              jsv-codegen generate-ts -s schema.json -o ./src/validators/
               jsv-codegen generate-metaschemas -o ./Generated/ -l ../JsonSchemaValidation
               jsv-codegen compile-test-schemas -t ./submodules/JSON-Schema-Test-Suite -o ./Generated/
               jsv-codegen analyze -s schema.json
@@ -182,6 +197,232 @@ internal static class Program
         string? outputPath = null;
         var writeRuntime = true;
         var formatAssertionEnabled = false;
+        var pipeline = "direct";
+        var ecmaScriptTarget = "ES2020";
+        var tscExecutable = "tsc";
+        var ecmaScriptTargetSpecified = false;
+        var tscSpecified = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            var nextArg = i + 1 < args.Length ? args[i + 1] : null;
+            switch (arg)
+            {
+                case "-s":
+                case "--schema":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
+                    schemaPath = nextArg;
+                    i++;
+                    break;
+                case "-o":
+                case "--output":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
+                    outputPath = nextArg;
+                    i++;
+                    break;
+                case "--no-runtime":
+                    writeRuntime = false;
+                    break;
+                case "--assert-format":
+                    formatAssertionEnabled = true;
+                    break;
+                case "--pipeline":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
+                    pipeline = nextArg!;
+                    i++;
+                    break;
+                case "--ecmascript-target":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
+                    ecmaScriptTarget = nextArg!;
+                    ecmaScriptTargetSpecified = true;
+                    i++;
+                    break;
+                case "--tsc":
+                    if (!IsOptionValue(nextArg))
+                    {
+                        Console.Error.WriteLine($"Error: Option {arg} requires a value.");
+                        return 1;
+                    }
+                    tscExecutable = nextArg!;
+                    tscSpecified = true;
+                    i++;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(schemaPath))
+        {
+            Console.Error.WriteLine("Error: Schema path is required (-s, --schema)");
+            return 1;
+        }
+        if (string.IsNullOrEmpty(outputPath))
+        {
+            Console.Error.WriteLine("Error: Output path is required (-o, --output)");
+            return 1;
+        }
+        if (!File.Exists(schemaPath))
+        {
+            Console.Error.WriteLine($"Error: Schema file not found: {schemaPath}");
+            return 1;
+        }
+        if (!Directory.Exists(outputPath))
+        {
+            Directory.CreateDirectory(outputPath);
+        }
+
+        Console.WriteLine($"Generating JS validator for: {schemaPath}");
+        Console.WriteLine($"Output directory: {outputPath}");
+
+        if (string.Equals(pipeline, "typescript", StringComparison.OrdinalIgnoreCase))
+        {
+            return HandleGenerateJsFromTypeScript(
+                schemaPath,
+                outputPath,
+                writeRuntime,
+                formatAssertionEnabled,
+                ecmaScriptTarget,
+                tscExecutable);
+        }
+
+        if (!string.Equals(pipeline, "direct", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine($"Error: Unsupported JS generation pipeline: {pipeline}. Expected 'direct' or 'typescript'.");
+            return 1;
+        }
+
+        if (ecmaScriptTargetSpecified || tscSpecified)
+        {
+            var optionNames = new List<string>();
+            if (ecmaScriptTargetSpecified) optionNames.Add("--ecmascript-target");
+            if (tscSpecified) optionNames.Add("--tsc");
+            var verb = optionNames.Count == 1 ? "requires" : "require";
+            Console.Error.WriteLine($"Error: {string.Join(" and ", optionNames)} {verb} --pipeline typescript.");
+            return 1;
+        }
+
+        var generator = new JsSchemaCodeGenerator
+        {
+            FormatAssertionEnabled = formatAssertionEnabled
+        };
+        var result = generator.Generate(schemaPath);
+        if (!result.Success)
+        {
+            Console.Error.WriteLine($"Generation failed: {result.Error}");
+            return 1;
+        }
+
+        var validatorPath = Path.Combine(outputPath, result.FileName!);
+        File.WriteAllText(validatorPath, result.GeneratedCode!);
+        Console.WriteLine($"Generated: {validatorPath}");
+
+        if (writeRuntime)
+        {
+            var runtimePath = Path.Combine(outputPath, JsRuntime.FileName);
+            File.WriteAllText(runtimePath, JsRuntime.GetSource());
+            Console.WriteLine($"Generated: {runtimePath}");
+        }
+        return 0;
+    }
+
+    private static int HandleGenerateJsFromTypeScript(
+        string schemaPath,
+        string outputPath,
+        bool writeRuntime,
+        bool formatAssertionEnabled,
+        string ecmaScriptTarget,
+        string tscExecutable)
+    {
+        Console.WriteLine("Pipeline: TypeScript-first via tsc");
+        Console.WriteLine($"ECMAScript target: {ecmaScriptTarget}");
+
+        var generator = new TsSchemaCodeGenerator
+        {
+            FormatAssertionEnabled = formatAssertionEnabled
+        };
+        var result = generator.Generate(schemaPath);
+        if (!result.Success)
+        {
+            Console.Error.WriteLine($"Generation failed: {result.Error}");
+            return 1;
+        }
+
+        var tempPath = Path.Combine(Path.GetTempPath(), "jsv-tsgen-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempPath);
+        try
+        {
+            var validatorTsPath = Path.Combine(tempPath, result.FileName!);
+            var runtimeTsPath = Path.Combine(tempPath, TsRuntime.FileName);
+            var runtimeDeclarationPath = Path.Combine(tempPath, TsRuntime.DeclarationFileName);
+            File.WriteAllText(validatorTsPath, result.GeneratedCode!);
+            if (writeRuntime)
+            {
+                File.WriteAllText(runtimeTsPath, TsRuntime.GetSource());
+            }
+            else
+            {
+                File.WriteAllText(runtimeDeclarationPath, TsRuntime.GetDeclarationSource());
+            }
+
+            IReadOnlyList<string> sourcePaths = writeRuntime
+                ? [validatorTsPath, runtimeTsPath]
+                : [validatorTsPath, runtimeDeclarationPath];
+
+            var compilationResult = TypeScriptCompiler.Compile(
+                sourcePaths,
+                outputPath,
+                ecmaScriptTarget,
+                tscExecutable);
+            if (!compilationResult.Success)
+            {
+                Console.Error.WriteLine($"TypeScript compilation failed: {compilationResult.Error}");
+                if (!string.IsNullOrWhiteSpace(compilationResult.StandardError))
+                {
+                    Console.Error.WriteLine(compilationResult.StandardError);
+                }
+                if (!string.IsNullOrWhiteSpace(compilationResult.StandardOutput))
+                {
+                    Console.Error.WriteLine(compilationResult.StandardOutput);
+                }
+                return 1;
+            }
+
+            var validatorJsPath = Path.Combine(outputPath, Path.ChangeExtension(result.FileName!, ".js"));
+            Console.WriteLine($"Generated: {validatorJsPath}");
+            if (writeRuntime)
+            {
+                Console.WriteLine($"Generated: {Path.Combine(outputPath, JsRuntime.FileName)}");
+            }
+            return 0;
+        }
+        finally
+        {
+            try { Directory.Delete(tempPath, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static int HandleGenerateTs(string[] args)
+    {
+        string? schemaPath = null;
+        string? outputPath = null;
+        var writeRuntime = true;
+        var formatAssertionEnabled = false;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -238,10 +479,10 @@ internal static class Program
             Directory.CreateDirectory(outputPath);
         }
 
-        Console.WriteLine($"Generating JS validator for: {schemaPath}");
+        Console.WriteLine($"Generating TS validator for: {schemaPath}");
         Console.WriteLine($"Output directory: {outputPath}");
 
-        var generator = new JsSchemaCodeGenerator
+        var generator = new TsSchemaCodeGenerator
         {
             FormatAssertionEnabled = formatAssertionEnabled
         };
@@ -258,8 +499,8 @@ internal static class Program
 
         if (writeRuntime)
         {
-            var runtimePath = Path.Combine(outputPath, JsRuntime.FileName);
-            File.WriteAllText(runtimePath, JsRuntime.GetSource());
+            var runtimePath = Path.Combine(outputPath, TsRuntime.FileName);
+            File.WriteAllText(runtimePath, TsRuntime.GetSource());
             Console.WriteLine($"Generated: {runtimePath}");
         }
         return 0;

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -67,3 +67,15 @@ Drafts 4 and 2019-09 continue to assert supported formats by default (matches th
 ### Shared Runtime Module
 
 Emitted validators import from a sibling `jsv-runtime.js`. The CLI writes both files by default; pass `--no-runtime` to suppress the runtime write if your build already provides one. The runtime ABI is versioned (`ABI VERSION: mvp-0`); bumping the version signals a breaking change to emitted validator expectations.
+
+### TypeScript-First Migration Path
+
+Issue #32 introduces a parallel TypeScript-first path without removing the direct JS generator. `jsv-codegen generate-ts` emits TypeScript source, and `jsv-codegen generate-js --pipeline typescript --ecmascript-target <target>` compiles that source with `tsc` to produce JavaScript for an explicit TypeScript compiler target. The direct JS path remains the default and should be kept available for performance comparison until the TypeScript path has proven parity.
+
+Current migration constraints:
+
+- The TS generator has its own orchestration and keyword emitter classes. The first implementation intentionally keeps emitted validator semantics aligned with the direct JS emitter so parity and performance comparisons remain meaningful.
+- `jsv-runtime.ts` is currently derived from the stable `jsv-runtime.js` ABI and marked `// @ts-nocheck`; converting the runtime to fully typed, TS-authored source is still follow-up work.
+- The package invokes an external `tsc` executable for JS-from-TS output. Install TypeScript separately or pass `--tsc <path>` to the CLI.
+- Draft 2020-12 TS-derived JS is tested through the JSON-Schema-Test-Suite against the same enabled case set as the direct JS target. This is parity coverage for the current JS capability gate, not a claim that deferred JS-target capabilities are complete.
+- Browser-query targeting and polyfill management remain out of scope. The exposed target is the `tsc` ECMAScript target, and consumers can apply their own downstream bundling or browser compatibility tooling.

--- a/TYPESCRIPT_CODEGEN_MIGRATION.md
+++ b/TYPESCRIPT_CODEGEN_MIGRATION.md
@@ -1,0 +1,71 @@
+# TypeScript-First JavaScript Codegen Migration
+
+## Current State
+
+The direct JavaScript generator remains the default path and is still the benchmark baseline:
+
+```bash
+jsv-codegen generate-js -s schema.json -o ./out
+```
+
+A parallel TypeScript-first path now exists:
+
+```bash
+jsv-codegen generate-ts -s schema.json -o ./out
+jsv-codegen generate-js -s schema.json -o ./out --pipeline typescript --ecmascript-target ES2020
+```
+
+The TypeScript path has its own orchestration, capability gate, reachability pass, context, literal helper, and keyword generator classes. The first implementation deliberately keeps generated validator semantics comparable with the direct JavaScript emitter so parity and performance comparisons remain meaningful.
+
+## Source Of Truth
+
+Short term, the canonical source remains the current schema analysis and the TS keyword emitter set. The TS path emits TypeScript-compatible ESM source with typed exported validator signatures.
+
+Medium term, the generator should move toward one of these models:
+
+- A target-neutral validation IR that can emit C#, TS, and any future target.
+- A TS-native emitter that becomes the canonical JS-family output, with direct JS retained only until parity and performance are proven.
+
+The IR option is cleaner long term, but larger. The current implementation preserves the current JS generator for performance comparison while giving TypeScript its own generator implementation.
+
+## Runtime
+
+`jsv-runtime.ts` is currently derived from `jsv-runtime.js` and marked `// @ts-nocheck`. This keeps the stable JS runtime ABI intact and allows `tsc` to produce `jsv-runtime.js` for the requested ECMAScript target.
+
+Follow-up work should convert the runtime to TS-authored source with explicit class fields, exported interfaces for registry/scope/evaluated-state shapes, and generated `.d.ts` coverage.
+
+## Toolchain
+
+No Node dependency is added to the .NET projects. The CLI invokes an external `tsc` executable for the TS-to-JS path. Consumers can either install TypeScript on PATH or pass `--tsc <path>`.
+
+The default direct JS path does not require Node or TypeScript.
+
+## tsc Invocation Point
+
+Current behavior:
+
+- `generate-ts`: development and inspection path; writes `.ts` source and `jsv-runtime.ts`.
+- `generate-js --pipeline typescript`: packaging/output path; writes temporary `.ts` source, invokes `tsc`, and emits `.js`.
+- tests: focused smoke coverage compiles and executes generated TS validators, and `TsTestSuiteRunner` runs Draft 2020-12 JSON-Schema-Test-Suite cases through TS-derived JS.
+- benchmarks: `NodeJsCompetitorBenchmarks` now compares Ajv, direct JS codegen, and TS-derived JS codegen.
+
+## ECMAScript Target Exposure
+
+The CLI exposes `--ecmascript-target <target>` only for `--pipeline typescript`. The value is passed through to `tsc --target`, so supported values follow the installed TypeScript compiler.
+
+Direct JS generation rejects `--ecmascript-target` to avoid implying that the direct emitter has per-target downleveling.
+
+## Explicitly Out Of Scope
+
+- Browser-query support.
+- Built-in polyfill selection or injection.
+- Replacing the direct JS generator before TS parity and benchmark parity are demonstrated.
+- Treating current compiled-generator coverage gaps as permanently out of scope.
+
+## Next Gates
+
+- Track unsupported or divergent cases separately instead of masking them as migration blockers.
+- By 2026-05-15, choose the deduplication strategy for the JS-family emitters: either introduce a target-neutral validation IR or promote the TS emitter to the canonical JS-family source and retire duplicated direct-JS keyword bodies behind benchmark gates.
+- Convert `jsv-runtime.ts` from no-check JS-compatible source into typed TS.
+- Replace internal `any` state/scope/registry signatures with typed TS contracts.
+- Add benchmark acceptance thresholds once enough TS-derived JS scenarios are stable.


### PR DESCRIPTION
## Summary

- add an independent TypeScript-first JavaScript codegen path with TS orchestrator, capability gate, reachability pass, runtime projection, tsc wrapper, and keyword emitters
- add CLI support for `generate-ts` and `generate-js --pipeline typescript --ecmascript-target <target>`
- run Draft 2020-12 JSON-Schema-Test-Suite cases through tsc-derived JS and add smoke coverage
- add TS-derived JS benchmark competitor while keeping direct JS as the baseline
- document migration scope, known limitations, and the follow-up to remove TypeScript garnish (#33)

Closes #32

## Verification

- `dotnet build JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --no-restore /p:UseSharedCompilation=false`
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --no-build --filter "FullyQualifiedName~TsSchemaCodeGeneratorTests"`
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --no-build --filter "FullyQualifiedName~TsTestSuiteRunner"`
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --no-build`
- `dotnet build JsonSchemaValidation.Benchmarks\JsonSchemaValidation.Benchmarks.csproj --no-restore /p:UseSharedCompilation=false`
- CLI smoke: `generate-js --pipeline typescript --no-runtime --ecmascript-target ES2020`