### PR TITLE
Add JavaScript code generation target adapter

### DIFF
--- a/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/NodeJsCompetitorBenchmarks.cs
+++ b/JsonSchemaValidation.Benchmarks/Benchmarks/Competitors/NodeJsCompetitorBenchmarks.cs
@@ -6,10 +6,9 @@ using System.Text.Json;
 using BenchmarkDotNet.Attributes;
 using FormFinch.JsonSchemaValidation.Benchmarks.Config;
 using FormFinch.JsonSchemaValidation.Benchmarks.Infrastructure;
-using FormFinch.JsonSchemaValidation.CodeGeneration.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Abstractions;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Schema;
-using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
-using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript;
 using FormFinch.JsonSchemaValidation.CodeGeneration.TypeScript;
 
 namespace FormFinch.JsonSchemaValidation.Benchmarks.Benchmarks.Competitors;
@@ -50,8 +49,10 @@ public class NodeJsCompetitorBenchmarks
 
         var directDirectory = Path.Combine(_generatedModuleDirectory, "direct");
         Directory.CreateDirectory(directDirectory);
-        File.WriteAllText(Path.Combine(directDirectory, JsRuntime.FileName), JsRuntime.GetSource());
-        File.WriteAllText(Path.Combine(directDirectory, "validator.js"), GenerateValidatorSource(schemaJson));
+        foreach (var artifact in GenerateDirectJavaScriptArtifacts(schemaJson))
+        {
+            File.WriteAllText(Path.Combine(directDirectory, artifact.RelativePath), artifact.Content);
+        }
 
         var typeScriptDerivedDirectory = Path.Combine(_generatedModuleDirectory, "typescript");
         Directory.CreateDirectory(typeScriptDerivedDirectory);
@@ -108,22 +109,33 @@ public class NodeJsCompetitorBenchmarks
         return _formFinchTsDerivedJsHost.ValidatePreparedBatch(BatchSize);
     }
 
-    private static string GenerateValidatorSource(string schemaJson)
+    private static IReadOnlyList<GeneratedArtifact> GenerateDirectJavaScriptArtifacts(string schemaJson)
     {
         using var schemaDoc = JsonDocument.Parse(schemaJson);
-        var generator = new JsSchemaCodeGenerator
+        var target = new JavaScriptCodeGenerationTarget();
+        var result = target.GenerateAsync(new CodeGenerationRequest
         {
-            DefaultDraft = SchemaDraft.Draft202012
-        };
-
-        var result = generator.Generate(schemaDoc.RootElement.Clone(), sourcePath: "benchmark-schema.json");
-        if (!result.Success || string.IsNullOrEmpty(result.GeneratedCode))
+            Schema = schemaDoc.RootElement.Clone(),
+            Options = new JavaScriptCodeGenerationOptions
+            {
+                DefaultDraft = SchemaDraft.Draft202012,
+                SourcePath = "benchmark-schema.json",
+                OutputHints = new CodeGenerationOutputHints
+                {
+                    BaseFileName = "validator"
+                }
+            }
+        }).GetAwaiter().GetResult();
+        if (!result.Success)
         {
+            var message = result.Diagnostics.Count > 0
+                ? string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.Message))
+                : "Unknown error";
             throw new InvalidOperationException(
-                $"Failed to generate JS benchmark validator: {result.Error ?? "Unknown error"}");
+                $"Failed to generate JS benchmark validator: {message}");
         }
 
-        return result.GeneratedCode;
+        return result.Artifacts;
     }
 
     private static string GenerateTypeScriptDerivedJavaScript(string schemaJson, string outputDirectory)

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/Generator/JsCapabilityGate.cs
@@ -154,20 +154,33 @@ public static class JsCapabilityGate
     /// </summary>
     public static string? CheckSupported(JsonElement root, SchemaDraft detectedDraft)
     {
+        return CheckSupport(root, detectedDraft)?.Reason;
+    }
+
+    /// <summary>
+    /// Returns structured rejection details if the schema uses deferred features,
+    /// or null if the schema is emit-safe for the MVP JS target.
+    /// </summary>
+    public static JsCapabilityGateRejection? CheckSupport(JsonElement root, SchemaDraft detectedDraft)
+    {
         if (!SupportedDrafts.Contains(detectedDraft))
         {
-            return $"JS target MVP supports Draft 4, Draft 2019-09, and Draft 2020-12 only; detected {detectedDraft}. " +
-                   "Other drafts are tracked as follow-up work.";
+            return new JsCapabilityGateRejection
+            {
+                FeatureName = "$schema",
+                Reason = $"JS target MVP supports Draft 4, Draft 2019-09, and Draft 2020-12 only; detected {detectedDraft}. " +
+                         "Other drafts are tracked as follow-up work."
+            };
         }
-        return Walk(root, detectedDraft);
+        return Walk(root, detectedDraft, string.Empty);
     }
 
-    private static string? Walk(JsonElement node, SchemaDraft draft)
+    private static JsCapabilityGateRejection? Walk(JsonElement node, SchemaDraft draft, string pointer)
     {
-        return node.ValueKind == JsonValueKind.Object ? WalkObject(node, draft) : null;
+        return node.ValueKind == JsonValueKind.Object ? WalkObject(node, draft, pointer) : null;
     }
 
-    private static string? WalkObject(JsonElement node, SchemaDraft draft)
+    private static JsCapabilityGateRejection? WalkObject(JsonElement node, SchemaDraft draft, string pointer)
     {
         var deferred = DeferredPerDraft[draft];
         var schemaValued = SchemaValuedPerDraft[draft];
@@ -193,8 +206,13 @@ public static class JsCapabilityGate
             }
             if (deferred.Contains(prop.Name))
             {
-                return $"JS target MVP does not support '{prop.Name}'. " +
-                       "Deferred to follow-up: $recursiveRef/$recursiveAnchor.";
+                return new JsCapabilityGateRejection
+                {
+                    FeatureName = prop.Name,
+                    JsonPointer = AppendPointer(pointer, prop.Name),
+                    Reason = $"JS target MVP does not support '{prop.Name}'. " +
+                             "Deferred to follow-up: $recursiveRef/$recursiveAnchor."
+                };
             }
 
             // Draft-specific "items": single schema in 2020-12; single or array in Draft 4.
@@ -204,12 +222,12 @@ public static class JsCapabilityGate
             {
                 if (draft == SchemaDraft.Draft4 && prop.Value.ValueKind == JsonValueKind.Array)
                 {
-                    var rejection = WalkSchemaArray(prop.Value, draft);
+                    var rejection = WalkSchemaArray(prop.Value, draft, AppendPointer(pointer, prop.Name));
                     if (rejection != null) return rejection;
                 }
                 else
                 {
-                    var rejection = Walk(prop.Value, draft);
+                    var rejection = Walk(prop.Value, draft, AppendPointer(pointer, prop.Name));
                     if (rejection != null) return rejection;
                 }
                 continue;
@@ -228,7 +246,7 @@ public static class JsCapabilityGate
                         dep.Value.ValueKind == JsonValueKind.True ||
                         dep.Value.ValueKind == JsonValueKind.False)
                     {
-                        var rejection = Walk(dep.Value, draft);
+                        var rejection = Walk(dep.Value, draft, AppendPointer(AppendPointer(pointer, prop.Name), dep.Name));
                         if (rejection != null) return rejection;
                     }
                 }
@@ -237,19 +255,19 @@ public static class JsCapabilityGate
 
             if (schemaValued.Contains(prop.Name))
             {
-                var rejection = Walk(prop.Value, draft);
+                var rejection = Walk(prop.Value, draft, AppendPointer(pointer, prop.Name));
                 if (rejection != null) return rejection;
             }
             else if (schemaArray.Contains(prop.Name) &&
                      prop.Value.ValueKind == JsonValueKind.Array)
             {
-                var rejection = WalkSchemaArray(prop.Value, draft);
+                var rejection = WalkSchemaArray(prop.Value, draft, AppendPointer(pointer, prop.Name));
                 if (rejection != null) return rejection;
             }
             else if (schemaMap.Contains(prop.Name) &&
                      prop.Value.ValueKind == JsonValueKind.Object)
             {
-                var rejection = WalkSchemaMap(prop.Value, draft);
+                var rejection = WalkSchemaMap(prop.Value, draft, AppendPointer(pointer, prop.Name));
                 if (rejection != null) return rejection;
             }
             // All other property values (data, annotations, unknown-in-this-draft
@@ -258,24 +276,48 @@ public static class JsCapabilityGate
         return null;
     }
 
-    private static string? WalkSchemaArray(JsonElement array, SchemaDraft draft)
+    private static JsCapabilityGateRejection? WalkSchemaArray(JsonElement array, SchemaDraft draft, string pointer)
     {
+        var index = 0;
         foreach (var item in array.EnumerateArray())
         {
-            var rejection = Walk(item, draft);
+            var rejection = Walk(item, draft, AppendPointer(pointer, index.ToString(System.Globalization.CultureInfo.InvariantCulture)));
             if (rejection != null) return rejection;
+            index++;
         }
         return null;
     }
 
-    private static string? WalkSchemaMap(JsonElement map, SchemaDraft draft)
+    private static JsCapabilityGateRejection? WalkSchemaMap(JsonElement map, SchemaDraft draft, string pointer)
     {
         foreach (var entry in map.EnumerateObject())
         {
-            var rejection = Walk(entry.Value, draft);
+            var rejection = Walk(entry.Value, draft, AppendPointer(pointer, entry.Name));
             if (rejection != null) return rejection;
         }
         return null;
     }
 
+    private static string AppendPointer(string pointer, string segment)
+    {
+        return $"{pointer}/{EscapePointerSegment(segment)}";
+    }
+
+    private static string EscapePointerSegment(string segment)
+    {
+        return segment.Replace("~", "~0", StringComparison.Ordinal).Replace("/", "~1", StringComparison.Ordinal);
+    }
+
+}
+
+/// <summary>
+/// Structured details for a JavaScript capability gate rejection.
+/// </summary>
+public sealed class JsCapabilityGateRejection
+{
+    public required string FeatureName { get; init; }
+
+    public string? JsonPointer { get; init; }
+
+    public required string Reason { get; init; }
 }

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/JavaScriptCodeGenerationOptions.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/JavaScriptCodeGenerationOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using FormFinch.JsonSchemaValidation.CodeGeneration.Abstractions;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript;
+
+/// <summary>
+/// Options for the direct JavaScript code generation target.
+/// </summary>
+public sealed class JavaScriptCodeGenerationOptions : CodeGenerationOptions
+{
+    /// <summary>
+    /// The import specifier used for the shared JavaScript runtime module.
+    /// </summary>
+    public string RuntimeImportSpecifier { get; init; } = "./jsv-runtime.js";
+
+    /// <summary>
+    /// Whether to assert supported "format" values for Draft 2020-12.
+    /// </summary>
+    public bool FormatAssertionEnabled { get; init; }
+
+    /// <summary>
+    /// Forces annotation tracking even when unevaluated* keywords are not present.
+    /// </summary>
+    public bool ForceAnnotationTracking { get; init; }
+
+    /// <summary>
+    /// Optional preloaded schemas keyed by absolute URI.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? ExternalSchemaDocuments { get; init; }
+}

--- a/JsonSchemaValidation.CodeGeneration.JavaScript/JavaScriptCodeGenerationTarget.cs
+++ b/JsonSchemaValidation.CodeGeneration.JavaScript/JavaScriptCodeGenerationTarget.cs
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using FormFinch.JsonSchemaValidation.CodeGeneration.Abstractions;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Schema;
+
+namespace FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript;
+
+/// <summary>
+/// Central contract adapter for the direct JavaScript code generation target.
+/// </summary>
+public sealed class JavaScriptCodeGenerationTarget : CodeGenerationTarget<JavaScriptCodeGenerationOptions>
+{
+    public override CodeGenerationTargetDescriptor Descriptor { get; } = new()
+    {
+        Id = "javascript",
+        DisplayName = "JavaScript",
+        SupportedFileExtensions = [".js"],
+        OptionsType = typeof(JavaScriptCodeGenerationOptions),
+        SupportedDrafts =
+        [
+            SchemaDraft.Draft4,
+            SchemaDraft.Draft201909,
+            SchemaDraft.Draft202012
+        ]
+    };
+
+    protected override ValueTask<CodeGenerationCapabilityResult> GetCapabilitiesAsync(
+        CodeGenerationRequest request,
+        JavaScriptCodeGenerationOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var draftResult = SchemaDraftDetector.DetectDraft(request.Schema, options.DefaultDraft);
+        if (!draftResult.Success)
+        {
+            return ValueTask.FromResult(new CodeGenerationCapabilityResult
+            {
+                CanGenerate = false,
+                Diagnostics =
+                [
+                    new CodeGenerationDiagnostic
+                    {
+                        Severity = CodeGenerationDiagnosticSeverity.Error,
+                        Code = "javascript.unsupported-draft",
+                        Message = draftResult.ErrorMessage!,
+                        TargetId = Descriptor.Id
+                    }
+                ]
+            });
+        }
+
+        var draftSelection = CreateDraftSelection(draftResult);
+        if (!Descriptor.SupportedDrafts.Contains(draftResult.Draft))
+        {
+            var message = $"JavaScript target supports Draft 4, Draft 2019-09, and Draft 2020-12 only; detected {draftResult.Draft}.";
+            return ValueTask.FromResult(new CodeGenerationCapabilityResult
+            {
+                CanGenerate = false,
+                DraftSelection = draftSelection,
+                Diagnostics =
+                [
+                    new CodeGenerationDiagnostic
+                    {
+                        Severity = CodeGenerationDiagnosticSeverity.Error,
+                        Code = "javascript.unsupported-draft",
+                        Message = message,
+                        TargetId = Descriptor.Id
+                    }
+                ],
+                UnsupportedDrafts =
+                [
+                    new UnsupportedDraftDetail
+                    {
+                        TargetId = Descriptor.Id,
+                        Draft = draftResult.Draft,
+                        Reason = message
+                    }
+                ]
+            });
+        }
+
+        var gateRejection = JsCapabilityGate.CheckSupport(request.Schema, draftResult.Draft);
+        if (gateRejection != null)
+        {
+            return ValueTask.FromResult(new CodeGenerationCapabilityResult
+            {
+                CanGenerate = false,
+                DraftSelection = draftSelection,
+                Diagnostics =
+                [
+                    new CodeGenerationDiagnostic
+                    {
+                        Severity = CodeGenerationDiagnosticSeverity.Error,
+                        Code = "javascript.unsupported-feature",
+                        Message = gateRejection.Reason,
+                        JsonPointer = gateRejection.JsonPointer,
+                        TargetId = Descriptor.Id
+                    }
+                ],
+                UnsupportedFeatures =
+                [
+                    new UnsupportedFeatureDetail
+                    {
+                        TargetId = Descriptor.Id,
+                        FeatureName = gateRejection.FeatureName,
+                        JsonPointer = gateRejection.JsonPointer,
+                        Draft = draftResult.Draft,
+                        Reason = gateRejection.Reason
+                    }
+                ]
+            });
+        }
+
+        return ValueTask.FromResult(new CodeGenerationCapabilityResult
+        {
+            CanGenerate = true,
+            DraftSelection = draftSelection
+        });
+    }
+
+    protected override ValueTask<CodeGenerationResult> GenerateAsync(
+        CodeGenerationRequest request,
+        JavaScriptCodeGenerationOptions options,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var generator = new JsSchemaCodeGenerator
+        {
+            DefaultDraft = options.DefaultDraft,
+            RuntimeImportSpecifier = options.RuntimeImportSpecifier,
+            FormatAssertionEnabled = options.FormatAssertionEnabled,
+            AlwaysTrackAnnotations = options.ForceAnnotationTracking,
+            ExternalSchemaDocuments = options.ExternalSchemaDocuments
+        };
+
+        var result = generator.Generate(request.Schema, options.SourcePath);
+        if (!result.Success)
+        {
+            return ValueTask.FromResult(CodeGenerationResult.Failed(new CodeGenerationDiagnostic
+            {
+                Severity = CodeGenerationDiagnosticSeverity.Error,
+                Code = "javascript.generation-failed",
+                Message = result.Error ?? "JavaScript code generation failed.",
+                TargetId = Descriptor.Id
+            }));
+        }
+
+        var artifacts = new List<GeneratedArtifact>
+        {
+            new()
+            {
+                RelativePath = GetPrimaryFileName(result.FileName, options.OutputHints),
+                Content = result.GeneratedCode!,
+                Kind = GeneratedArtifactKind.Source,
+                Role = GeneratedArtifactRole.Primary,
+                MediaType = "text/javascript"
+            }
+        };
+
+        if (options.EmitSupportArtifacts)
+        {
+            string runtimeSource;
+            try
+            {
+                runtimeSource = JsRuntime.GetSource();
+            }
+            catch (Exception ex)
+            {
+                return ValueTask.FromResult(CodeGenerationResult.Failed(new CodeGenerationDiagnostic
+                {
+                    Severity = CodeGenerationDiagnosticSeverity.Error,
+                    Code = "javascript.runtime-generation-failed",
+                    Message = $"JavaScript runtime artifact generation failed: {ex.Message}",
+                    TargetId = Descriptor.Id
+                }));
+            }
+
+            artifacts.Add(new GeneratedArtifact
+            {
+                RelativePath = JsRuntime.FileName,
+                Content = runtimeSource,
+                Kind = GeneratedArtifactKind.Runtime,
+                Role = GeneratedArtifactRole.Support,
+                MediaType = "text/javascript"
+            });
+        }
+
+        return ValueTask.FromResult(CodeGenerationResult.Succeeded(artifacts.ToArray()));
+    }
+
+    private static DraftSelection CreateDraftSelection(DraftDetectionResult draftResult)
+    {
+        return new DraftSelection
+        {
+            Draft = draftResult.Draft,
+            Source = GetDraftSelectionSource(draftResult.Source),
+            SchemaUri = draftResult.SchemaUri
+        };
+    }
+
+    private static DraftSelectionSource GetDraftSelectionSource(DraftDetectionSource source)
+    {
+        return source switch
+        {
+            DraftDetectionSource.DefaultDraft => DraftSelectionSource.DefaultDraft,
+            DraftDetectionSource.InferredSchemaUri => DraftSelectionSource.InferredSchemaUri,
+            DraftDetectionSource.ExplicitSchemaUri => DraftSelectionSource.ExplicitSchemaUri,
+            _ => throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown draft detection source.")
+        };
+    }
+
+    private static string GetPrimaryFileName(string? generatedFileName, CodeGenerationOutputHints outputHints)
+    {
+        var baseName = outputHints.BaseFileName ?? outputHints.ModuleName;
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            return generatedFileName ?? "validator.js";
+        }
+
+        var fileName = Path.GetFileName(baseName);
+        if (string.IsNullOrWhiteSpace(fileName) || fileName is "." or "..")
+        {
+            fileName = "validator";
+        }
+
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var sanitizedCharacters = fileName.Select(c =>
+            invalidCharacters.Contains(c) || c is '/' or '\\' or ':' ? '_' : c);
+        fileName = new string(sanitizedCharacters.ToArray()).Trim('.', ' ');
+        if (string.IsNullOrWhiteSpace(fileName) || fileName is "." or "..")
+        {
+            fileName = "validator";
+        }
+
+        return string.Equals(Path.GetExtension(fileName), ".js", StringComparison.OrdinalIgnoreCase)
+            ? fileName
+            : Path.ChangeExtension(fileName, ".js");
+    }
+
+}

--- a/JsonSchemaValidation.CodeGenerator.Tests/JavaScriptCodeGenerationTargetTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JavaScriptCodeGenerationTargetTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Text.Json;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Abstractions;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+public sealed class JavaScriptCodeGenerationTargetTests
+{
+    [Fact]
+    public async Task GetCapabilitiesAsync_SupportedSchema_ReturnsDraftSelection()
+    {
+        using var doc = JsonDocument.Parse("""{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"string"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions()
+        };
+
+        var result = await target.GetCapabilitiesAsync(request);
+
+        Assert.True(result.CanGenerate);
+        Assert.NotNull(result.DraftSelection);
+        Assert.Equal("javascript", target.Descriptor.Id);
+        Assert.Equal(typeof(JavaScriptCodeGenerationOptions), target.Descriptor.OptionsType);
+    }
+
+    [Fact]
+    public async Task GetCapabilitiesAsync_UnsupportedDraft_ReturnsDiagnosticAndDraftDetail()
+    {
+        using var doc = JsonDocument.Parse("""{"$schema":"http://json-schema.org/draft-07/schema#","type":"string"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions()
+        };
+
+        var result = await target.GetCapabilitiesAsync(request);
+
+        Assert.False(result.CanGenerate);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        var detail = Assert.Single(result.UnsupportedDrafts);
+        Assert.Equal(CodeGenerationDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal("javascript.unsupported-draft", diagnostic.Code);
+        Assert.Equal("javascript", diagnostic.TargetId);
+        Assert.Equal("javascript", detail.TargetId);
+    }
+
+    [Fact]
+    public async Task GetCapabilitiesAsync_UnsupportedFeature_ReturnsDiagnosticAndFeatureDetail()
+    {
+        using var doc = JsonDocument.Parse("""{"$schema":"https://json-schema.org/draft/2020-12/schema","$recursiveRef":"#"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions()
+        };
+
+        var result = await target.GetCapabilitiesAsync(request);
+
+        Assert.False(result.CanGenerate);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        var detail = Assert.Single(result.UnsupportedFeatures);
+        Assert.Equal(CodeGenerationDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal("javascript.unsupported-feature", diagnostic.Code);
+        Assert.Equal("javascript", diagnostic.TargetId);
+        Assert.Equal("/$recursiveRef", diagnostic.JsonPointer);
+        Assert.Equal("$recursiveRef", detail.FeatureName);
+        Assert.Equal("/$recursiveRef", detail.JsonPointer);
+        Assert.Equal("javascript", detail.TargetId);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_EmitsPrimarySourceAndRuntimeArtifacts()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"string"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions
+            {
+                OutputHints = new CodeGenerationOutputHints
+                {
+                    BaseFileName = "generated-validator"
+                }
+            }
+        };
+
+        var result = await target.GenerateAsync(request);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Artifacts.Count);
+        var source = Assert.Single(result.Artifacts, artifact => artifact.Role == GeneratedArtifactRole.Primary);
+        var runtime = Assert.Single(result.Artifacts, artifact => artifact.Kind == GeneratedArtifactKind.Runtime);
+        Assert.Equal("generated-validator.js", source.RelativePath);
+        Assert.Equal(GeneratedArtifactKind.Source, source.Kind);
+        Assert.Contains("export function validate(data)", source.Content);
+        Assert.Equal(JsRuntime.FileName, runtime.RelativePath);
+        Assert.Contains("export class EvaluatedState", runtime.Content);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_EmitSupportArtifactsFalse_SkipsRuntimeArtifact()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"string"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions
+            {
+                EmitSupportArtifacts = false
+            }
+        };
+
+        var result = await target.GenerateAsync(request);
+
+        Assert.True(result.Success);
+        var artifact = Assert.Single(result.Artifacts);
+        Assert.Equal("validator.js", artifact.RelativePath);
+        Assert.Equal(GeneratedArtifactRole.Primary, artifact.Role);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_OutputHintWithPathSegments_SanitizesPrimaryArtifactName()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"string"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions
+            {
+                EmitSupportArtifacts = false,
+                OutputHints = new CodeGenerationOutputHints
+                {
+                    BaseFileName = "../nested/bad:name.ts"
+                }
+            }
+        };
+
+        var result = await target.GenerateAsync(request);
+
+        Assert.True(result.Success);
+        var artifact = Assert.Single(result.Artifacts);
+        Assert.Equal("bad_name.js", artifact.RelativePath);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_InvalidSchema_ReturnsGenerationDiagnostic()
+    {
+        using var doc = JsonDocument.Parse("42");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new JavaScriptCodeGenerationOptions()
+        };
+
+        var result = await target.GenerateAsync(request);
+
+        Assert.False(result.Success);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(CodeGenerationDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal("javascript.generation-failed", diagnostic.Code);
+        Assert.Equal("javascript", diagnostic.TargetId);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WrongOptionsType_ThrowsClearArgumentException()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"string"}""");
+        var target = new JavaScriptCodeGenerationTarget();
+        var request = new CodeGenerationRequest
+        {
+            Schema = doc.RootElement,
+            Options = new CodeGenerationOptions()
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            async () => await target.GenerateAsync(request));
+
+        Assert.Contains(typeof(JavaScriptCodeGenerationOptions).FullName!, exception.Message);
+        Assert.Contains(typeof(CodeGenerationOptions).FullName!, exception.Message);
+        Assert.Equal("request", exception.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary
- add `JavaScriptCodeGenerationTarget` and strongly typed JavaScript target options for the direct JS generator
- return generated validator and runtime artifacts through the central `CodeGenerationResult` model
- expose JS capability diagnostics with structured unsupported draft/feature details and JSON Pointer locations
- update the Node benchmark direct-JS path to consume returned target artifacts

Closes #40

## Verification
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj -f net8.0 --no-restore /p:UseSharedCompilation=false`
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj -f net10.0 --no-restore /p:UseSharedCompilation=false`
- `dotnet build JsonSchemaValidation.Benchmarks\JsonSchemaValidation.Benchmarks.csproj -f net8.0 --no-restore /p:UseSharedCompilation=false`
- `dotnet build JsonSchemaValidation.Benchmarks\JsonSchemaValidation.Benchmarks.csproj -f net10.0 --no-restore /p:UseSharedCompilation=false`