### PR TITLE
Tighten TypeScript runtime ABI

### DIFF
--- a/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsDynamicRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsDynamicRefCodeGenerator.cs
@@ -50,7 +50,12 @@ public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
         return GenerateExternalDynamicRefCode(context, refValue);
     }
 
-    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context) => [];
+    public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
+    {
+        return context.RequiresScopeTracking && !context.RequiresAnnotationTracking
+            ? ["EMPTY_EVALUATED_STATE"]
+            : [];
+    }
 
     private static string GenerateLocalDynamicRefCode(TsCodeGenerationContext context, string anchorName, string refValue)
     {
@@ -185,6 +190,10 @@ public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
         {
             args.Add(context.EvaluatedStateExpr);
         }
+        else
+        {
+            args.Add("EMPTY_EVALUATED_STATE");
+        }
         args.Add(context.LocationExpr);
         if (context.RequiresRegistry)
         {
@@ -225,8 +234,8 @@ public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
                     ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
                     : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
                 : context.RequiresRegistry
-                    ? $"(data, scope, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
-                    : $"(data, scope, location = \"\") => validate_{schemaHash}(data, scope, location)";
+                    ? $"(data, scope, _evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
+                    : $"(data, scope, _evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, location)";
             sb.AppendLine($"    {TsLiteral.String(anchorName)}: {delegateExpr},");
         }
         sb.AppendLine("  }");

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsDynamicRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsDynamicRefCodeGenerator.cs
@@ -53,7 +53,7 @@ public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
     public IEnumerable<string> GetRuntimeImports(TsCodeGenerationContext context)
     {
         return context.RequiresScopeTracking && !context.RequiresAnnotationTracking
-            ? ["EMPTY_EVALUATED_STATE"]
+            ? ["EMPTY_EVALUATED_STATE", "EvaluatedState"]
             : [];
     }
 
@@ -192,7 +192,7 @@ public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
         }
         else
         {
-            args.Add("EMPTY_EVALUATED_STATE");
+            args.Add($"{validatorExpr}.ignoresEvaluatedState === true ? EMPTY_EVALUATED_STATE : new EvaluatedState()");
         }
         args.Add(context.LocationExpr);
         if (context.RequiresRegistry)
@@ -234,8 +234,8 @@ public sealed class TsDynamicRefCodeGenerator : ITsKeywordCodeGenerator
                     ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
                     : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
                 : context.RequiresRegistry
-                    ? $"(data, scope, _evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
-                    : $"(data, scope, _evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, location)";
+                    ? $"Object.assign((data: JsonValue, scope: CompiledValidatorScope, _evaluatedState: EvaluatedState, location: JsonPointer = \"\", registry: ValidatorRegistry = null) => validate_{schemaHash}(data, scope, location, registry), {{ ignoresEvaluatedState: true }})"
+                    : $"Object.assign((data: JsonValue, scope: CompiledValidatorScope, _evaluatedState: EvaluatedState, location: JsonPointer = \"\") => validate_{schemaHash}(data, scope, location), {{ ignoresEvaluatedState: true }})";
             sb.AppendLine($"    {TsLiteral.String(anchorName)}: {delegateExpr},");
         }
         sb.AppendLine("  }");

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsRefCodeGenerator.cs
@@ -235,8 +235,8 @@ public sealed class TsRefCodeGenerator : ITsKeywordCodeGenerator
                     ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
                     : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
                 : context.RequiresRegistry
-                    ? $"(data, scope, _evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
-                    : $"(data, scope, _evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, location)";
+                    ? $"Object.assign((data: JsonValue, scope: CompiledValidatorScope, _evaluatedState: EvaluatedState, location: JsonPointer = \"\", registry: ValidatorRegistry = null) => validate_{schemaHash}(data, scope, location, registry), {{ ignoresEvaluatedState: true }})"
+                    : $"Object.assign((data: JsonValue, scope: CompiledValidatorScope, _evaluatedState: EvaluatedState, location: JsonPointer = \"\") => validate_{schemaHash}(data, scope, location), {{ ignoresEvaluatedState: true }})";
             sb.AppendLine($"      {TsLiteral.String(anchorName)}: {delegateExpr},");
         }
         sb.AppendLine("    }");

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsRefCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/Keywords/TsRefCodeGenerator.cs
@@ -235,8 +235,8 @@ public sealed class TsRefCodeGenerator : ITsKeywordCodeGenerator
                     ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
                     : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
                 : context.RequiresRegistry
-                    ? $"(data, scope, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
-                    : $"(data, scope, location = \"\") => validate_{schemaHash}(data, scope, location)";
+                    ? $"(data, scope, _evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
+                    : $"(data, scope, _evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, location)";
             sb.AppendLine($"      {TsLiteral.String(anchorName)}: {delegateExpr},");
         }
         sb.AppendLine("    }");

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/Runtime/jsv-runtime.ts
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/Runtime/jsv-runtime.ts
@@ -43,13 +43,13 @@ type SegmenterConstructor = new (
 ) => SegmenterLike;
 type IntlWithSegmenter = typeof Intl & { Segmenter?: SegmenterConstructor };
 type RegexGroups = Record<string, string | undefined>;
-type DynamicAnchorValidator = (
+export type DynamicAnchorValidator = ((
     data: JsonValue,
     scope: CompiledValidatorScope,
     evaluatedState: EvaluatedState,
     location?: JsonPointer,
     registry?: ValidatorRegistry
-) => boolean;
+) => boolean) & { ignoresEvaluatedState?: boolean };
 
 export type CompiledScopeEntry = {
     dynamicAnchors?: Record<string, DynamicAnchorValidator> | null;
@@ -227,6 +227,7 @@ export class EvaluatedState {
     }
 }
 
+// Shared sentinel for generated dynamic-anchor delegates that explicitly ignore evaluated state.
 export const EMPTY_EVALUATED_STATE = new EvaluatedState();
 
 export class Registry {

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/Runtime/jsv-runtime.ts
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/Runtime/jsv-runtime.ts
@@ -46,8 +46,8 @@ type RegexGroups = Record<string, string | undefined>;
 type DynamicAnchorValidator = (
     data: JsonValue,
     scope: CompiledValidatorScope,
-    evaluatedStateOrLocation?: EvaluatedState | JsonPointer,
-    locationOrRegistry?: JsonPointer | ValidatorRegistry,
+    evaluatedState: EvaluatedState,
+    location?: JsonPointer,
     registry?: ValidatorRegistry
 ) => boolean;
 
@@ -226,6 +226,8 @@ export class EvaluatedState {
         this.mergeFrom(snapshot);
     }
 }
+
+export const EMPTY_EVALUATED_STATE = new EvaluatedState();
 
 export class Registry {
     private readonly _validators = new Map<string, ValidatorHandle>();

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/TsRuntime.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/TsRuntime.cs
@@ -62,7 +62,7 @@ public static class TsRuntime
             }
             export type ValidatorHandle = ValidatorFn | FragmentValidator | ValidatorModule;
             export type ValidatorRegistry = { tryGetValidator(uri: string): ValidatorHandle | null } | null;
-            export type DynamicAnchorValidator = (data: JsonValue, scope: CompiledValidatorScope, evaluatedState: EvaluatedState, location?: JsonPointer, registry?: ValidatorRegistry) => boolean;
+            export type DynamicAnchorValidator = ((data: JsonValue, scope: CompiledValidatorScope, evaluatedState: EvaluatedState, location?: JsonPointer, registry?: ValidatorRegistry) => boolean) & { ignoresEvaluatedState?: boolean };
             export type CompiledScopeEntry = {
               dynamicAnchors?: Record<string, DynamicAnchorValidator> | null;
               hasRecursiveAnchor?: boolean;
@@ -84,6 +84,7 @@ public static class TsRuntime
               isItemEvaluated(location: string, index: number): boolean;
               setEvaluatedItemsUpTo(location: string, count: number): void;
             }
+            /** Shared sentinel for generated dynamic-anchor delegates that explicitly ignore evaluated state. */
             export const EMPTY_EVALUATED_STATE: EvaluatedState;
             export class Registry {
               registerForUri(uri: string, validator: ValidatorHandle): void;

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/TsRuntime.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/TsRuntime.cs
@@ -62,7 +62,7 @@ public static class TsRuntime
             }
             export type ValidatorHandle = ValidatorFn | FragmentValidator | ValidatorModule;
             export type ValidatorRegistry = { tryGetValidator(uri: string): ValidatorHandle | null } | null;
-            export type DynamicAnchorValidator = (data: JsonValue, scope: CompiledValidatorScope, evaluatedStateOrLocation?: EvaluatedState | JsonPointer, locationOrRegistry?: JsonPointer | ValidatorRegistry, registry?: ValidatorRegistry) => boolean;
+            export type DynamicAnchorValidator = (data: JsonValue, scope: CompiledValidatorScope, evaluatedState: EvaluatedState, location?: JsonPointer, registry?: ValidatorRegistry) => boolean;
             export type CompiledScopeEntry = {
               dynamicAnchors?: Record<string, DynamicAnchorValidator> | null;
               hasRecursiveAnchor?: boolean;
@@ -84,6 +84,7 @@ public static class TsRuntime
               isItemEvaluated(location: string, index: number): boolean;
               setEvaluatedItemsUpTo(location: string, count: number): void;
             }
+            export const EMPTY_EVALUATED_STATE: EvaluatedState;
             export class Registry {
               registerForUri(uri: string, validator: ValidatorHandle): void;
               tryGetValidator(uri: string): ValidatorHandle | null;

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/TsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/TsSchemaCodeGenerator.cs
@@ -179,6 +179,19 @@ public sealed class TsSchemaCodeGenerator
 
             var methods = new StringBuilder();
             var runtimeImports = new SortedSet<string>(StringComparer.Ordinal);
+            var runtimeTypeImports = new SortedSet<string>(StringComparer.Ordinal)
+            {
+                "FragmentValidator",
+                "JsonValue",
+            };
+            if (requiresScopeTracking || requiresPropertyAnnotations || requiresItemAnnotations)
+            {
+                runtimeTypeImports.Add("JsonPointer");
+            }
+            if (requiresRegistryParameter)
+            {
+                runtimeTypeImports.Add("ValidatorRegistry");
+            }
             if (requiresPropertyAnnotations || requiresItemAnnotations)
             {
                 runtimeImports.Add("EvaluatedState");
@@ -211,6 +224,7 @@ public sealed class TsSchemaCodeGenerator
                 rootHash,
                 methods.ToString(),
                 runtimeImports,
+                runtimeTypeImports,
                 requiresPropertyAnnotations || requiresItemAnnotations,
                 requiresScopeTracking,
                 requiresRegistryParameter,
@@ -253,15 +267,15 @@ public sealed class TsSchemaCodeGenerator
         var parameterParts = new List<string> { "v: JsonValue" };
         if (requiresScopeTracking)
         {
-            parameterParts.Add("_scope: any");
+            parameterParts.Add("_scope: CompiledValidatorScope");
         }
         if (requiresPropertyAnnotations || requiresItemAnnotations)
         {
-            parameterParts.Add("_eval: any");
+            parameterParts.Add("_eval: EvaluatedState");
         }
         if (requiresScopeTracking || requiresPropertyAnnotations || requiresItemAnnotations)
         {
-            parameterParts.Add("_loc: string");
+            parameterParts.Add("_loc: JsonPointer");
         }
         if (requiresRegistryParameter)
         {
@@ -458,6 +472,7 @@ public sealed class TsSchemaCodeGenerator
         string rootHash,
         string methods,
         SortedSet<string> runtimeImports,
+        SortedSet<string> runtimeTypeImports,
         bool requiresAnnotationTracking,
         bool requiresScopeTracking,
         bool requiresRegistry,
@@ -473,10 +488,11 @@ public sealed class TsSchemaCodeGenerator
             sb.Append("import { ");
             sb.Append(string.Join(", ", runtimeImports));
             sb.AppendLine($" }} from {TsLiteral.String(RuntimeImportSpecifier)};");
-            sb.AppendLine();
         }
 
-        sb.Append(TypeScriptPreamble());
+        sb.Append("import type { ");
+        sb.Append(string.Join(", ", runtimeTypeImports));
+        sb.AppendLine($" }} from {TsLiteral.String(RuntimeImportSpecifier)};");
         sb.AppendLine();
 
         sb.Append(methods);
@@ -495,16 +511,16 @@ public sealed class TsSchemaCodeGenerator
         {
             if (requiresRegistry)
             {
-                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, new EvaluatedState(), location, registry); }}");
-                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, evaluatedState, location, registry); }}");
-                sb.AppendLine($"export function validateWithScopeAndState(data: JsonValue, scope: any, evaluatedState: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, evaluatedState, location, registry); }}");
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: CompiledValidatorScope, location: JsonPointer = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, new EvaluatedState(), location, registry); }}");
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: EvaluatedState, location: JsonPointer = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, evaluatedState, location, registry); }}");
+                sb.AppendLine($"export function validateWithScopeAndState(data: JsonValue, scope: CompiledValidatorScope, evaluatedState: EvaluatedState, location: JsonPointer = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, evaluatedState, location, registry); }}");
                 sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, new EvaluatedState(), \"\", registry); }}");
             }
             else
             {
-                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\"): boolean {{ return validate_{rootHash}(data, scope, new EvaluatedState(), location); }}");
-                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\"): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, evaluatedState, location); }}");
-                sb.AppendLine($"export function validateWithScopeAndState(data: JsonValue, scope: any, evaluatedState: any, location = \"\"): boolean {{ return validate_{rootHash}(data, scope, evaluatedState, location); }}");
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: CompiledValidatorScope, location: JsonPointer = \"\"): boolean {{ return validate_{rootHash}(data, scope, new EvaluatedState(), location); }}");
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: EvaluatedState, location: JsonPointer = \"\"): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, evaluatedState, location); }}");
+                sb.AppendLine($"export function validateWithScopeAndState(data: JsonValue, scope: CompiledValidatorScope, evaluatedState: EvaluatedState, location: JsonPointer = \"\"): boolean {{ return validate_{rootHash}(data, scope, evaluatedState, location); }}");
                 sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validate_{rootHash}(data, CompiledValidatorScope.empty, new EvaluatedState(), \"\"); }}");
             }
         }
@@ -512,12 +528,12 @@ public sealed class TsSchemaCodeGenerator
         {
             if (requiresRegistry)
             {
-                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, location, registry); }}");
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: CompiledValidatorScope, location: JsonPointer = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, scope, location, registry); }}");
                 sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithScope(data, CompiledValidatorScope.empty, \"\", registry); }}");
             }
             else
             {
-                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: any, location = \"\"): boolean {{ return validate_{rootHash}(data, scope, location); }}");
+                sb.AppendLine($"export function validateWithScope(data: JsonValue, scope: CompiledValidatorScope, location: JsonPointer = \"\"): boolean {{ return validate_{rootHash}(data, scope, location); }}");
                 sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithScope(data, CompiledValidatorScope.empty, \"\"); }}");
             }
         }
@@ -525,12 +541,12 @@ public sealed class TsSchemaCodeGenerator
         {
             if (requiresRegistry)
             {
-                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, evaluatedState, location, registry); }}");
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: EvaluatedState, location: JsonPointer = \"\", registry: ValidatorRegistry = null): boolean {{ return validate_{rootHash}(data, evaluatedState, location, registry); }}");
                 sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithState(data, new EvaluatedState(), \"\", registry); }}");
             }
             else
             {
-                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: any, location = \"\"): boolean {{ return validate_{rootHash}(data, evaluatedState, location); }}");
+                sb.AppendLine($"export function validateWithState(data: JsonValue, evaluatedState: EvaluatedState, location: JsonPointer = \"\"): boolean {{ return validate_{rootHash}(data, evaluatedState, location); }}");
                 sb.AppendLine($"export function validate({exportParameters}): boolean {{ return validateWithState(data, new EvaluatedState(), \"\"); }}");
             }
         }
@@ -550,7 +566,7 @@ public sealed class TsSchemaCodeGenerator
         sb.AppendLine($"export const schemaUri = {schemaUriLiteral};");
         sb.AppendLine();
 
-        sb.AppendLine("export const fragmentValidators = {");
+        sb.AppendLine("export const fragmentValidators: Record<string, FragmentValidator> = {");
         foreach (var fragment in fragmentValidators)
         {
             sb.AppendLine($"  {TsLiteral.String(fragment.Uri)}: {{");
@@ -611,15 +627,6 @@ public sealed class TsSchemaCodeGenerator
         return sb.ToString();
     }
 
-    private static string TypeScriptPreamble()
-    {
-        return """
-            type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
-            type ValidatorRegistry = { tryGetValidator(uri: string): any } | null;
-
-            """;
-    }
-
     private static string BuildScopePushCode(
         SubschemaInfo subschemaInfo,
         bool requiresAnnotationTracking,
@@ -643,8 +650,8 @@ public sealed class TsSchemaCodeGenerator
                     ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
                     : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
                 : requiresRegistry
-                    ? $"(data, scope, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
-                    : $"(data, scope, location = \"\") => validate_{schemaHash}(data, scope, location)";
+                    ? $"(data, scope, _evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
+                    : $"(data, scope, _evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, location)";
             sb.AppendLine($"    {TsLiteral.String(anchorName)}: {delegateExpr},");
         }
         sb.AppendLine("  }");

--- a/JsonSchemaValidation.CodeGeneration.TypeScript/TsSchemaCodeGenerator.cs
+++ b/JsonSchemaValidation.CodeGeneration.TypeScript/TsSchemaCodeGenerator.cs
@@ -186,6 +186,7 @@ public sealed class TsSchemaCodeGenerator
             };
             if (requiresScopeTracking || requiresPropertyAnnotations || requiresItemAnnotations)
             {
+                runtimeTypeImports.Add("EvaluatedState");
                 runtimeTypeImports.Add("JsonPointer");
             }
             if (requiresRegistryParameter)
@@ -218,6 +219,7 @@ public sealed class TsSchemaCodeGenerator
                     runtimeImports));
                 methods.AppendLine();
             }
+            runtimeTypeImports.ExceptWith(runtimeImports);
 
             var module = GenerateModule(
                 schemaUri,
@@ -650,8 +652,8 @@ public sealed class TsSchemaCodeGenerator
                     ? $"(data, scope, evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, evaluatedState, location, registry)"
                     : $"(data, scope, evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, evaluatedState, location)"
                 : requiresRegistry
-                    ? $"(data, scope, _evaluatedState, location = \"\", registry = null) => validate_{schemaHash}(data, scope, location, registry)"
-                    : $"(data, scope, _evaluatedState, location = \"\") => validate_{schemaHash}(data, scope, location)";
+                    ? $"Object.assign((data: JsonValue, scope: CompiledValidatorScope, _evaluatedState: EvaluatedState, location: JsonPointer = \"\", registry: ValidatorRegistry = null) => validate_{schemaHash}(data, scope, location, registry), {{ ignoresEvaluatedState: true }})"
+                    : $"Object.assign((data: JsonValue, scope: CompiledValidatorScope, _evaluatedState: EvaluatedState, location: JsonPointer = \"\") => validate_{schemaHash}(data, scope, location), {{ ignoresEvaluatedState: true }})";
             sb.AppendLine($"    {TsLiteral.String(anchorName)}: {delegateExpr},");
         }
         sb.AppendLine("  }");

--- a/JsonSchemaValidation.CodeGenerator.Tests/TsSchemaCodeGeneratorTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/TsSchemaCodeGeneratorTests.cs
@@ -21,9 +21,66 @@ public class TsSchemaCodeGeneratorTests
         Assert.Equal("validator.ts", result.FileName);
         Assert.Contains("TypeScript target", result.GeneratedCode);
         Assert.DoesNotContain("@ts-nocheck", result.GeneratedCode);
-        Assert.Contains("type JsonValue", result.GeneratedCode);
+        Assert.Contains("import type {", result.GeneratedCode);
+        Assert.Contains("JsonValue", result.GeneratedCode);
         Assert.Contains("export function validate(data: JsonValue): boolean", result.GeneratedCode);
         Assert.Contains("export default", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_StatefulSchema_UsesTypedRuntimeAbiWithoutGeneratedAny()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "properties": { "name": { "type": "string" } },
+              "unevaluatedProperties": false
+            }
+            """).RootElement);
+
+        Assert.True(result.Success, result.Error);
+        Assert.DoesNotContain(": any", result.GeneratedCode);
+        Assert.DoesNotContain("): any", result.GeneratedCode);
+        Assert.Contains("import { EvaluatedState, escapeJsonPointer }", result.GeneratedCode);
+        Assert.Contains("import type { FragmentValidator, JsonPointer, JsonValue }", result.GeneratedCode);
+        Assert.DoesNotContain("ValidatorRegistry", result.GeneratedCode);
+        Assert.Contains("_eval: EvaluatedState", result.GeneratedCode);
+        Assert.Contains("_loc: JsonPointer", result.GeneratedCode);
+        Assert.Contains("export const fragmentValidators: Record<string, FragmentValidator>", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_DynamicScopeSchema_UsesTypedScopeRuntimeAbiWithoutGeneratedAny()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$dynamicAnchor": "node",
+              "type": "object",
+              "properties": {
+                "child": { "$dynamicRef": "#node" }
+              }
+            }
+            """).RootElement);
+
+        Assert.True(result.Success, result.Error);
+        Assert.DoesNotContain(": any", result.GeneratedCode);
+        Assert.DoesNotContain("): any", result.GeneratedCode);
+        Assert.Contains("import { CompiledValidatorScope, EMPTY_EVALUATED_STATE }", result.GeneratedCode);
+        Assert.Contains("_scope: CompiledValidatorScope", result.GeneratedCode);
+        Assert.Contains("scope: CompiledValidatorScope", result.GeneratedCode);
+        Assert.Contains("EMPTY_EVALUATED_STATE", result.GeneratedCode);
+    }
+
+    [Fact]
+    public void Generate_SimpleSchema_DoesNotImportUnusedRuntimeTypes()
+    {
+        var result = _generator.Generate(JsonDocument.Parse("""{ "type": "string" }""").RootElement);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Contains("import type { FragmentValidator, JsonValue }", result.GeneratedCode);
+        Assert.DoesNotContain("JsonPointer", result.GeneratedCode);
+        Assert.DoesNotContain("ValidatorRegistry", result.GeneratedCode);
     }
 
     [Fact]
@@ -195,6 +252,95 @@ public class TsSchemaCodeGeneratorTests
 
             var compileResult = TypeScriptCompiler.Compile(
                 [runtimePath],
+                outputDir,
+                ecmaScriptTarget: "ES2020",
+                strict: true,
+                noImplicitAny: true);
+
+            Assert.True(compileResult.Success, compileResult.Error);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void GeneratedSource_WithTscAvailable_CompilesWithStrictSettings()
+    {
+        if (!TypeScriptCompiler.IsAvailable())
+        {
+            throw Xunit.Sdk.SkipException.ForSkip("TypeScript compiler 'tsc' is required for this test.");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-ts-generated-strict-test-" + Guid.NewGuid().ToString("N"));
+        var outputDir = Path.Combine(tempDir, "out");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            using var schema = JsonDocument.Parse("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "properties": { "name": { "type": "string" } },
+                  "unevaluatedProperties": false
+                }
+                """);
+            var result = _generator.Generate(schema.RootElement.Clone());
+            Assert.True(result.Success, result.Error);
+
+            var validatorPath = Path.Combine(tempDir, result.FileName!);
+            var runtimePath = Path.Combine(tempDir, TsRuntime.FileName);
+            File.WriteAllText(validatorPath, result.GeneratedCode);
+            File.WriteAllText(runtimePath, TsRuntime.GetSource());
+
+            var compileResult = TypeScriptCompiler.Compile(
+                [validatorPath, runtimePath],
+                outputDir,
+                ecmaScriptTarget: "ES2020",
+                strict: true,
+                noImplicitAny: true);
+
+            Assert.True(compileResult.Success, compileResult.Error);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void DynamicScopeGeneratedSource_WithTscAvailable_CompilesWithStrictSettings()
+    {
+        if (!TypeScriptCompiler.IsAvailable())
+        {
+            throw Xunit.Sdk.SkipException.ForSkip("TypeScript compiler 'tsc' is required for this test.");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "jsv-ts-dynamic-scope-strict-test-" + Guid.NewGuid().ToString("N"));
+        var outputDir = Path.Combine(tempDir, "out");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            using var schema = JsonDocument.Parse("""
+                {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "$dynamicAnchor": "node",
+                  "type": "object",
+                  "properties": {
+                    "child": { "$dynamicRef": "#node" }
+                  }
+                }
+                """);
+            var result = _generator.Generate(schema.RootElement.Clone());
+            Assert.True(result.Success, result.Error);
+
+            var validatorPath = Path.Combine(tempDir, result.FileName!);
+            var runtimePath = Path.Combine(tempDir, TsRuntime.FileName);
+            File.WriteAllText(validatorPath, result.GeneratedCode);
+            File.WriteAllText(runtimePath, TsRuntime.GetSource());
+
+            var compileResult = TypeScriptCompiler.Compile(
+                [validatorPath, runtimePath],
                 outputDir,
                 ecmaScriptTarget: "ES2020",
                 strict: true,

--- a/JsonSchemaValidation.CodeGenerator.Tests/TsSchemaCodeGeneratorTests.cs
+++ b/JsonSchemaValidation.CodeGenerator.Tests/TsSchemaCodeGeneratorTests.cs
@@ -66,10 +66,11 @@ public class TsSchemaCodeGeneratorTests
         Assert.True(result.Success, result.Error);
         Assert.DoesNotContain(": any", result.GeneratedCode);
         Assert.DoesNotContain("): any", result.GeneratedCode);
-        Assert.Contains("import { CompiledValidatorScope, EMPTY_EVALUATED_STATE }", result.GeneratedCode);
+        Assert.Contains("CompiledValidatorScope", result.GeneratedCode);
+        Assert.Contains("EMPTY_EVALUATED_STATE", result.GeneratedCode);
+        Assert.Contains("EvaluatedState", result.GeneratedCode);
         Assert.Contains("_scope: CompiledValidatorScope", result.GeneratedCode);
         Assert.Contains("scope: CompiledValidatorScope", result.GeneratedCode);
-        Assert.Contains("EMPTY_EVALUATED_STATE", result.GeneratedCode);
     }
 
     [Fact]

--- a/TYPESCRIPT_CODEGEN_MIGRATION.md
+++ b/TYPESCRIPT_CODEGEN_MIGRATION.md
@@ -34,7 +34,9 @@ The IR option is cleaner long term, but larger. The current implementation prese
 
 `jsv-runtime.ts` is authored TypeScript. It exports the shared runtime helpers plus concrete ABI types for JSON values, validator modules, registry handles, dynamic scope, and evaluated-state tracking. The runtime source must not contain `// @ts-nocheck`.
 
-The TypeScript target assembly no longer depends on `FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript` for runtime projection. Focused tests compile the runtime with `strict: true` and `noImplicitAny: true`; generated validator modules still use the broader migration compiler settings until the remaining internal `any` state/scope/registry signatures are replaced.
+The TypeScript target assembly no longer depends on `FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript` for runtime projection. Focused tests compile the runtime with `strict: true` and `noImplicitAny: true`. Generated validator modules now import the runtime ABI types and compile under the same strict/noImplicitAny gate for covered state/scope/registry scenarios.
+
+`DynamicAnchorValidator` now uses the stable generated-validator shape `data, scope, evaluatedState, location, registry`. Scope-only callers pass `EMPTY_EVALUATED_STATE` when they need to call a dynamic-anchor delegate but do not track annotations themselves.
 
 ## Toolchain
 
@@ -69,6 +71,6 @@ Direct JS generation rejects `--ecmascript-target` to avoid implying that the di
 
 - Track unsupported or divergent cases separately instead of masking them as migration blockers.
 - By 2026-05-15, choose the deduplication strategy for the JS-family emitters: either introduce a target-neutral validation IR or promote the TS emitter to the canonical JS-family source and retire duplicated direct-JS keyword bodies behind benchmark gates.
-- Replace internal `any` state/scope/registry signatures with typed TS contracts.
-- Enable strict generated-validator compiler gates once those internal signatures are typed.
+- Expand strict generated-validator coverage beyond the current focused state/scope/registry scenarios.
+- Decide whether to add and hard-enable `noUncheckedIndexedAccess`/`exactOptionalPropertyTypes` after runtime index-safety cleanup.
 - Add benchmark acceptance thresholds once enough TS-derived JS scenarios are stable.

--- a/TYPESCRIPT_CODEGEN_MIGRATION.md
+++ b/TYPESCRIPT_CODEGEN_MIGRATION.md
@@ -36,7 +36,7 @@ The IR option is cleaner long term, but larger. The current implementation prese
 
 The TypeScript target assembly no longer depends on `FormFinch.JsonSchemaValidation.CodeGeneration.JavaScript` for runtime projection. Focused tests compile the runtime with `strict: true` and `noImplicitAny: true`. Generated validator modules now import the runtime ABI types and compile under the same strict/noImplicitAny gate for covered state/scope/registry scenarios.
 
-`DynamicAnchorValidator` now uses the stable generated-validator shape `data, scope, evaluatedState, location, registry`. Scope-only callers pass `EMPTY_EVALUATED_STATE` when they need to call a dynamic-anchor delegate but do not track annotations themselves.
+`DynamicAnchorValidator` now uses the stable generated-validator shape `data, scope, evaluatedState, location, registry`. Generated scope-only dynamic-anchor delegates are marked as `ignoresEvaluatedState`; scope-only callers pass `EMPTY_EVALUATED_STATE` only to marked delegates and allocate a fresh `EvaluatedState` for unknown delegates that may need annotation state.
 
 ## Toolchain
 


### PR DESCRIPTION
## Summary
- import canonical runtime ABI types from `jsv-runtime.ts` instead of emitting local loose declarations
- type generated state/scope/location/fragment-validator surfaces and tighten dynamic-anchor dispatch
- avoid scope-only `$dynamicRef` allocation with `EMPTY_EVALUATED_STATE`
- document the dynamic-anchor ABI shape and add strict compile coverage for state and scope paths

## Tests
- `dotnet test JsonSchemaValidation.CodeGenerator.Tests\JsonSchemaValidation.CodeGenerator.Tests.csproj --filter "FullyQualifiedName~TypeScript|FullyQualifiedName~Ts"`
  - net8.0: 4661 passed
  - net10.0: 4665 passed

Closes #33