### PR TITLE
Part of #35: Refactor jsv-codegen target composition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,20 @@ jsv-codegen generate-js -s schema.json -o ./out --pipeline typescript --ecmascri
 
 Keep the default direct JS generator available when working on this path; it is the parity and benchmark baseline.
 
+## Code Generation Architecture
+
+The central `FormFinch.JsonSchemaValidation.CodeGeneration` assembly owns target-neutral schema analysis and the shared `ICodeGenerationTarget` contract. It must not reference C#, JavaScript, or TypeScript emitters.
+
+Target-specific generation lives in peer assemblies:
+
+- `FormFinch.JsonSchemaValidation.CodeGeneration.CSharp`
+- `FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript`
+- `FormFinch.JsonSchemaValidation.CodeGeneration.TypeScript`
+
+The `jsv-codegen` CLI is the composition root. It explicitly registers those targets, keeps the compatibility aliases `generate`, `generate-js`, and `generate-ts`, maps CLI arguments into strongly typed target options, and writes returned `GeneratedArtifact` values consistently. Do not add reflection-based target discovery to the central package.
+
+The split target assemblies are project-referenced in this repository. When preparing NuGet publishing, keep package ids aligned with the assembly names above and version them together with `FormFinch.JsonSchemaValidation` until a separate package-versioning policy is agreed.
+
 ### Code Coverage
 
 ```bash

--- a/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+#if NET10_0
+using Xunit;
+
+namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
+
+[CollectionDefinition(nameof(CodeGeneratorCliCollection), DisableParallelization = true)]
+public sealed class CodeGeneratorCliCollection;
+
+[Collection(nameof(CodeGeneratorCliCollection))]
+public sealed class CodeGeneratorCliTests
+{
+    [Fact]
+    public async Task Generate_WritesCSharpArtifactThroughRegisteredTarget()
+    {
+        using var workspace = TemporaryWorkspace.Create();
+        var schemaPath = workspace.WriteSchema("""{"type":"string"}""");
+        var outputPath = workspace.CreateDirectory("csharp");
+
+        var exitCode = await RunCliAsync(
+            "generate",
+            "-s", schemaPath,
+            "-o", outputPath,
+            "-n", "Generated.Tests",
+            "-c", "CliValidator");
+
+        Assert.Equal(0, exitCode);
+        var validatorPath = Path.Combine(outputPath, "CliValidator.cs");
+        Assert.True(File.Exists(validatorPath));
+        var source = File.ReadAllText(validatorPath);
+        Assert.Contains("namespace Generated.Tests", source);
+        Assert.Contains("class CliValidator", source);
+    }
+
+    [Fact]
+    public async Task GenerateJs_WritesReturnedSourceAndRuntimeArtifacts()
+    {
+        using var workspace = TemporaryWorkspace.Create();
+        var schemaPath = workspace.WriteSchema("""{"type":"string"}""");
+        var outputPath = workspace.CreateDirectory("javascript");
+
+        var exitCode = await RunCliAsync(
+            "generate-js",
+            "-s", schemaPath,
+            "-o", outputPath);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(Path.Combine(outputPath, "jsv-runtime.js")));
+        var validatorPath = Assert.Single(
+            Directory.GetFiles(outputPath, "*.js"),
+            path => !string.Equals(Path.GetFileName(path), "jsv-runtime.js", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("export function validate(data)", File.ReadAllText(validatorPath));
+    }
+
+    [Fact]
+    public async Task GenerateTs_NoRuntimeSkipsSupportArtifact()
+    {
+        using var workspace = TemporaryWorkspace.Create();
+        var schemaPath = workspace.WriteSchema("""{"type":"string"}""");
+        var outputPath = workspace.CreateDirectory("typescript");
+
+        var exitCode = await RunCliAsync(
+            "generate-ts",
+            "-s", schemaPath,
+            "-o", outputPath,
+            "--no-runtime");
+
+        Assert.Equal(0, exitCode);
+        Assert.False(File.Exists(Path.Combine(outputPath, "jsv-runtime.ts")));
+        var validatorPath = Assert.Single(Directory.GetFiles(outputPath, "*.ts"));
+        Assert.Contains("export function validate(data: JsonValue): boolean", File.ReadAllText(validatorPath));
+    }
+
+    private static async Task<int> RunCliAsync(params string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        try
+        {
+            Console.SetOut(output);
+            Console.SetError(error);
+            return await Program.RunAsync(args);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    private sealed class TemporaryWorkspace : IDisposable
+    {
+        private readonly string _path;
+
+        private TemporaryWorkspace(string path)
+        {
+            _path = path;
+        }
+
+        public static TemporaryWorkspace Create()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "jsv-codegen-cli-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return new TemporaryWorkspace(path);
+        }
+
+        public string WriteSchema(string schema)
+        {
+            var schemaPath = Path.Combine(_path, "schema.json");
+            File.WriteAllText(schemaPath, schema);
+            return schemaPath;
+        }
+
+        public string CreateDirectory(string name)
+        {
+            var path = Path.Combine(_path, name);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_path, recursive: true);
+            }
+            catch
+            {
+                // Best effort cleanup for Windows file-scanner races.
+            }
+        }
+    }
+}
+#endif

--- a/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
@@ -7,7 +7,9 @@ using Xunit;
 namespace FormFinch.JsonSchemaValidation.CodeGenerator.Tests;
 
 [CollectionDefinition(nameof(CodeGeneratorCliCollection), DisableParallelization = true)]
-public sealed class CodeGeneratorCliCollection;
+public sealed class CodeGeneratorCliCollection
+{
+}
 
 [Collection(nameof(CodeGeneratorCliCollection))]
 public sealed class CodeGeneratorCliTests

--- a/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
@@ -108,7 +108,7 @@ public sealed class CodeGeneratorCliTests
         {
             Console.SetOut(output);
             Console.SetError(error);
-            var exitCode = await Program.RunAsync(args);
+            var exitCode = await FormFinch.JsonSchemaValidation.CodeGenerator.Program.RunAsync(args);
             return (exitCode, output.ToString(), error.ToString());
         }
         finally

--- a/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/CodeGeneratorCliTests.cs
@@ -75,7 +75,29 @@ public sealed class CodeGeneratorCliTests
         Assert.Contains("export function validate(data: JsonValue): boolean", File.ReadAllText(validatorPath));
     }
 
+    [Fact]
+    public async Task Generate_InvalidJson_ReturnsFailure()
+    {
+        using var workspace = TemporaryWorkspace.Create();
+        var schemaPath = workspace.WriteSchema("{");
+        var outputPath = workspace.CreateDirectory("invalid");
+
+        var result = await RunCliWithOutputAsync(
+            "generate",
+            "-s", schemaPath,
+            "-o", outputPath);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Failed to parse schema JSON", result.StandardError);
+    }
+
     private static async Task<int> RunCliAsync(params string[] args)
+    {
+        var result = await RunCliWithOutputAsync(args);
+        return result.ExitCode;
+    }
+
+    private static async Task<(int ExitCode, string StandardOutput, string StandardError)> RunCliWithOutputAsync(params string[] args)
     {
         var originalOut = Console.Out;
         var originalError = Console.Error;
@@ -86,7 +108,8 @@ public sealed class CodeGeneratorCliTests
         {
             Console.SetOut(output);
             Console.SetError(error);
-            return await Program.RunAsync(args);
+            var exitCode = await Program.RunAsync(args);
+            return (exitCode, output.ToString(), error.ToString());
         }
         finally
         {

--- a/JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaValidation.CodeGenerator.Tests.csproj
+++ b/JsonSchemaValidation.CodeGenerator.Tests/JsonSchemaValidation.CodeGenerator.Tests.csproj
@@ -21,6 +21,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\JsonSchemaValidation.CodeGenerator\JsonSchemaValidation.CodeGenerator.csproj" Condition="'$(TargetFramework)' == 'net10.0'" />
     <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration.CSharp\JsonSchemaValidation.CodeGeneration.CSharp.csproj" />
     <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration\JsonSchemaValidation.CodeGeneration.csproj" />
     <ProjectReference Include="..\JsonSchemaValidation.CodeGeneration.JavaScript\JsonSchemaValidation.CodeGeneration.JavaScript.csproj" />

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -423,7 +423,7 @@ internal static class Program
             Console.WriteLine($"Generated: {validatorJsPath}");
             if (writeRuntime)
             {
-                Console.WriteLine($"Generated: {Path.Combine(outputPath, "jsv-runtime.js")}");
+                Console.WriteLine($"Generated: {Path.Combine(outputPath, Path.ChangeExtension(TsRuntime.FileName, ".js"))}");
             }
             return 0;
         }

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -3,10 +3,10 @@
 // See LICENSE file in the project root for full license information.
 using System.Text;
 using System.Text.Json;
-using FormFinch.JsonSchemaValidation.CodeGeneration.CSharp.Generator;
+using FormFinch.JsonSchemaValidation.CodeGeneration.Abstractions;
+using FormFinch.JsonSchemaValidation.CodeGeneration.CSharp;
+using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript;
 using FormFinch.JsonSchemaValidation.CodeGeneration.Schema;
-using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Generator;
-using FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript.Runtime;
 using FormFinch.JsonSchemaValidation.CodeGeneration.TypeScript;
 using FormFinch.JsonSchemaValidation.Common;
 
@@ -14,7 +14,16 @@ namespace FormFinch.JsonSchemaValidation.CodeGenerator;
 
 internal static class Program
 {
-    private static int Main(string[] args)
+    private const string CSharpTargetId = "csharp";
+    private const string JavaScriptTargetId = "javascript";
+    private const string TypeScriptTargetId = "typescript";
+
+    private static async Task<int> Main(string[] args)
+    {
+        return await RunAsync(args);
+    }
+
+    internal static async Task<int> RunAsync(string[] args)
     {
         if (args.Length == 0)
         {
@@ -22,20 +31,21 @@ internal static class Program
             return 1;
         }
 
+        var targets = CreateTargetRegistry();
         var command = args[0].ToLowerInvariant();
         var remainingArgs = args.Skip(1).ToArray();
 
-        return command switch
+        return await (command switch
         {
-            "generate" => HandleGenerate(remainingArgs),
-            "generate-js" => HandleGenerateJs(remainingArgs),
-            "generate-ts" => HandleGenerateTs(remainingArgs),
-            "generate-metaschemas" => HandleGenerateMetaschemas(remainingArgs),
-            "compile-test-schemas" => HandleCompileTestSchemas(remainingArgs),
-            "analyze" => HandleAnalyze(remainingArgs),
-            "--help" or "-h" or "help" => PrintUsage(),
-            _ => PrintUsage()
-        };
+            "generate" => HandleGenerateAsync(remainingArgs, targets),
+            "generate-js" => HandleGenerateJsAsync(remainingArgs, targets),
+            "generate-ts" => HandleGenerateTsAsync(remainingArgs, targets),
+            "generate-metaschemas" => HandleGenerateMetaschemasAsync(remainingArgs, targets),
+            "compile-test-schemas" => HandleCompileTestSchemasAsync(remainingArgs, targets),
+            "analyze" => Task.FromResult(HandleAnalyze(remainingArgs)),
+            "--help" or "-h" or "help" => Task.FromResult(PrintUsage()),
+            _ => Task.FromResult(PrintUsage())
+        });
     }
 
     private static int PrintUsage()
@@ -112,7 +122,9 @@ internal static class Program
         return 1;
     }
 
-    private static int HandleGenerate(string[] args)
+    private static async Task<int> HandleGenerateAsync(
+        string[] args,
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets)
     {
         string? schemaPath = null;
         string? outputPath = null;
@@ -176,23 +188,23 @@ internal static class Program
         Console.WriteLine($"Output directory: {outputPath}");
         Console.WriteLine($"Namespace: {namespaceName}");
 
-        // Use GeneratedRegex for AOT compilation - source generator will provide implementations
-        var generator = new CSharpSchemaCodeGenerator { UseGeneratedRegex = true };
-        var result = generator.Generate(schemaPath, namespaceName, className);
-
-        if (result.Success)
+        var options = new CSharpCodeGenerationOptions
         {
-            var fullOutputPath = Path.Combine(outputPath, result.FileName!);
-            File.WriteAllText(fullOutputPath, result.GeneratedCode);
-            Console.WriteLine($"Generated: {fullOutputPath}");
-            return 0;
-        }
+            SourcePath = schemaPath,
+            UseGeneratedRegex = true,
+            OutputHints = new CodeGenerationOutputHints
+            {
+                NamespaceName = namespaceName,
+                TypeName = className
+            }
+        };
 
-        Console.Error.WriteLine($"Generation failed: {result.Error}");
-        return 1;
+        return await GenerateWithTargetAsync(targets, CSharpTargetId, schemaPath, outputPath, options);
     }
 
-    private static int HandleGenerateJs(string[] args)
+    private static async Task<int> HandleGenerateJsAsync(
+        string[] args,
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets)
     {
         string? schemaPath = null;
         string? outputPath = null;
@@ -293,7 +305,8 @@ internal static class Program
 
         if (string.Equals(pipeline, "typescript", StringComparison.OrdinalIgnoreCase))
         {
-            return HandleGenerateJsFromTypeScript(
+            return await HandleGenerateJsFromTypeScriptAsync(
+                targets,
                 schemaPath,
                 outputPath,
                 writeRuntime,
@@ -318,31 +331,18 @@ internal static class Program
             return 1;
         }
 
-        var generator = new JsSchemaCodeGenerator
+        var options = new JavaScriptCodeGenerationOptions
         {
+            SourcePath = schemaPath,
+            EmitSupportArtifacts = writeRuntime,
             FormatAssertionEnabled = formatAssertionEnabled
         };
-        var result = generator.Generate(schemaPath);
-        if (!result.Success)
-        {
-            Console.Error.WriteLine($"Generation failed: {result.Error}");
-            return 1;
-        }
 
-        var validatorPath = Path.Combine(outputPath, result.FileName!);
-        File.WriteAllText(validatorPath, result.GeneratedCode!);
-        Console.WriteLine($"Generated: {validatorPath}");
-
-        if (writeRuntime)
-        {
-            var runtimePath = Path.Combine(outputPath, JsRuntime.FileName);
-            File.WriteAllText(runtimePath, JsRuntime.GetSource());
-            Console.WriteLine($"Generated: {runtimePath}");
-        }
-        return 0;
+        return await GenerateWithTargetAsync(targets, JavaScriptTargetId, schemaPath, outputPath, options);
     }
 
-    private static int HandleGenerateJsFromTypeScript(
+    private static async Task<int> HandleGenerateJsFromTypeScriptAsync(
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets,
         string schemaPath,
         string outputPath,
         bool writeRuntime,
@@ -353,14 +353,25 @@ internal static class Program
         Console.WriteLine("Pipeline: TypeScript-first via tsc");
         Console.WriteLine($"ECMAScript target: {ecmaScriptTarget}");
 
-        var generator = new TsSchemaCodeGenerator
+        var options = new TypeScriptCodeGenerationOptions
         {
+            SourcePath = schemaPath,
+            EmitSupportArtifacts = writeRuntime,
             FormatAssertionEnabled = formatAssertionEnabled
         };
-        var result = generator.Generate(schemaPath);
+
+        var request = CreateGenerationRequest(schemaPath, options);
+        var capabilityResult = await GetTarget(targets, TypeScriptTargetId).GetCapabilitiesAsync(request);
+        if (!capabilityResult.CanGenerate)
+        {
+            PrintDiagnostics(capabilityResult.Diagnostics);
+            return 1;
+        }
+
+        var result = await GetTarget(targets, TypeScriptTargetId).GenerateAsync(request);
         if (!result.Success)
         {
-            Console.Error.WriteLine($"Generation failed: {result.Error}");
+            PrintGenerationFailure(result.Diagnostics);
             return 1;
         }
 
@@ -368,21 +379,25 @@ internal static class Program
         Directory.CreateDirectory(tempPath);
         try
         {
-            var validatorTsPath = Path.Combine(tempPath, result.FileName!);
-            var runtimeTsPath = Path.Combine(tempPath, TsRuntime.FileName);
-            var runtimeDeclarationPath = Path.Combine(tempPath, TsRuntime.DeclarationFileName);
-            File.WriteAllText(validatorTsPath, result.GeneratedCode!);
-            if (writeRuntime)
+            if (!TryGetSinglePrimaryArtifact(result.Artifacts, out var primaryArtifact, out var primaryArtifactError))
             {
-                File.WriteAllText(runtimeTsPath, TsRuntime.GetSource());
+                Console.Error.WriteLine($"Generation failed: {primaryArtifactError}");
+                return 1;
             }
-            else
+
+            var artifactPaths = WriteArtifacts(tempPath, result.Artifacts, announce: false);
+            var validatorTsPath = Path.GetFullPath(Path.Combine(tempPath, primaryArtifact.RelativePath));
+            var runtimeDeclarationPath = Path.Combine(tempPath, TsRuntime.DeclarationFileName);
+
+            if (!writeRuntime)
             {
                 File.WriteAllText(runtimeDeclarationPath, TsRuntime.GetDeclarationSource());
             }
 
             IReadOnlyList<string> sourcePaths = writeRuntime
-                ? [validatorTsPath, runtimeTsPath]
+                ? artifactPaths
+                    .Where(path => string.Equals(Path.GetExtension(path), ".ts", StringComparison.OrdinalIgnoreCase))
+                    .ToArray()
                 : [validatorTsPath, runtimeDeclarationPath];
 
             var compilationResult = TypeScriptCompiler.Compile(
@@ -404,11 +419,11 @@ internal static class Program
                 return 1;
             }
 
-            var validatorJsPath = Path.Combine(outputPath, Path.ChangeExtension(result.FileName!, ".js"));
+            var validatorJsPath = Path.Combine(outputPath, Path.ChangeExtension(primaryArtifact.RelativePath, ".js"));
             Console.WriteLine($"Generated: {validatorJsPath}");
             if (writeRuntime)
             {
-                Console.WriteLine($"Generated: {Path.Combine(outputPath, JsRuntime.FileName)}");
+                Console.WriteLine($"Generated: {Path.Combine(outputPath, "jsv-runtime.js")}");
             }
             return 0;
         }
@@ -418,7 +433,9 @@ internal static class Program
         }
     }
 
-    private static int HandleGenerateTs(string[] args)
+    private static async Task<int> HandleGenerateTsAsync(
+        string[] args,
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets)
     {
         string? schemaPath = null;
         string? outputPath = null;
@@ -483,28 +500,14 @@ internal static class Program
         Console.WriteLine($"Generating TS validator for: {schemaPath}");
         Console.WriteLine($"Output directory: {outputPath}");
 
-        var generator = new TsSchemaCodeGenerator
+        var options = new TypeScriptCodeGenerationOptions
         {
+            SourcePath = schemaPath,
+            EmitSupportArtifacts = writeRuntime,
             FormatAssertionEnabled = formatAssertionEnabled
         };
-        var result = generator.Generate(schemaPath);
-        if (!result.Success)
-        {
-            Console.Error.WriteLine($"Generation failed: {result.Error}");
-            return 1;
-        }
 
-        var validatorPath = Path.Combine(outputPath, result.FileName!);
-        File.WriteAllText(validatorPath, result.GeneratedCode!);
-        Console.WriteLine($"Generated: {validatorPath}");
-
-        if (writeRuntime)
-        {
-            var runtimePath = Path.Combine(outputPath, TsRuntime.FileName);
-            File.WriteAllText(runtimePath, TsRuntime.GetSource());
-            Console.WriteLine($"Generated: {runtimePath}");
-        }
-        return 0;
+        return await GenerateWithTargetAsync(targets, TypeScriptTargetId, schemaPath, outputPath, options);
     }
 
     /// <summary>
@@ -520,7 +523,179 @@ internal static class Program
         return !string.IsNullOrEmpty(arg);
     }
 
-    private static int HandleGenerateMetaschemas(string[] args)
+    private static IReadOnlyDictionary<string, ICodeGenerationTarget> CreateTargetRegistry()
+    {
+        ICodeGenerationTarget[] targets =
+        [
+            new CSharpCodeGenerationTarget(),
+            new JavaScriptCodeGenerationTarget(),
+            new TypeScriptCodeGenerationTarget()
+        ];
+
+        return targets.ToDictionary(target => target.Descriptor.Id, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static ICodeGenerationTarget GetTarget(
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets,
+        string targetId)
+    {
+        if (targets.TryGetValue(targetId, out var target))
+        {
+            return target;
+        }
+
+        throw new InvalidOperationException($"Code generation target '{targetId}' is not registered.");
+    }
+
+    private static async Task<int> GenerateWithTargetAsync(
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets,
+        string targetId,
+        string schemaPath,
+        string outputPath,
+        CodeGenerationOptions options)
+    {
+        var target = GetTarget(targets, targetId);
+        var request = CreateGenerationRequest(schemaPath, options);
+        var capabilityResult = await target.GetCapabilitiesAsync(request);
+        if (!capabilityResult.CanGenerate)
+        {
+            PrintDiagnostics(capabilityResult.Diagnostics);
+            return 1;
+        }
+
+        var result = await target.GenerateAsync(request);
+        if (!result.Success)
+        {
+            PrintGenerationFailure(result.Diagnostics);
+            return 1;
+        }
+
+        WriteArtifacts(outputPath, result.Artifacts, announce: true);
+        return 0;
+    }
+
+    private static CodeGenerationRequest CreateGenerationRequest(
+        string schemaPath,
+        CodeGenerationOptions options)
+    {
+        using var schemaDocument = JsonDocument.Parse(File.ReadAllText(schemaPath));
+        return new CodeGenerationRequest
+        {
+            Schema = schemaDocument.RootElement.Clone(),
+            Options = options
+        };
+    }
+
+    private static IReadOnlyList<string> WriteArtifacts(
+        string outputDirectory,
+        IReadOnlyList<GeneratedArtifact> artifacts,
+        bool announce)
+    {
+        var outputRoot = Path.GetFullPath(outputDirectory);
+        var outputRootWithSeparator = EnsureTrailingDirectorySeparator(outputRoot);
+        var writtenPaths = new List<string>(artifacts.Count);
+
+        foreach (var artifact in artifacts)
+        {
+            if (string.IsNullOrWhiteSpace(artifact.RelativePath))
+            {
+                throw new InvalidOperationException("Generated artifact has no relative path.");
+            }
+
+            if (Path.IsPathRooted(artifact.RelativePath))
+            {
+                throw new InvalidOperationException(
+                    $"Generated artifact path must be relative: {artifact.RelativePath}");
+            }
+
+            var artifactPath = Path.GetFullPath(Path.Combine(outputRoot, artifact.RelativePath));
+            if (!artifactPath.StartsWith(outputRootWithSeparator, GetPathComparison()))
+            {
+                throw new InvalidOperationException(
+                    $"Generated artifact path escapes the output directory: {artifact.RelativePath}");
+            }
+
+            var artifactDirectory = Path.GetDirectoryName(artifactPath);
+            if (!string.IsNullOrEmpty(artifactDirectory))
+            {
+                Directory.CreateDirectory(artifactDirectory);
+            }
+
+            File.WriteAllText(artifactPath, artifact.Content);
+            writtenPaths.Add(artifactPath);
+            if (announce)
+            {
+                Console.WriteLine($"Generated: {artifactPath}");
+            }
+        }
+
+        return writtenPaths;
+    }
+
+    private static string EnsureTrailingDirectorySeparator(string path)
+    {
+        return Path.EndsInDirectorySeparator(path)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+    }
+
+    private static StringComparison GetPathComparison()
+    {
+        return OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+    }
+
+    private static void PrintGenerationFailure(IReadOnlyList<CodeGenerationDiagnostic> diagnostics)
+    {
+        Console.Error.WriteLine($"Generation failed: {FormatDiagnostics(diagnostics)}");
+    }
+
+    private static void PrintDiagnostics(IReadOnlyList<CodeGenerationDiagnostic> diagnostics)
+    {
+        if (diagnostics.Count == 0)
+        {
+            Console.Error.WriteLine("Generation failed: target reported that the schema is unsupported.");
+            return;
+        }
+
+        foreach (var diagnostic in diagnostics)
+        {
+            Console.Error.WriteLine($"{diagnostic.Code}: {diagnostic.Message}");
+        }
+    }
+
+    private static string FormatDiagnostics(IReadOnlyList<CodeGenerationDiagnostic> diagnostics)
+    {
+        return diagnostics.Count == 0
+            ? "Unknown error."
+            : string.Join("; ", diagnostics.Select(diagnostic => diagnostic.Message));
+    }
+
+    private static bool TryGetSinglePrimaryArtifact(
+        IReadOnlyList<GeneratedArtifact> artifacts,
+        out GeneratedArtifact primaryArtifact,
+        out string error)
+    {
+        var primaryArtifacts = artifacts
+            .Where(artifact => artifact.Role == GeneratedArtifactRole.Primary)
+            .ToArray();
+
+        if (primaryArtifacts.Length == 1)
+        {
+            primaryArtifact = primaryArtifacts[0];
+            error = string.Empty;
+            return true;
+        }
+
+        primaryArtifact = null!;
+        error = $"Expected exactly one primary generated artifact, but target emitted {primaryArtifacts.Length}.";
+        return false;
+    }
+
+    private static async Task<int> HandleGenerateMetaschemasAsync(
+        string[] args,
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets)
     {
         string? outputPath = null;
         string? libPath = null;
@@ -573,8 +748,7 @@ internal static class Program
         Console.WriteLine($"Output directory: {outputPath}");
         Console.WriteLine();
 
-        // Use GeneratedRegex for AOT compilation - source generator will provide implementations
-        var generator = new CSharpSchemaCodeGenerator { UseGeneratedRegex = true };
+        var target = GetTarget(targets, CSharpTargetId);
         var successCount = 0;
         var failCount = 0;
 
@@ -595,21 +769,43 @@ internal static class Program
                 Directory.CreateDirectory(draftOutputPath);
             }
 
-            var result = generator.Generate(
-                schemaPath,
-                "FormFinch.JsonSchemaValidation.CompiledValidators.Generated",
-                $"CompiledValidator_{schema.ClassName}");
+            var options = new CSharpCodeGenerationOptions
+            {
+                SourcePath = schemaPath,
+                UseGeneratedRegex = true,
+                OutputHints = new CodeGenerationOutputHints
+                {
+                    NamespaceName = "FormFinch.JsonSchemaValidation.CompiledValidators.Generated",
+                    TypeName = $"CompiledValidator_{schema.ClassName}"
+                }
+            };
+            var request = CreateGenerationRequest(schemaPath, options);
+            var capabilityResult = await target.GetCapabilitiesAsync(request);
+            if (!capabilityResult.CanGenerate)
+            {
+                Console.Error.WriteLine($"  FAIL: {schema.FileName} - {FormatDiagnostics(capabilityResult.Diagnostics)}");
+                failCount++;
+                continue;
+            }
+
+            var result = await target.GenerateAsync(request);
 
             if (result.Success)
             {
-                var fullOutputPath = Path.Combine(draftOutputPath, result.FileName!);
-                File.WriteAllText(fullOutputPath, result.GeneratedCode);
-                Console.WriteLine($"  OK: {schema.DraftFolder}/{result.FileName}");
+                if (!TryGetSinglePrimaryArtifact(result.Artifacts, out var primaryArtifact, out var primaryArtifactError))
+                {
+                    Console.Error.WriteLine($"  FAIL: {schema.FileName} - {primaryArtifactError}");
+                    failCount++;
+                    continue;
+                }
+
+                WriteArtifacts(draftOutputPath, result.Artifacts, announce: false);
+                Console.WriteLine($"  OK: {schema.DraftFolder}/{Path.GetFileName(primaryArtifact.RelativePath)}");
                 successCount++;
             }
             else
             {
-                Console.Error.WriteLine($"  FAIL: {schema.FileName} - {result.Error}");
+                Console.Error.WriteLine($"  FAIL: {schema.FileName} - {FormatDiagnostics(result.Diagnostics)}");
                 failCount++;
             }
         }
@@ -620,7 +816,9 @@ internal static class Program
         return failCount > 0 ? 1 : 0;
     }
 
-    private static int HandleCompileTestSchemas(string[] args)
+    private static async Task<int> HandleCompileTestSchemasAsync(
+        string[] args,
+        IReadOnlyDictionary<string, ICodeGenerationTarget> targets)
     {
         string? testSuitePath = null;
         string? outputPath = null;
@@ -717,8 +915,7 @@ internal static class Program
             draftDirs.Add(dir);
         }
 
-        // Use GeneratedRegex for AOT compilation - source generator will provide implementations
-        var generator = new CSharpSchemaCodeGenerator { UseGeneratedRegex = true };
+        var target = GetTarget(targets, CSharpTargetId);
         var uniqueSchemas = new Dictionary<string, (JsonElement Schema, string DraftName)>(StringComparer.Ordinal);
         var successCount = 0;
         var failCount = 0;
@@ -778,24 +975,38 @@ internal static class Program
         Console.WriteLine("Phase 2: Generating compiled validators...");
         var generatedValidators = new List<(string Hash, string ClassName)>();
 
-        foreach (var (hash, (schema, draftName)) in uniqueSchemas)
+        foreach (var (hash, (schema, _)) in uniqueSchemas)
         {
             var className = $"CompiledTestSchema_{hash}";
 
             try
             {
-                // Write schema to temp file for generator
-                var tempSchemaPath = Path.Combine(Path.GetTempPath(), $"schema_{hash}.json");
-                File.WriteAllText(tempSchemaPath, schema.GetRawText());
+                var request = new CodeGenerationRequest
+                {
+                    Schema = schema,
+                    Options = new CSharpCodeGenerationOptions
+                    {
+                        SourcePath = $"{className}.json",
+                        UseGeneratedRegex = true,
+                        OutputHints = new CodeGenerationOutputHints
+                        {
+                            NamespaceName = namespaceName,
+                            TypeName = className
+                        }
+                    }
+                };
+                var capabilityResult = await target.GetCapabilitiesAsync(request);
+                if (!capabilityResult.CanGenerate)
+                {
+                    skippedCount++;
+                    continue;
+                }
 
-                var result = generator.Generate(tempSchemaPath, namespaceName, className);
-
-                File.Delete(tempSchemaPath);
+                var result = await target.GenerateAsync(request);
 
                 if (result.Success)
                 {
-                    var fullOutputPath = Path.Combine(outputPath, $"{className}.cs");
-                    File.WriteAllText(fullOutputPath, result.GeneratedCode);
+                    WriteArtifacts(outputPath, result.Artifacts, announce: false);
                     generatedValidators.Add((hash, className));
                     successCount++;
                 }

--- a/JsonSchemaValidation.CodeGenerator/Program.cs
+++ b/JsonSchemaValidation.CodeGenerator/Program.cs
@@ -360,7 +360,12 @@ internal static class Program
             FormatAssertionEnabled = formatAssertionEnabled
         };
 
-        var request = CreateGenerationRequest(schemaPath, options);
+        if (!TryCreateGenerationRequest(schemaPath, options, out var request, out var requestError))
+        {
+            Console.Error.WriteLine($"Generation failed: {requestError}");
+            return 1;
+        }
+
         var capabilityResult = await GetTarget(targets, TypeScriptTargetId).GetCapabilitiesAsync(request);
         if (!capabilityResult.CanGenerate)
         {
@@ -555,7 +560,12 @@ internal static class Program
         CodeGenerationOptions options)
     {
         var target = GetTarget(targets, targetId);
-        var request = CreateGenerationRequest(schemaPath, options);
+        if (!TryCreateGenerationRequest(schemaPath, options, out var request, out var requestError))
+        {
+            Console.Error.WriteLine($"Generation failed: {requestError}");
+            return 1;
+        }
+
         var capabilityResult = await target.GetCapabilitiesAsync(request);
         if (!capabilityResult.CanGenerate)
         {
@@ -574,16 +584,41 @@ internal static class Program
         return 0;
     }
 
-    private static CodeGenerationRequest CreateGenerationRequest(
+    private static bool TryCreateGenerationRequest(
         string schemaPath,
-        CodeGenerationOptions options)
+        CodeGenerationOptions options,
+        out CodeGenerationRequest request,
+        out string error)
     {
-        using var schemaDocument = JsonDocument.Parse(File.ReadAllText(schemaPath));
-        return new CodeGenerationRequest
+        try
         {
-            Schema = schemaDocument.RootElement.Clone(),
-            Options = options
-        };
+            using var schemaDocument = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            request = new CodeGenerationRequest
+            {
+                Schema = schemaDocument.RootElement.Clone(),
+                Options = options
+            };
+            error = string.Empty;
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            request = null!;
+            error = $"Failed to parse schema JSON '{schemaPath}': {ex.Message}";
+            return false;
+        }
+        catch (IOException ex)
+        {
+            request = null!;
+            error = $"Failed to read schema file '{schemaPath}': {ex.Message}";
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            request = null!;
+            error = $"Failed to read schema file '{schemaPath}': {ex.Message}";
+            return false;
+        }
     }
 
     private static IReadOnlyList<string> WriteArtifacts(
@@ -779,7 +814,13 @@ internal static class Program
                     TypeName = $"CompiledValidator_{schema.ClassName}"
                 }
             };
-            var request = CreateGenerationRequest(schemaPath, options);
+            if (!TryCreateGenerationRequest(schemaPath, options, out var request, out var requestError))
+            {
+                Console.Error.WriteLine($"  FAIL: {schema.FileName} - {requestError}");
+                failCount++;
+                continue;
+            }
+
             var capabilityResult = await target.GetCapabilitiesAsync(request);
             if (!capabilityResult.CanGenerate)
             {

--- a/JsonSchemaValidation.CodeGenerator/Properties/AssemblyInfo.cs
+++ b/JsonSchemaValidation.CodeGenerator/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 FormFinch VOF
+// Licensed under the PolyForm Noncommercial License 1.0.0.
+// See LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FormFinch.JsonSchemaValidation.CodeGenerator.Tests")]

--- a/README.md
+++ b/README.md
@@ -78,22 +78,24 @@ This library is dual-licensed:
 
 See [COMMERCIAL.md](https://github.com/formfinch/JsonSchemaValidation/blob/main/COMMERCIAL.md) for details.
 
-## JavaScript Code-Gen (Preview)
+## Code-Gen Targets (Preview)
 
-`jsv-codegen` can emit compiled JavaScript validators for use in browsers, Node, or bundlers — the same source-of-truth schema validates on both server (.NET) and client (JS).
+`jsv-codegen` composes pluggable C#, JavaScript, and TypeScript targets through the central `FormFinch.JsonSchemaValidation.CodeGeneration` contract. Existing command aliases remain available:
 
 ```bash
+jsv-codegen generate -s schema.json -o ./Generated/ -n MyApp.Generated -c PersonValidator
 jsv-codegen generate-js -s schema.json -o ./src/validators/
+jsv-codegen generate-ts -s schema.json -o ./src/validators/
 ```
 
-This writes `<schema>.js` (an ESM module exporting `validate(data): boolean`) and a sibling `jsv-runtime.js` (shared helpers and format validators). Import and use:
+The JavaScript target emits ESM validators for use in browsers, Node, or bundlers. `generate-js` writes `<schema>.js` (an ESM module exporting `validate(data): boolean`) and a sibling `jsv-runtime.js` (shared helpers and format validators). Import and use:
 
 ```js
 import validator from "./src/validators/person.js";
 if (!validator.validate(data)) { /* reject */ }
 ```
 
-MVP scope: Drafts 2020-12 and 4, self-contained schemas with local `$ref` only. See [Known Limitations](https://github.com/formfinch/JsonSchemaValidation/blob/main/KNOWN_LIMITATIONS.md#javascript-code-gen-target-jsv-codegen-generate-js) for the full list of deferred features and behavioral notes.
+Current JS/TS scope: Drafts 2020-12, 2019-09, and 4 with target capability checks before emission. See [Known Limitations](https://github.com/formfinch/JsonSchemaValidation/blob/main/KNOWN_LIMITATIONS.md#javascript-code-gen-target-jsv-codegen-generate-js) for the full list of deferred features and behavioral notes.
 
 ## Documentation
 


### PR DESCRIPTION
Part of #35.
Closes #41.

## Summary
- register C#, JavaScript, and TypeScript code generation targets explicitly in `jsv-codegen`
- route existing `generate`, `generate-js`, and `generate-ts` aliases through the central target contract
- centralize artifact writing and capability diagnostics in the CLI
- update CLI regression tests and docs for the pluggable target assembly structure

## Verification
- `dotnet build JsonSchemaValidation.CodeGenerator\JsonSchemaValidation.CodeGenerator.csproj --no-restore`
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --framework net10.0 --no-restore`
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --framework net8.0 --no-restore`
- `dotnet build JsonSchemaValidationSolution.slnx --no-restore`
- `git diff --check`